### PR TITLE
Add UNKNOWN event type

### DIFF
--- a/src/main/java/com/box/sdk/BoxEvent.java
+++ b/src/main/java/com/box/sdk/BoxEvent.java
@@ -58,7 +58,17 @@ public class BoxEvent extends BoxResource {
                 this.sourceInfo = BoxResource.parseInfo(this.getAPI(), value.asObject());
                 break;
             case "event_type":
-                this.type = BoxEvent.Type.valueOf(value.asString());
+                String stringValue = value.asString();
+                for (Type t : Type.values()) {
+                    if (t.name().equals(stringValue)) {
+                        this.type = t;
+                        break;
+                    }
+                }
+
+                if (this.type == null) {
+                    this.type = Type.UNKNOWN;
+                }
                 break;
             default:
                 break;
@@ -69,6 +79,11 @@ public class BoxEvent extends BoxResource {
      * Enumerates the possible types for an event.
      */
     public enum Type {
+        /**
+         * The type of the event is unknown.
+         */
+        UNKNOWN,
+
         /**
          * An file or folder was created.
          */

--- a/src/test/java/com/box/sdk/BoxEventTest.java
+++ b/src/test/java/com/box/sdk/BoxEventTest.java
@@ -1,0 +1,19 @@
+package com.box.sdk;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class BoxEventTest {
+    @Test
+    @Category(UnitTest.class)
+    public void newBoxEventHandlesUnknownEventType() {
+        String eventJSON = "{ \"type\": \"event\", \"event_id\": \"f82c3ba03e41f7e8a7608363cc6c0390183c3f83\", "
+            + "\"event_type\": \"UNKNOWN_EVENT_TYPE\" }";
+        BoxEvent event = new BoxEvent(null, eventJSON);
+
+        assertThat(event.getType(), is(BoxEvent.Type.UNKNOWN));
+    }
+}


### PR DESCRIPTION
The UNKNOWN event type is used in cases where the API returns a new type
that the SDK doesn't understand. This prevents an exception from being
thrown while parsing the event JSON.

Fixes #50.