### PR TITLE
Always re-add event id to cache after removing

### DIFF
--- a/src/main/java/com/box/sdk/LRUCache.java
+++ b/src/main/java/com/box/sdk/LRUCache.java
@@ -14,9 +14,7 @@ class LRUCache<E> {
 
     boolean add(E item) {
         boolean newItem = !this.linkedHashSet.remove(item);
-        if (newItem) {
-            this.linkedHashSet.add(item);
-        }
+        this.linkedHashSet.add(item);
 
         if (this.linkedHashSet.size() >= MAX_SIZE) {
             Iterator<E> it = this.linkedHashSet.iterator();

--- a/src/test/java/com/box/sdk/LRUCacheTest.java
+++ b/src/test/java/com/box/sdk/LRUCacheTest.java
@@ -26,6 +26,16 @@ public class LRUCacheTest {
         assertThat(added, is(false));
     }
 
+    @Category(UnitTest.class)
+    public void addReturnsFalseForExistingItemMultipleTimes() {
+        LRUCache<Integer> lru = new LRUCache<Integer>();
+        lru.add(1);
+        lru.add(1);
+        boolean added = lru.add(1);
+
+        assertThat(added, is(false));
+    }
+
     @Test
     @Category(UnitTest.class)
     public void addRemovesOldestItemWhenMaxSizeIsReached() {


### PR DESCRIPTION
Relying on remove to check if an item is already in the ```LinkedHashSet``` doesn't work because we can get events more than just twice.  The first time an ID is added this will work, and the second time the ID is added this will also work, but the third time will fail because we just removed the ID from the hashset in attempt number 2, so the listener gets called every other time.

Fixes #57 