### PR TITLE
Fixed custom domain support

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -44,6 +44,7 @@ public class BoxAPIConnection {
     private String userAgent;
     private String accessToken;
     private String refreshToken;
+    private String tokenURL;
     private String baseURL;
     private String baseUploadURL;
     private boolean autoRefresh;
@@ -71,6 +72,7 @@ public class BoxAPIConnection {
         this.clientSecret = clientSecret;
         this.accessToken = accessToken;
         this.refreshToken = refreshToken;
+        this.tokenURL = TOKEN_URL_STRING;
         this.baseURL = DEFAULT_BASE_URL;
         this.baseUploadURL = DEFAULT_BASE_UPLOAD_URL;
         this.autoRefresh = true;
@@ -108,7 +110,7 @@ public class BoxAPIConnection {
     public void authenticate(String authCode) {
         URL url = null;
         try {
-            url = new URL(TOKEN_URL_STRING);
+            url = new URL(this.tokenURL);
         } catch (MalformedURLException e) {
             assert false : "An invalid token URL indicates a bug in the SDK.";
             throw new RuntimeException("An invalid token URL indicates a bug in the SDK.", e);
@@ -145,6 +147,24 @@ public class BoxAPIConnection {
      */
     public long getExpires() {
         return this.expires;
+    }
+
+    /**
+     * Gets the token URL that's used to request access tokens.  The default value is
+     * "https://www.box.com/api/oauth2/token".
+     * @return the token URL.
+     */
+    public String getTokenURL() {
+        return this.tokenURL;
+    }
+
+    /**
+     * Sets the token URL that's used to request access tokens.  For example, the default token URL is
+     * "https://www.box.com/api/oauth2/token".
+     * @param tokenURL the token URL.
+     */
+    public void setTokenURL(String tokenURL) {
+        this.tokenURL = tokenURL;
     }
 
     /**
@@ -317,7 +337,7 @@ public class BoxAPIConnection {
 
         URL url = null;
         try {
-            url = new URL(TOKEN_URL_STRING);
+            url = new URL(this.tokenURL);
         } catch (MalformedURLException e) {
             this.refreshLock.writeLock().unlock();
             assert false : "An invalid refresh URL indicates a bug in the SDK.";

--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -30,7 +30,6 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         "item_status", "item_collection", "sync_state", "has_collaborations", "permissions", "tags",
         "can_non_owners_invite"};
 
-    private static final String UPLOAD_FILE_URL_BASE = "https://upload.box.com/api/2.0/";
     private static final URLTemplate CREATE_FOLDER_URL = new URLTemplate("folders");
     private static final URLTemplate COPY_FOLDER_URL = new URLTemplate("folders/%s/copy");
     private static final URLTemplate DELETE_FOLDER_URL = new URLTemplate("folders/%s?recursive=%b");
@@ -322,7 +321,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
      * @return              the uploaded file's info.
      */
     public BoxFile.Info uploadFile(FileUploadParams uploadParams) {
-        URL uploadURL = UPLOAD_FILE_URL.build(UPLOAD_FILE_URL_BASE);
+        URL uploadURL = UPLOAD_FILE_URL.build(this.getAPI().getBaseUploadURL());
         BoxMultipartRequest request = new BoxMultipartRequest(getAPI(), uploadURL);
         request.putField("parent_id", getID());
 


### PR DESCRIPTION
The SDK has partial support for custom domains using getBaseURL/setBaseURL and getBaseUploadURL/setBaseUploadURL.

There were two missing pieces though:

First, the SDK also required getTokenURL/setTokenURL to use a custom domain token endpoint.

Second, the BoxFolder class did not use BoxAPIConnection.getBaseUploadURL, so uploads would not work.

This commit fixes those two issues.