### PR TITLE
Fixes #67, Fixes #68, Fixes #69 - Metadata feedback and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 build/
 .DS_Store
 src/test/config/config.properties
+/target/

--- a/src/main/java/com/box/sdk/Metadata.java
+++ b/src/main/java/com/box/sdk/Metadata.java
@@ -2,6 +2,7 @@ package com.box.sdk;
 
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
 
 /**
  * The Metadata class represents one type instance of Box metadata.
@@ -41,7 +42,7 @@ public class Metadata {
      * @return the metadata ID.
      */
     public String getID() {
-        return this.values.get("$id").asString();
+        return this.get("/$id");
     }
 
     /**
@@ -49,7 +50,7 @@ public class Metadata {
      * @return the metadata type.
      */
     public String getTypeName() {
-        return this.values.get("$type").asString();
+        return this.get("/$type");
     }
 
     /**
@@ -57,7 +58,7 @@ public class Metadata {
      * @return the parent object ID.
      */
     public String getParentID() {
-        return this.values.get("$parent").asString();
+        return this.get("/$parent");
     }
 
     /**
@@ -108,11 +109,15 @@ public class Metadata {
 
     /**
      * Returns a value.
-     * @param key the metadata property name.
+     * @param path the path that designates the key. Must be prefixed with a "/".
      * @return the metadata property value.
      */
-    public String get(String key) {
-        return this.values.get(key).asString();
+    public String get(String path) {
+        final JsonValue value = this.values.get(this.pathToProperty(path));
+        if (value == null) {
+            return null;
+        }
+        return value.asString();
     }
 
     /**
@@ -142,6 +147,9 @@ public class Metadata {
      * @return the JSON property name.
      */
     private String pathToProperty(String path) {
+        if (path == null || !path.startsWith("/")) {
+            throw new IllegalArgumentException("Path must be prefixed with a \"/\".");
+        }
         return path.substring(1);
     }
 

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -368,11 +368,11 @@ public class BoxFileTest {
 
         InputStream uploadStream = new ByteArrayInputStream(fileBytes);
         BoxFile uploadedFile = rootFolder.uploadFile(uploadStream, fileName).getResource();
-        uploadedFile.createMetadata(new Metadata().add("foo", "bar"));
+        uploadedFile.createMetadata(new Metadata().add("/foo", "bar"));
 
         Metadata check1 = uploadedFile.getMetadata();
         Assert.assertNotNull(check1);
-        Assert.assertEquals("bar", check1.get("foo"));
+        Assert.assertEquals("bar", check1.get("/foo"));
 
         uploadedFile.delete();
     }
@@ -387,17 +387,17 @@ public class BoxFileTest {
 
         InputStream uploadStream = new ByteArrayInputStream(fileBytes);
         BoxFile uploadedFile = rootFolder.uploadFile(uploadStream, fileName).getResource();
-        uploadedFile.createMetadata(new Metadata().add("foo", "bar"));
+        uploadedFile.createMetadata(new Metadata().add("/foo", "bar"));
 
         Metadata check1 = uploadedFile.getMetadata();
         Assert.assertNotNull(check1);
-        Assert.assertEquals("bar", check1.get("foo"));
+        Assert.assertEquals("bar", check1.get("/foo"));
 
         uploadedFile.updateMetadata(check1.replace("/foo", "baz"));
 
         Metadata check2 = uploadedFile.getMetadata();
         Assert.assertNotNull(check2);
-        Assert.assertEquals("baz", check2.get("foo"));
+        Assert.assertEquals("baz", check2.get("/foo"));
 
         uploadedFile.delete();
     }

--- a/src/test/java/com/box/sdk/MetadataTest.java
+++ b/src/test/java/com/box/sdk/MetadataTest.java
@@ -1,0 +1,111 @@
+package com.box.sdk;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.eclipsesource.json.JsonArray;
+import com.eclipsesource.json.JsonObject;
+
+public class MetadataTest {
+
+    @Test
+    @Category(UnitTest.class)
+    public void testConstructor() {
+        Metadata m = new Metadata();
+        Assert.assertEquals("{}", m.toString());
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void testCopyConstructor() {
+        Metadata m1 = new Metadata().add("/foo", "bar");
+        Metadata m2 = new Metadata(m1);
+        Assert.assertEquals("{\"foo\":\"bar\"}", m2.toString());
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void testAdd() {
+        Metadata m = new Metadata().add("/foo", "bar");
+        JsonArray operations = JsonArray.readFrom(m.getPatch());
+        Assert.assertEquals(1, operations.size());
+        JsonObject op = operations.get(0).asObject();
+        Assert.assertEquals("add", op.get("op").asString());
+        Assert.assertEquals("/foo", op.get("path").asString());
+        Assert.assertEquals("bar", op.get("value").asString());
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void testReplace() {
+        Metadata m = new Metadata().replace("/foo", "bar");
+        JsonArray operations = JsonArray.readFrom(m.getPatch());
+        Assert.assertEquals(1, operations.size());
+        JsonObject op = operations.get(0).asObject();
+        Assert.assertEquals("replace", op.get("op").asString());
+        Assert.assertEquals("/foo", op.get("path").asString());
+        Assert.assertEquals("bar", op.get("value").asString());
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void testTest() {
+        Metadata m = new Metadata().test("/foo", "bar");
+        JsonArray operations = JsonArray.readFrom(m.getPatch());
+        Assert.assertEquals(1, operations.size());
+        JsonObject op = operations.get(0).asObject();
+        Assert.assertEquals("test", op.get("op").asString());
+        Assert.assertEquals("/foo", op.get("path").asString());
+        Assert.assertEquals("bar", op.get("value").asString());
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void testRemove() {
+        Metadata m = new Metadata().remove("/foo");
+        JsonArray operations = JsonArray.readFrom(m.getPatch());
+        Assert.assertEquals(1, operations.size());
+        JsonObject op = operations.get(0).asObject();
+        Assert.assertEquals("remove", op.get("op").asString());
+        Assert.assertEquals("/foo", op.get("path").asString());
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void testInvalidGet() {
+        Metadata m = new Metadata();
+        Assert.assertEquals(null, m.get("/foo"));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @Category(UnitTest.class)
+    public void testNullPath() {
+        new Metadata().add(null, "value");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    @Category(UnitTest.class)
+    public void testInvalidPath() {
+        new Metadata().add("key", "value");
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void testMetaProperties() {
+        String json = "{\"$id\":\"123\",\"$type\":\"my type\",\"$parent\":\"456\"}";
+        Metadata m = new Metadata(JsonObject.readFrom(json));
+        Assert.assertEquals("123", m.getID());
+        Assert.assertEquals("my type", m.getTypeName());
+        Assert.assertEquals("456", m.getParentID());
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void testMissingMetaProperties() {
+        Metadata m = new Metadata();
+        Assert.assertEquals(null, m.getID());
+        Assert.assertEquals(null, m.getTypeName());
+        Assert.assertEquals(null, m.getParentID());
+    }
+}


### PR DESCRIPTION
Now using the "/path" format for all operations, including get().

Handling missing values more gracefully, returning null.

Fixed bug in integration tests.

Added a bunch of unit tests to catch key vs. path problems.