### PR TITLE
Adding support for JDK 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'java'
 apply plugin: 'maven'
 apply plugin: 'signing'
 
-sourceCompatibility = 1.7
+sourceCompatibility = 1.6
 
 group = 'com.box'
 archivesBaseName = 'box-java-sdk'

--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -8,7 +8,6 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -205,13 +204,14 @@ public class BoxAPIRequest {
      */
     @Override
     public String toString() {
+        String lineSeparator = System.getProperty("line.separator");
         StringBuilder builder = new StringBuilder();
         builder.append("Request");
-        builder.append(System.lineSeparator());
+        builder.append(lineSeparator);
         builder.append(this.method);
         builder.append(' ');
         builder.append(this.url.toString());
-        builder.append(System.lineSeparator());
+        builder.append(lineSeparator);
 
         for (Map.Entry<String, List<String>> entry : this.requestProperties.entrySet()) {
             List<String> nonEmptyValues = new ArrayList<String>();
@@ -233,12 +233,12 @@ public class BoxAPIRequest {
             }
 
             builder.delete(builder.length() - 2, builder.length());
-            builder.append(System.lineSeparator());
+            builder.append(lineSeparator);
         }
 
         String bodyString = this.bodyToString();
         if (bodyString != null) {
-            builder.append(System.lineSeparator());
+            builder.append(lineSeparator);
             builder.append(bodyString);
         }
 
@@ -321,7 +321,7 @@ public class BoxAPIRequest {
         HttpURLConnection connection = this.createConnection();
 
         if (this.bodyLength > 0) {
-            connection.setFixedLengthStreamingMode(this.bodyLength);
+            connection.setFixedLengthStreamingMode((int) this.bodyLength);
             connection.setDoOutput(true);
         }
 

--- a/src/main/java/com/box/sdk/BoxAPIResponse.java
+++ b/src/main/java/com/box/sdk/BoxAPIResponse.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +86,7 @@ public class BoxAPIResponse {
      * @return the length of the response's body.
      */
     public long getContentLength() {
-        return this.connection.getContentLengthLong();
+        return this.connection.getContentLength();
     }
 
     /**
@@ -160,16 +159,17 @@ public class BoxAPIResponse {
 
     @Override
     public String toString() {
+        String lineSeparator = System.getProperty("line.separator");
         Map<String, List<String>> headers = this.connection.getHeaderFields();
         StringBuilder builder = new StringBuilder();
         builder.append("Response");
-        builder.append(System.lineSeparator());
+        builder.append(lineSeparator);
         builder.append(this.connection.getRequestMethod());
         builder.append(' ');
         builder.append(this.connection.getURL().toString());
-        builder.append(System.lineSeparator());
+        builder.append(lineSeparator);
         builder.append(headers.get(null).get(0));
-        builder.append(System.lineSeparator());
+        builder.append(lineSeparator);
 
         for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
             String key = entry.getKey();
@@ -196,12 +196,12 @@ public class BoxAPIResponse {
             }
 
             builder.delete(builder.length() - 2, builder.length());
-            builder.append(System.lineSeparator());
+            builder.append(lineSeparator);
         }
 
         String bodyString = this.bodyToString();
         if (bodyString != null && bodyString != "") {
-            builder.append(System.lineSeparator());
+            builder.append(lineSeparator);
             builder.append(bodyString);
         }
 

--- a/src/main/java/com/box/sdk/BoxCollaboration.java
+++ b/src/main/java/com/box/sdk/BoxCollaboration.java
@@ -233,59 +233,55 @@ public class BoxCollaboration extends BoxResource {
             String memberName = member.getName();
             JsonValue value = member.getValue();
             try {
-                switch (memberName) {
-                    case "created_by":
-                        JsonObject userJSON = value.asObject();
-                        if (this.createdBy == null) {
-                            String userID = userJSON.get("id").asString();
-                            BoxUser user = new BoxUser(getAPI(), userID);
-                            this.createdBy = user.new Info(userJSON);
-                        } else {
-                            this.createdBy.update(userJSON);
-                        }
-                        break;
-                    case "created_at":
-                        this.createdAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "modified_at":
-                        this.modifiedAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "expires_at":
-                        this.expiresAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "status":
-                        String statusString = value.asString().toUpperCase();
-                        this.status = Status.valueOf(statusString);
-                        break;
-                    case "accessible_by":
-                        userJSON = value.asObject();
-                        if (this.accessibleBy == null) {
-                            String userID = userJSON.get("id").asString();
-                            BoxUser user = new BoxUser(getAPI(), userID);
-                            BoxUser.Info userInfo = user.new Info(userJSON);
-                            this.accessibleBy = userInfo;
-                        } else {
-                            this.accessibleBy.update(userJSON);
-                        }
-                        break;
-                    case "role":
-                        this.role = Role.fromJSONString(value.asString());
-                        break;
-                    case "acknowledged_at":
-                        this.acknowledgedAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "item":
-                        JsonObject folderJSON = value.asObject();
-                        if (this.item == null) {
-                            String folderID = folderJSON.get("id").asString();
-                            BoxFolder folder = new BoxFolder(getAPI(), folderID);
-                            this.item = folder.new Info(folderJSON);
-                        } else {
-                            this.item.update(folderJSON);
-                        }
-                        break;
-                    default:
-                        break;
+                if (memberName.equals("created_by")) {
+                    JsonObject userJSON = value.asObject();
+                    if (this.createdBy == null) {
+                        String userID = userJSON.get("id").asString();
+                        BoxUser user = new BoxUser(getAPI(), userID);
+                        this.createdBy = user.new Info(userJSON);
+                    } else {
+                        this.createdBy.update(userJSON);
+                    }
+
+                } else if (memberName.equals("created_at")) {
+                    this.createdAt = BoxDateFormat.parse(value.asString());
+
+                } else if (memberName.equals("modified_at")) {
+                    this.modifiedAt = BoxDateFormat.parse(value.asString());
+
+                } else if (memberName.equals("expires_at")) {
+                    this.expiresAt = BoxDateFormat.parse(value.asString());
+
+                } else if (memberName.equals("status")) {
+                    String statusString = value.asString().toUpperCase();
+                    this.status = Status.valueOf(statusString);
+
+                } else if (memberName.equals("accessible_by")) {
+                    JsonObject userJSON = value.asObject();
+                    if (this.accessibleBy == null) {
+                        String userID = userJSON.get("id").asString();
+                        BoxUser user = new BoxUser(getAPI(), userID);
+                        BoxUser.Info userInfo = user.new Info(userJSON);
+                        this.accessibleBy = userInfo;
+                    } else {
+                        this.accessibleBy.update(userJSON);
+                    }
+
+                } else if (memberName.equals("role")) {
+                    this.role = Role.fromJSONString(value.asString());
+
+                } else if (memberName.equals("acknowledged_at")) {
+                    this.acknowledgedAt = BoxDateFormat.parse(value.asString());
+
+                } else if (memberName.equals("item")) {
+                    JsonObject folderJSON = value.asObject();
+                    if (this.item == null) {
+                        String folderID = folderJSON.get("id").asString();
+                        BoxFolder folder = new BoxFolder(getAPI(), folderID);
+                        this.item = folder.new Info(folderJSON);
+                    } else {
+                        this.item.update(folderJSON);
+                    }
                 }
             } catch (ParseException e) {
                 assert false : "A ParseException indicates a bug in the SDK.";
@@ -384,25 +380,24 @@ public class BoxCollaboration extends BoxResource {
         }
 
         static Role fromJSONString(String jsonValue) {
-            switch (jsonValue) {
-                case "editor":
-                    return EDITOR;
-                case "viewer":
-                    return VIEWER;
-                case "previewer":
-                    return PREVIEWER;
-                case "uploader":
-                    return UPLOADER;
-                case "previewer uploader":
-                    return PREVIEWER_UPLOADER;
-                case "viewer uploader":
-                    return VIEWER_UPLOADER;
-                case "co-owner":
-                    return CO_OWNER;
-                case "owner":
-                    return OWNER;
-                default:
-                    throw new IllegalArgumentException("The provided JSON value isn't a valid Role.");
+            if (jsonValue.equals("editor")) {
+                return EDITOR;
+            } else if (jsonValue.equals("viewer")) {
+                return VIEWER;
+            } else if (jsonValue.equals("previewer")) {
+                return PREVIEWER;
+            } else if (jsonValue.equals("uploader")) {
+                return UPLOADER;
+            } else if (jsonValue.equals("previewer uploader")) {
+                return PREVIEWER_UPLOADER;
+            } else if (jsonValue.equals("viewer uploader")) {
+                return VIEWER_UPLOADER;
+            } else if (jsonValue.equals("co-owner")) {
+                return CO_OWNER;
+            } else if (jsonValue.equals("owner")) {
+                return OWNER;
+            } else {
+                throw new IllegalArgumentException("The provided JSON value isn't a valid Role.");
             }
         }
 

--- a/src/main/java/com/box/sdk/BoxCollaborator.java
+++ b/src/main/java/com/box/sdk/BoxCollaborator.java
@@ -90,18 +90,13 @@ public abstract class BoxCollaborator extends BoxResource {
 
             try {
                 JsonValue value = member.getValue();
-                switch (member.getName()) {
-                    case "name":
-                        this.name = value.asString();
-                        break;
-                    case "created_at":
-                        this.createdAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "modified_at":
-                        this.modifiedAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    default:
-                        break;
+                String name = member.getName();
+                if (name.equals("name")) {
+                    this.name = value.asString();
+                } else if (name.equals("created_at")) {
+                    this.createdAt = BoxDateFormat.parse(value.asString());
+                } else if (name.equals("modified_at")) {
+                    this.modifiedAt = BoxDateFormat.parse(value.asString());
                 }
             } catch (ParseException e) {
                 assert false : "A ParseException indicates a bug in the SDK.";

--- a/src/main/java/com/box/sdk/BoxComment.java
+++ b/src/main/java/com/box/sdk/BoxComment.java
@@ -225,44 +225,40 @@ public class BoxComment extends BoxResource {
             try {
                 String memberName = member.getName();
                 JsonValue value = member.getValue();
-                switch (memberName) {
-                    case "is_reply_comment":
-                        this.isReplyComment = value.asBoolean();
-                        break;
-                    case "message":
-                        this.message = value.asString();
-                        break;
-                    case "tagged_message":
-                        this.taggedMessage = value.asString();
-                        break;
-                    case "created_by":
-                        JsonObject userJSON = value.asObject();
-                        if (this.createdBy == null) {
-                            String userID = userJSON.get("id").asString();
-                            BoxUser user = new BoxUser(getAPI(), userID);
-                            this.createdBy = user.new Info(userJSON);
-                        } else {
-                            this.createdBy.update(userJSON);
-                        }
-                        break;
-                    case "created_at":
-                        this.createdAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "item":
-                        this.parseItem(value);
-                        break;
-                    case "modified_by":
-                        userJSON = value.asObject();
-                        if (this.modifiedBy == null) {
-                            String userID = userJSON.get("id").asString();
-                            BoxUser user = new BoxUser(getAPI(), userID);
-                            this.modifiedBy = user.new Info(userJSON);
-                        } else {
-                            this.modifiedBy.update(userJSON);
-                        }
-                        break;
-                    default:
-                        break;
+                if (memberName.equals("is_reply_comment")) {
+                    this.isReplyComment = value.asBoolean();
+
+                } else if (memberName.equals("message")) {
+                    this.message = value.asString();
+
+                } else if (memberName.equals("tagged_message")) {
+                    this.taggedMessage = value.asString();
+
+                } else if (memberName.equals("created_by")) {
+                    JsonObject userJSON = value.asObject();
+                    if (this.createdBy == null) {
+                        String userID = userJSON.get("id").asString();
+                        BoxUser user = new BoxUser(getAPI(), userID);
+                        this.createdBy = user.new Info(userJSON);
+                    } else {
+                        this.createdBy.update(userJSON);
+                    }
+
+                } else if (memberName.equals("created_at")) {
+                    this.createdAt = BoxDateFormat.parse(value.asString());
+
+                } else if (memberName.equals("item")) {
+                    this.parseItem(value);
+
+                } else if (memberName.equals("modified_by")) {
+                    JsonObject userJSON = value.asObject();
+                    if (this.modifiedBy == null) {
+                        String userID = userJSON.get("id").asString();
+                        BoxUser user = new BoxUser(getAPI(), userID);
+                        this.modifiedBy = user.new Info(userJSON);
+                    } else {
+                        this.modifiedBy.update(userJSON);
+                    }
                 }
             } catch (ParseException e) {
                 assert false : "A ParseException indicates a bug in the SDK.";

--- a/src/main/java/com/box/sdk/BoxDateFormat.java
+++ b/src/main/java/com/box/sdk/BoxDateFormat.java
@@ -12,7 +12,7 @@ public final class BoxDateFormat {
     private static final ThreadLocal<DateFormat> THREAD_LOCAL_DATE_FORMAT = new ThreadLocal<DateFormat>() {
         @Override
         protected DateFormat initialValue() {
-            return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX");
+            return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
         }
     };
 

--- a/src/main/java/com/box/sdk/BoxEvent.java
+++ b/src/main/java/com/box/sdk/BoxEvent.java
@@ -53,25 +53,22 @@ public class BoxEvent extends BoxResource {
             return;
         }
 
-        switch (member.getName()) {
-            case "source":
-                this.sourceInfo = BoxResource.parseInfo(this.getAPI(), value.asObject());
-                break;
-            case "event_type":
-                String stringValue = value.asString();
-                for (Type t : Type.values()) {
-                    if (t.name().equals(stringValue)) {
-                        this.type = t;
-                        break;
-                    }
-                }
+        String memberName = member.getName();
+        if (memberName.equals("source")) {
+            this.sourceInfo = BoxResource.parseInfo(this.getAPI(), value.asObject());
 
-                if (this.type == null) {
-                    this.type = Type.UNKNOWN;
+        } else if (memberName.equals("event_type")) {
+            String stringValue = value.asString();
+            for (Type t : Type.values()) {
+                if (t.name().equals(stringValue)) {
+                    this.type = t;
+                    break;
                 }
-                break;
-            default:
-                break;
+            }
+
+            if (this.type == null) {
+                this.type = Type.UNKNOWN;
+            }
         }
     }
 

--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -559,27 +559,18 @@ public class BoxFile extends BoxItem {
 
             String memberName = member.getName();
             JsonValue value = member.getValue();
-            switch (memberName) {
-                case "sha1":
-                    this.sha1 = value.asString();
-                    break;
-                case "version_number":
-                    this.versionNumber = value.asString();
-                    break;
-                case "comment_count":
-                    this.commentCount = value.asLong();
-                    break;
-                case "permissions":
-                    this.permissions = this.parsePermissions(value.asObject());
-                    break;
-                case "extension":
-                    this.extension = value.asString();
-                    break;
-                case "is_package":
-                    this.isPackage = value.asBoolean();
-                    break;
-                default:
-                    break;
+            if (memberName.equals("sha1")) {
+                this.sha1 = value.asString();
+            } else if (memberName.equals("version_number")) {
+                this.versionNumber = value.asString();
+            } else if (memberName.equals("comment_count")) {
+                this.commentCount = value.asLong();
+            } else if (memberName.equals("permissions")) {
+                this.permissions = this.parsePermissions(value.asObject());
+            } else if (memberName.equals("extension")) {
+                this.extension = value.asString();
+            } else if (memberName.equals("is_package")) {
+                this.isPackage = value.asBoolean();
             }
         }
 
@@ -592,33 +583,22 @@ public class BoxFile extends BoxItem {
                 }
 
                 String memberName = member.getName();
-                switch (memberName) {
-                    case "can_download":
-                        permissions.add(Permission.CAN_DOWNLOAD);
-                        break;
-                    case "can_upload":
-                        permissions.add(Permission.CAN_UPLOAD);
-                        break;
-                    case "can_rename":
-                        permissions.add(Permission.CAN_RENAME);
-                        break;
-                    case "can_delete":
-                        permissions.add(Permission.CAN_DELETE);
-                        break;
-                    case "can_share":
-                        permissions.add(Permission.CAN_SHARE);
-                        break;
-                    case "can_set_share_access":
-                        permissions.add(Permission.CAN_SET_SHARE_ACCESS);
-                        break;
-                    case "can_preview":
-                        permissions.add(Permission.CAN_PREVIEW);
-                        break;
-                    case "can_comment":
-                        permissions.add(Permission.CAN_COMMENT);
-                        break;
-                    default:
-                        break;
+                if (memberName.equals("can_download")) {
+                    permissions.add(Permission.CAN_DOWNLOAD);
+                } else if (memberName.equals("can_upload")) {
+                    permissions.add(Permission.CAN_UPLOAD);
+                } else if (memberName.equals("can_rename")) {
+                    permissions.add(Permission.CAN_RENAME);
+                } else if (memberName.equals("can_delete")) {
+                    permissions.add(Permission.CAN_DELETE);
+                } else if (memberName.equals("can_share")) {
+                    permissions.add(Permission.CAN_SHARE);
+                } else if (memberName.equals("can_set_share_access")) {
+                    permissions.add(Permission.CAN_SET_SHARE_ACCESS);
+                } else if (memberName.equals("can_preview")) {
+                    permissions.add(Permission.CAN_PREVIEW);
+                } else if (memberName.equals("can_comment")) {
+                    permissions.add(Permission.CAN_COMMENT);
                 }
             }
 

--- a/src/main/java/com/box/sdk/BoxFileVersion.java
+++ b/src/main/java/com/box/sdk/BoxFileVersion.java
@@ -48,30 +48,22 @@ public class BoxFileVersion extends BoxResource {
             }
 
             try {
-                switch (member.getName()) {
-                    case "sha1":
-                        this.sha1 = value.asString();
-                        break;
-                    case "name":
-                        this.name = value.asString();
-                        break;
-                    case "size":
-                        this.size = Double.valueOf(value.toString()).longValue();
-                        break;
-                    case "created_at":
-                        this.createdAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "modified_at":
-                        this.modifiedAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "modified_by":
-                        JsonObject userJSON = value.asObject();
-                        String userID = userJSON.get("id").asString();
-                        BoxUser user = new BoxUser(getAPI(), userID);
-                        this.modifiedBy = user.new Info(userJSON);
-                        break;
-                    default:
-                        break;
+                String memberName = member.getName();
+                if (memberName.equals("sha1")) {
+                    this.sha1 = value.asString();
+                } else if (memberName.equals("name")) {
+                    this.name = value.asString();
+                } else if (memberName.equals("size")) {
+                    this.size = Double.valueOf(value.toString()).longValue();
+                } else if (memberName.equals("created_at")) {
+                    this.createdAt = BoxDateFormat.parse(value.asString());
+                } else if (memberName.equals("modified_at")) {
+                    this.modifiedAt = BoxDateFormat.parse(value.asString());
+                } else if (memberName.equals("modified_by")) {
+                    JsonObject userJSON = value.asObject();
+                    String userID = userJSON.get("id").asString();
+                    BoxUser user = new BoxUser(getAPI(), userID);
+                    this.modifiedBy = user.new Info(userJSON);
                 }
             } catch (ParseException e) {
                 assert false : "A ParseException indicates a bug in the SDK.";

--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -371,6 +371,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
      */
     public Iterable<BoxItem.Info> getChildren(final String... fields) {
         return new Iterable<BoxItem.Info>() {
+            @Override
             public Iterator<BoxItem.Info> iterator() {
                 String queryString = new QueryStringBuilder().appendParam("fields", fields).toString();
                 URL url = GET_ITEMS_URL.buildWithQuery(getAPI().getBaseURL(), queryString, getID());
@@ -418,6 +419,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
      * Returns an iterator over the items in this folder.
      * @return an iterator over the items in this folder.
      */
+    @Override
     public Iterator<BoxItem.Info> iterator() {
         URL url = GET_ITEMS_URL.build(this.getAPI().getBaseURL(), BoxFolder.this.getID());
         return new BoxItemIterator(BoxFolder.this.getAPI(), url);
@@ -430,6 +432,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
      */
     public Iterable<BoxItem.Info> search(final String query) {
         return new Iterable<BoxItem.Info>() {
+            @Override
             public Iterator<BoxItem.Info> iterator() {
                 QueryStringBuilder builder = new QueryStringBuilder();
                 builder.appendParam("query", query);
@@ -553,28 +556,24 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
 
             String memberName = member.getName();
             JsonValue value = member.getValue();
-            switch (memberName) {
-                case "folder_upload_email":
-                    if (this.uploadEmail == null) {
-                        this.uploadEmail = new BoxUploadEmail(value.asObject());
-                    } else {
-                        this.uploadEmail.update(value.asObject());
-                    }
-                    break;
-                case "has_collaborations":
-                    this.hasCollaborations = value.asBoolean();
-                    break;
-                case "sync_state":
-                    this.syncState = SyncState.fromJSONValue(value.asString());
-                    break;
-                case "permissions":
-                    this.permissions = this.parsePermissions(value.asObject());
-                    break;
-                case "can_non_owners_invite":
-                    this.canNonOwnersInvite = value.asBoolean();
-                    break;
-                default:
-                    break;
+            if (memberName.equals("folder_upload_email")) {
+                if (this.uploadEmail == null) {
+                    this.uploadEmail = new BoxUploadEmail(value.asObject());
+                } else {
+                    this.uploadEmail.update(value.asObject());
+                }
+
+            } else if (memberName.equals("has_collaborations")) {
+                this.hasCollaborations = value.asBoolean();
+
+            } else if (memberName.equals("sync_state")) {
+                this.syncState = SyncState.fromJSONValue(value.asString());
+
+            } else if (memberName.equals("permissions")) {
+                this.permissions = this.parsePermissions(value.asObject());
+
+            } else if (memberName.equals("can_non_owners_invite")) {
+                this.canNonOwnersInvite = value.asBoolean();
             }
         }
 
@@ -587,30 +586,20 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
                 }
 
                 String memberName = member.getName();
-                switch (memberName) {
-                    case "can_download":
-                        permissions.add(Permission.CAN_DOWNLOAD);
-                        break;
-                    case "can_upload":
-                        permissions.add(Permission.CAN_UPLOAD);
-                        break;
-                    case "can_rename":
-                        permissions.add(Permission.CAN_RENAME);
-                        break;
-                    case "can_delete":
-                        permissions.add(Permission.CAN_DELETE);
-                        break;
-                    case "can_share":
-                        permissions.add(Permission.CAN_SHARE);
-                        break;
-                    case "can_invite_collaborator":
-                        permissions.add(Permission.CAN_INVITE_COLLABORATOR);
-                        break;
-                    case "can_set_share_access":
-                        permissions.add(Permission.CAN_SET_SHARE_ACCESS);
-                        break;
-                    default:
-                        break;
+                if (memberName.equals("can_download")) {
+                    permissions.add(Permission.CAN_DOWNLOAD);
+                } else if (memberName.equals("can_upload")) {
+                    permissions.add(Permission.CAN_UPLOAD);
+                } else if (memberName.equals("can_rename")) {
+                    permissions.add(Permission.CAN_RENAME);
+                } else if (memberName.equals("can_delete")) {
+                    permissions.add(Permission.CAN_DELETE);
+                } else if (memberName.equals("can_share")) {
+                    permissions.add(Permission.CAN_SHARE);
+                } else if (memberName.equals("can_invite_collaborator")) {
+                    permissions.add(Permission.CAN_INVITE_COLLABORATOR);
+                } else if (memberName.equals("can_set_share_access")) {
+                    permissions.add(Permission.CAN_SET_SHARE_ACCESS);
                 }
             }
 

--- a/src/main/java/com/box/sdk/BoxItem.java
+++ b/src/main/java/com/box/sdk/BoxItem.java
@@ -360,77 +360,56 @@ public abstract class BoxItem extends BoxResource {
 
             try {
                 JsonValue value = member.getValue();
-                switch (member.getName()) {
-                    case "sequence_id":
-                        this.sequenceID = value.asString();
-                        break;
-                    case "etag":
-                        this.etag = value.asString();
-                        break;
-                    case "name":
-                        this.name = value.asString();
-                        break;
-                    case "created_at":
-                        this.createdAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "modified_at":
-                        this.modifiedAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "description":
-                        this.description = value.asString();
-                        break;
-                    case "size":
-                        this.size = Double.valueOf(value.toString()).longValue();
-                        break;
-                    case "trashed_at":
-                        this.trashedAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "purged_at":
-                        this.purgedAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "content_created_at":
-                        this.contentCreatedAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "content_modified_at":
-                        this.contentModifiedAt = BoxDateFormat.parse(value.asString());
-                        break;
-                    case "path_collection":
-                        this.pathCollection = this.parsePathCollection(value.asObject());
-                        break;
-                    case "created_by":
-                        this.createdBy = this.parseUserInfo(value.asObject());
-                        break;
-                    case "modified_by":
-                        this.modifiedBy = this.parseUserInfo(value.asObject());
-                        break;
-                    case "owned_by":
-                        this.ownedBy = this.parseUserInfo(value.asObject());
-                        break;
-                    case "shared_link":
-                        if (this.sharedLink == null) {
-                            this.setSharedLink(new BoxSharedLink(value.asObject()));
-                        } else {
-                            this.sharedLink.update(value.asObject());
-                        }
-                        break;
-                    case "tags":
-                        this.tags = this.parseTags(value.asArray());
-                        break;
-                    case "parent":
-                        JsonObject jsonObject = value.asObject();
-                        if (this.parent == null) {
-                            String id = jsonObject.get("id").asString();
-                            BoxFolder parentFolder = new BoxFolder(getAPI(), id);
-                            this.parent = parentFolder.new Info(jsonObject);
-                        } else {
-                            this.parent.update(jsonObject);
-                        }
-                        break;
-                    case "item_status":
-                        this.itemStatus = value.asString();
-                        break;
-                    default:
-                        break;
+                String memberName = member.getName();
+                if (memberName.equals("sequence_id")) {
+                    this.sequenceID = value.asString();
+                } else if (memberName.equals("etag")) {
+                    this.etag = value.asString();
+                } else if (memberName.equals("name")) {
+                    this.name = value.asString();
+                } else if (memberName.equals("created_at")) {
+                    this.createdAt = BoxDateFormat.parse(value.asString());
+                } else if (memberName.equals("modified_at")) {
+                    this.modifiedAt = BoxDateFormat.parse(value.asString());
+                } else if (memberName.equals("description")) {
+                    this.description = value.asString();
+                } else if (memberName.equals("size")) {
+                    this.size = Double.valueOf(value.toString()).longValue();
+                } else if (memberName.equals("trashed_at")) {
+                    this.trashedAt = BoxDateFormat.parse(value.asString());
+                } else if (memberName.equals("purged_at")) {
+                    this.purgedAt = BoxDateFormat.parse(value.asString());
+                } else if (memberName.equals("content_created_at")) {
+                    this.contentCreatedAt = BoxDateFormat.parse(value.asString());
+                } else if (memberName.equals("content_modified_at")) {
+                    this.contentModifiedAt = BoxDateFormat.parse(value.asString());
+                } else if (memberName.equals("path_collection")) {
+                    this.pathCollection = this.parsePathCollection(value.asObject());
+                } else if (memberName.equals("created_by")) {
+                    this.createdBy = this.parseUserInfo(value.asObject());
+                } else if (memberName.equals("modified_by")) {
+                    this.modifiedBy = this.parseUserInfo(value.asObject());
+                } else if (memberName.equals("owned_by")) {
+                    this.ownedBy = this.parseUserInfo(value.asObject());
+                } else if (memberName.equals("shared_link")) {
+                    if (this.sharedLink == null) {
+                        this.setSharedLink(new BoxSharedLink(value.asObject()));
+                    } else {
+                        this.sharedLink.update(value.asObject());
+                    }
+                } else if (memberName.equals("tags")) {
+                    this.tags = this.parseTags(value.asArray());
+                } else if (memberName.equals("parent")) {
+                    JsonObject jsonObject = value.asObject();
+                    if (this.parent == null) {
+                        String id = jsonObject.get("id").asString();
+                        BoxFolder parentFolder = new BoxFolder(getAPI(), id);
+                        this.parent = parentFolder.new Info(jsonObject);
+                    } else {
+                        this.parent.update(jsonObject);
+                    }
+                } else if (memberName.equals("item_status")) {
+                    this.itemStatus = value.asString();
                 }
             } catch (ParseException e) {
                 assert false : "A ParseException indicates a bug in the SDK.";

--- a/src/main/java/com/box/sdk/BoxJSONResponse.java
+++ b/src/main/java/com/box/sdk/BoxJSONResponse.java
@@ -3,7 +3,6 @@ package com.box.sdk;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Used to read HTTP responses containing JSON from the Box API.

--- a/src/main/java/com/box/sdk/BoxMultipartRequest.java
+++ b/src/main/java/com/box/sdk/BoxMultipartRequest.java
@@ -5,7 +5,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/com/box/sdk/BoxResource.java
+++ b/src/main/java/com/box/sdk/BoxResource.java
@@ -26,27 +26,26 @@ public abstract class BoxResource {
         String type = jsonObject.get("type").asString();
         String id = jsonObject.get("id").asString();
 
-        switch (type) {
-            case "folder":
-                BoxFolder folder = new BoxFolder(api, id);
-                return folder.new Info(jsonObject);
-            case "file":
-                BoxFile file = new BoxFile(api, id);
-                return file.new Info(jsonObject);
-            case "comment":
-                BoxComment comment = new BoxComment(api, id);
-                return comment.new Info(jsonObject);
-            case "collaboration":
-                BoxCollaboration collaboration = new BoxCollaboration(api, id);
-                return collaboration.new Info(jsonObject);
-            case "user":
-                BoxUser user = new BoxUser(api, id);
-                return user.new Info(jsonObject);
-            case "group":
-                BoxGroup group = new BoxGroup(api, id);
-                return group.new Info(jsonObject);
-            default:
-                return null;
+        if (type.equals("folder")) {
+            BoxFolder folder = new BoxFolder(api, id);
+            return folder.new Info(jsonObject);
+        } else if (type.equals("file")) {
+            BoxFile file = new BoxFile(api, id);
+            return file.new Info(jsonObject);
+        } else if (type.equals("comment")) {
+            BoxComment comment = new BoxComment(api, id);
+            return comment.new Info(jsonObject);
+        } else if (type.equals("collaboration")) {
+            BoxCollaboration collaboration = new BoxCollaboration(api, id);
+            return collaboration.new Info(jsonObject);
+        } else if (type.equals("user")) {
+            BoxUser user = new BoxUser(api, id);
+            return user.new Info(jsonObject);
+        } else if (type.equals("group")) {
+            BoxGroup group = new BoxGroup(api, id);
+            return group.new Info(jsonObject);
+        } else {
+            return null;
         }
     }
 

--- a/src/main/java/com/box/sdk/BoxSharedLink.java
+++ b/src/main/java/com/box/sdk/BoxSharedLink.java
@@ -154,41 +154,30 @@ public class BoxSharedLink extends BoxJSONObject {
     void parseJSONMember(JsonObject.Member member) {
         JsonValue value = member.getValue();
         try {
-            switch (member.getName()) {
-                case "url":
-                    this.url = value.asString();
-                    break;
-                case "download_url":
-                    this.downloadUrl = value.asString();
-                    break;
-                case "vanity_url":
-                    this.vanityUrl = value.asString();
-                    break;
-                case "is_password_enabled":
-                    this.isPasswordEnabled = value.asBoolean();
-                    break;
-                case "unshared_at":
-                    this.unsharedAt = BoxDateFormat.parse(value.asString());
-                    break;
-                case "download_count":
-                    this.downloadCount = Double.valueOf(value.toString()).longValue();
-                    break;
-                case "preview_count":
-                    this.previewCount = Double.valueOf(value.toString()).longValue();
-                    break;
-                case "access":
-                    String accessString = value.asString().toUpperCase();
-                    this.access = Access.valueOf(accessString);
-                    break;
-                case "permissions":
-                    if (this.permissions == null) {
-                        this.setPermissions(new Permissions(value.asObject()));
-                    } else {
-                        this.permissions.update(value.asObject());
-                    }
-                    break;
-                default:
-                    break;
+            String memberName = member.getName();
+            if (memberName.equals("url")) {
+                this.url = value.asString();
+            } else if (memberName.equals("download_url")) {
+                this.downloadUrl = value.asString();
+            } else if (memberName.equals("vanity_url")) {
+                this.vanityUrl = value.asString();
+            } else if (memberName.equals("is_password_enabled")) {
+                this.isPasswordEnabled = value.asBoolean();
+            } else if (memberName.equals("unshared_at")) {
+                this.unsharedAt = BoxDateFormat.parse(value.asString());
+            } else if (memberName.equals("download_count")) {
+                this.downloadCount = Double.valueOf(value.toString()).longValue();
+            } else if (memberName.equals("preview_count")) {
+                this.previewCount = Double.valueOf(value.toString()).longValue();
+            } else if (memberName.equals("access")) {
+                String accessString = value.asString().toUpperCase();
+                this.access = Access.valueOf(accessString);
+            } else if (memberName.equals("permissions")) {
+                if (this.permissions == null) {
+                    this.setPermissions(new Permissions(value.asObject()));
+                } else {
+                    this.permissions.update(value.asObject());
+                }
             }
         } catch (ParseException e) {
             assert false : "A ParseException indicates a bug in the SDK.";
@@ -256,15 +245,11 @@ public class BoxSharedLink extends BoxJSONObject {
         @Override
         void parseJSONMember(JsonObject.Member member) {
             JsonValue value = member.getValue();
-            switch (member.getName()) {
-                case "can_download":
-                    this.canDownload = value.asBoolean();
-                    break;
-                case "can_preview":
-                    this.canPreview = value.asBoolean();
-                    break;
-                default:
-                    break;
+            String memberName = member.getName();
+            if (memberName.equals("can_download")) {
+                this.canDownload = value.asBoolean();
+            } else if (memberName.equals("can_preview")) {
+                this.canPreview = value.asBoolean();
             }
         }
     }

--- a/src/main/java/com/box/sdk/BoxUploadEmail.java
+++ b/src/main/java/com/box/sdk/BoxUploadEmail.java
@@ -52,17 +52,14 @@ public class BoxUploadEmail extends BoxJSONObject {
         return this.email;
     }
 
+    @Override
     void parseJSONMember(JsonObject.Member member) {
         JsonValue value = member.getValue();
-        switch (member.getName()) {
-            case "access":
-                this.access = Access.fromJSONValue(value.asString());
-                break;
-            case "email":
-                this.email = value.asString();
-                break;
-            default:
-                break;
+        String memberName = member.getName();
+        if (memberName.equals("access")) {
+            this.access = Access.fromJSONValue(value.asString());
+        } else if (memberName.equals("email")) {
+            this.email = value.asString();
         }
     }
 

--- a/src/main/java/com/box/sdk/BoxUser.java
+++ b/src/main/java/com/box/sdk/BoxUser.java
@@ -222,45 +222,31 @@ public class BoxUser extends BoxCollaborator {
             super.parseJSONMember(member);
 
             JsonValue value = member.getValue();
-            switch (member.getName()) {
-                case "login":
-                    this.login = value.asString();
-                    break;
-                case "role":
-                    this.role = this.parseRole(value);
-                    break;
-                case "language":
-                    this.language = value.asString();
-                    break;
-                case "timezone":
-                    this.timezone = value.asString();
-                    break;
-                case "space_amount":
-                    this.spaceAmount = Double.valueOf(value.toString()).longValue();
-                    break;
-                case "space_used":
-                    this.spaceUsed = Double.valueOf(value.toString()).longValue();
-                    break;
-                case "max_upload_size":
-                    this.maxUploadSize = Double.valueOf(value.toString()).longValue();
-                    break;
-                case "status":
-                    this.status = this.parseStatus(value);
-                    break;
-                case "job_title":
-                    this.jobTitle = value.asString();
-                    break;
-                case "phone":
-                    this.jobTitle = value.asString();
-                    break;
-                case "address":
-                    this.address = value.asString();
-                    break;
-                case "avatar_url":
-                    this.avatarURL = value.asString();
-                    break;
-                default:
-                    break;
+            String memberName = member.getName();
+            if (memberName.equals("login")) {
+                this.login = value.asString();
+            } else if (memberName.equals("role")) {
+                this.role = this.parseRole(value);
+            } else if (memberName.equals("language")) {
+                this.language = value.asString();
+            } else if (memberName.equals("timezone")) {
+                this.timezone = value.asString();
+            } else if (memberName.equals("space_amount")) {
+                this.spaceAmount = Double.valueOf(value.toString()).longValue();
+            } else if (memberName.equals("space_used")) {
+                this.spaceUsed = Double.valueOf(value.toString()).longValue();
+            } else if (memberName.equals("max_upload_size")) {
+                this.maxUploadSize = Double.valueOf(value.toString()).longValue();
+            } else if (memberName.equals("status")) {
+                this.status = this.parseStatus(value);
+            } else if (memberName.equals("job_title")) {
+                this.jobTitle = value.asString();
+            } else if (memberName.equals("phone")) {
+                this.phone = value.asString();
+            } else if (memberName.equals("address")) {
+                this.address = value.asString();
+            } else if (memberName.equals("avatar_url")) {
+                this.avatarURL = value.asString();
             }
         }
 

--- a/src/main/java/com/box/sdk/StandardCharsets.java
+++ b/src/main/java/com/box/sdk/StandardCharsets.java
@@ -1,0 +1,20 @@
+package com.box.sdk;
+
+import java.nio.charset.Charset;
+
+/**
+ * Constant definitions for the standard Charsets.
+ *
+ * NB: Replace with java.nio.charset.StandardCharsets when we drop 1.6 support.
+ */
+public final class StandardCharsets {
+
+    /**
+     * Eight-bit UCS Transformation Format.
+     */
+    public static final Charset UTF_8 = Charset.forName("UTF-8");
+
+    private StandardCharsets() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/com/box/sdk/BoxCommentTest.java
+++ b/src/test/java/com/box/sdk/BoxCommentTest.java
@@ -2,7 +2,6 @@ package com.box.sdk;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -6,12 +6,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.RandomAccessFile;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.Collection;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -43,7 +41,7 @@ public class BoxFileTest {
         URL fileURL = this.getClass().getResource("/sample-files/" + fileName);
         String filePath = URLDecoder.decode(fileURL.getFile(), "utf-8");
         long fileSize = new File(filePath).length();
-        byte[] fileContent = Files.readAllBytes(Paths.get(filePath));
+        byte[] fileContent = readAllBytes(filePath);
 
         InputStream uploadStream = new FileInputStream(filePath);
         ProgressListener mockUploadListener = mock(ProgressListener.class);
@@ -72,7 +70,7 @@ public class BoxFileTest {
         URL fileURL = this.getClass().getResource("/sample-files/" + fileName);
         String filePath = URLDecoder.decode(fileURL.getFile(), "utf-8");
         long fileSize = new File(filePath).length();
-        byte[] fileContent = Files.readAllBytes(Paths.get(filePath));
+        byte[] fileContent = readAllBytes(filePath);
 
         InputStream uploadStream = new FileInputStream(filePath);
         ProgressListener mockUploadListener = mock(ProgressListener.class);
@@ -400,5 +398,13 @@ public class BoxFileTest {
         Assert.assertEquals("baz", check2.get("/foo"));
 
         uploadedFile.delete();
+    }
+
+
+    private static byte[] readAllBytes(String fileName) throws IOException {
+        RandomAccessFile f = new RandomAccessFile(fileName, "r");
+        byte[] b = new byte[(int) f.length()];
+        f.read(b);
+        return b;
     }
 }

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -2,7 +2,6 @@ package com.box.sdk;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Date;

--- a/src/test/java/com/box/sdk/BoxTrashTest.java
+++ b/src/test/java/com/box/sdk/BoxTrashTest.java
@@ -2,7 +2,6 @@ package com.box.sdk;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;


### PR DESCRIPTION
Per customer request, adding backwards support for Java 1.6.

There should be zero functional changes.

Summary of changes:
* Converted "switch on string" to if/else chains.  There may be a slight performance penalty, but it should be negligible compared to the overall HTTPS request.
* Replaced System.lineSeparator() with System.getProperty("line.separator")
* Replaced SimpleDateFormat "X" with "Z"
* Replaced StandardCharsets with custom helper class
* Replaced Files.readAllBytes with custom helper method

Fixes #62 - correctly parsing user phone field