### PR TITLE
Added event listener for stream position changes

### DIFF
--- a/src/main/java/com/box/sdk/EventListener.java
+++ b/src/main/java/com/box/sdk/EventListener.java
@@ -11,6 +11,12 @@ public interface EventListener {
     void onEvent(BoxEvent event);
 
     /**
+     * Invoked when an updated stream position is received from the API.
+     * @param position of the stream.
+     */
+    void onNextPosition(long position);
+
+    /**
      * Invoked when an error occurs while waiting for events to be received.
      *
      * <p>When an EventStream encounters an exception, it will invoke this method on each of its listeners until one

--- a/src/test/java/com/box/sdk/EventStreamTest.java
+++ b/src/test/java/com/box/sdk/EventStreamTest.java
@@ -33,10 +33,17 @@ public class EventStreamTest {
         BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
         EventStream stream = new EventStream(api);
         stream.addListener(new EventListener() {
+            @Override
             public void onEvent(BoxEvent event) {
                 observedEvents.add(event);
             }
 
+            @Override
+            public void onNextPosition(long position) {
+                return;
+            }
+
+            @Override
             public boolean onException(Throwable e) {
                 return true;
             }


### PR DESCRIPTION
If we want to be able to start and stop the ALF stream more granularly, we need to know the last stream position that has already been checked.  There is already a way to start an ALF stream at a specific point, but getting the next_stream_position from the request wasn't there.