### PR TITLE
Adds BoxFile.Info.getVersion()

### DIFF
--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -29,7 +29,7 @@ public class BoxFile extends BoxItem {
     public static final String[] ALL_FIELDS = {"type", "id", "sequence_id", "etag", "sha1", "name", "description",
         "size", "path_collection", "created_at", "modified_at", "trashed_at", "purged_at", "content_created_at",
         "content_modified_at", "created_by", "modified_by", "owned_by", "shared_link", "parent", "item_status",
-        "version_number", "comment_count", "permissions", "tags", "lock", "extension", "is_package"};
+        "version_number", "comment_count", "permissions", "tags", "lock", "extension", "is_package", "file_version"};
 
     private static final URLTemplate FILE_URL_TEMPLATE = new URLTemplate("files/%s");
     private static final URLTemplate CONTENT_URL_TEMPLATE = new URLTemplate("files/%s/content");
@@ -476,6 +476,7 @@ public class BoxFile extends BoxItem {
         private EnumSet<Permission> permissions;
         private String extension;
         private boolean isPackage;
+        private BoxFileVersion version;
 
         /**
          * Constructs an empty Info object.
@@ -553,6 +554,14 @@ public class BoxFile extends BoxItem {
             return this.isPackage;
         }
 
+        /**
+         * Gets the current version details of the file.
+         * @return the current version details of the file.
+         */
+        public BoxFileVersion getVersion() {
+            return this.version;
+        }
+
         @Override
         protected void parseJSONMember(JsonObject.Member member) {
             super.parseJSONMember(member);
@@ -571,6 +580,8 @@ public class BoxFile extends BoxItem {
                 this.extension = value.asString();
             } else if (memberName.equals("is_package")) {
                 this.isPackage = value.asBoolean();
+            } else if (memberName.equals("file_version")) {
+                this.version = this.parseFileVersion(value.asObject());
             }
         }
 
@@ -603,6 +614,10 @@ public class BoxFile extends BoxItem {
             }
 
             return permissions;
+        }
+
+        private BoxFileVersion parseFileVersion(JsonObject jsonObject) {
+            return new BoxFileVersion(BoxFile.this.getAPI(), jsonObject, BoxFile.this.getID());
         }
     }
 

--- a/src/main/java/com/box/sdk/BoxFileVersion.java
+++ b/src/main/java/com/box/sdk/BoxFileVersion.java
@@ -20,6 +20,7 @@ public class BoxFileVersion extends BoxResource {
 
     private final String fileID;
 
+    private String versionID;
     private String sha1;
     private String name;
     private long size;
@@ -49,7 +50,9 @@ public class BoxFileVersion extends BoxResource {
 
             try {
                 String memberName = member.getName();
-                if (memberName.equals("sha1")) {
+                if (memberName.equals("id")) {
+                    this.versionID = value.asString();
+                } else if (memberName.equals("sha1")) {
                     this.sha1 = value.asString();
                 } else if (memberName.equals("name")) {
                     this.name = value.asString();
@@ -69,6 +72,14 @@ public class BoxFileVersion extends BoxResource {
                 assert false : "A ParseException indicates a bug in the SDK.";
             }
         }
+    }
+
+    /**
+     * Gets the version ID of this version of the file.
+     * @return the version ID of this version of the file.
+     */
+    public String getVersionID() {
+        return this.versionID;
     }
 
     /**

--- a/src/main/java/com/box/sdk/BoxItem.java
+++ b/src/main/java/com/box/sdk/BoxItem.java
@@ -21,7 +21,8 @@ public abstract class BoxItem extends BoxResource {
         "size", "path_collection", "created_at", "modified_at", "trashed_at", "purged_at", "content_created_at",
         "content_modified_at", "created_by", "modified_by", "owned_by", "shared_link", "parent", "item_status",
         "version_number", "comment_count", "permissions", "tags", "lock", "extension", "is_package",
-        "folder_upload_email", "item_collection", "sync_state", "has_collaborations", "can_non_owners_invite"};
+        "folder_upload_email", "item_collection", "sync_state", "has_collaborations", "can_non_owners_invite",
+        "file_version"};
 
     private static final URLTemplate SHARED_ITEM_URL_TEMPLATE = new URLTemplate("shared_items");
 

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -167,6 +167,8 @@ public class BoxFileTest {
         assertThat(uploadedFileInfo.getExtension(), is(equalTo("txt")));
         assertThat(uploadedFileInfo.getIsPackage(), is(false));
         assertThat(uploadedFileInfo.getItemStatus(), is(equalTo("active")));
+        assertThat(uploadedFileInfo.getVersion(), not(nullValue()));
+        assertThat(uploadedFileInfo.getVersion().getVersionID(), not(nullValue()));
 
         uploadedFileInfo.getResource().delete();
     }


### PR DESCRIPTION
Previously it was not possible to retrieve the "version ID" of a
file.  Version ID is being promoted to a first class primitive.

This commit adds the ability to optionally retrieve the version ID.