### PR TITLE
Refresh access token when expires timestamp is 0

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -310,13 +310,9 @@ public class BoxAPIConnection {
         boolean needsRefresh;
 
         this.refreshLock.readLock().lock();
-        if (this.expires == 0) {
-            needsRefresh = false;
-        } else {
-            long now = System.currentTimeMillis();
-            long tokenDuration = (now - this.lastRefresh);
-            needsRefresh = (tokenDuration >= this.expires - REFRESH_EPSILON);
-        }
+        long now = System.currentTimeMillis();
+        long tokenDuration = (now - this.lastRefresh);
+        needsRefresh = (tokenDuration >= this.expires - REFRESH_EPSILON);
         this.refreshLock.readLock().unlock();
 
         return needsRefresh;

--- a/src/test/java/com/box/sdk/BoxAPIConnectionTest.java
+++ b/src/test/java/com/box/sdk/BoxAPIConnectionTest.java
@@ -18,7 +18,12 @@ public class BoxAPIConnectionTest {
     @Test
     @Category(UnitTest.class)
     public void canRefreshWhenGivenRefreshToken() {
-        BoxAPIConnection api = new BoxAPIConnection("", "", "", "");
+        final String anyClientID = "";
+        final String anyClientSecret = "";
+        final String anyAccessToken = "";
+        final String anyRefreshToken = "";
+
+        BoxAPIConnection api = new BoxAPIConnection(anyClientID, anyClientSecret, anyAccessToken, anyRefreshToken);
 
         assertThat(api.canRefresh(), is(true));
     }
@@ -26,7 +31,9 @@ public class BoxAPIConnectionTest {
     @Test
     @Category(UnitTest.class)
     public void needsRefreshWhenTokenHasExpired() {
-        BoxAPIConnection api = new BoxAPIConnection("");
+        final String anyAccessToken = "";
+
+        BoxAPIConnection api = new BoxAPIConnection(anyAccessToken);
         api.setExpires(-1);
 
         assertThat(api.needsRefresh(), is(true));
@@ -35,7 +42,9 @@ public class BoxAPIConnectionTest {
     @Test
     @Category(UnitTest.class)
     public void doesNotNeedRefreshWhenTokenHasNotExpired() {
-        BoxAPIConnection api = new BoxAPIConnection("");
+        final String anyAccessToken = "";
+
+        BoxAPIConnection api = new BoxAPIConnection(anyAccessToken);
         api.setExpires(Long.MAX_VALUE);
 
         assertThat(api.needsRefresh(), is(not(true)));
@@ -43,11 +52,13 @@ public class BoxAPIConnectionTest {
 
     @Test
     @Category(UnitTest.class)
-    public void doesNotNeedRefreshWhenExpiresIsZero() {
-        BoxAPIConnection api = new BoxAPIConnection("");
+    public void needsRefreshWhenExpiresIsZero() {
+        final String anyAccessToken = "";
+
+        BoxAPIConnection api = new BoxAPIConnection(anyAccessToken);
         api.setExpires(0);
 
-        assertThat(api.needsRefresh(), is(not(true)));
+        assertThat(api.needsRefresh(), is(true));
     }
 
     @Test


### PR DESCRIPTION
The `needsRefresh()` method in `BoxAPIConnection` would always return
false if the expires timestamp is 0. A more intuitive behavior is to
always refresh if we don't know when the token is going to expire. This
avoids issues with constructing an API connection and forgetting to call
`setExpires(long)`. For example:

	BoxAPIConnection api = new BoxAPIConnection("id", "secret",
		"storedAccess", "storedRefresh");

	// This call can fail if the stored access token had expired because
	// the expiration timestamp is 0.
	BoxFolder rootFolder = BoxFolder.getRootFolder(api);