### PR TITLE
Add User-Agent headers to the auth requests

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -121,6 +121,7 @@ public class BoxAPIConnection {
 
         BoxAPIRequest request = new BoxAPIRequest(url, "POST");
         request.addHeader("Content-Type", "application/x-www-form-urlencoded");
+        request.addHeader("User-Agent", this.getUserAgent());
         request.setBody(urlParameters);
 
         BoxJSONResponse response = (BoxJSONResponse) request.send();
@@ -345,6 +346,7 @@ public class BoxAPIConnection {
 
         BoxAPIRequest request = new BoxAPIRequest(url, "POST");
         request.addHeader("Content-Type", "application/x-www-form-urlencoded");
+        request.addHeader("User-Agent", this.getUserAgent());
         request.setBody(urlParameters);
 
         String json;


### PR DESCRIPTION
The authentication calls didn't have the userAgent being sent resulting the default ```Java/1.7.0_uXX``` user agent