### PR TITLE
Long download requests

### DIFF
--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -121,9 +121,9 @@ public class BoxFile extends BoxItem {
             }
         } catch (IOException e) {
             throw new BoxAPIException("Couldn't connect to the Box API due to a network error.", e);
+        } finally {
+            response.disconnect();
         }
-
-        response.disconnect();
     }
 
     /**
@@ -175,9 +175,9 @@ public class BoxFile extends BoxItem {
             }
         } catch (IOException e) {
             throw new BoxAPIException("Couldn't connect to the Box API due to a network error.", e);
+        } finally {
+            response.disconnect();
         }
-
-        response.disconnect();
     }
 
     @Override


### PR DESCRIPTION
If a download request gets terminated, or errors the request continues to listen to the input stream since the disconnect isn't called in the exception scenario.  I moved the disconnect in a finally block to make sure that it will be called immediately and not leave the network up and running.