### PR TITLE
Add EventLog for retrieving a static log of events

### DIFF
--- a/src/main/java/com/box/sdk/BoxEvent.java
+++ b/src/main/java/com/box/sdk/BoxEvent.java
@@ -9,6 +9,7 @@ import com.eclipsesource.json.JsonValue;
 public class BoxEvent extends BoxResource {
     private BoxResource.Info sourceInfo;
     private BoxEvent.Type type;
+    private JsonObject sourceJSON;
 
     /**
      * Constructs a BoxEvent from a JSON string.
@@ -33,10 +34,28 @@ public class BoxEvent extends BoxResource {
 
     /**
      * Gets info about the source of this event.
+     *
+     * <p>Note that there is a bug in the enterprise event stream where certain event sources don't correctly map to a
+     * BoxResource.Info. In the case where the event source JSON cannot be mapped to a BoxResource.Info, you can use the
+     * {@link #getSourceJSON} method to access the raw JSON representation of the event source.</p>
+     *
      * @return info about the source of this event.
      */
     public BoxResource.Info getSourceInfo() {
         return this.sourceInfo;
+    }
+
+    /**
+     * Gets the raw JSON object containing information about the source of this event.
+     *
+     * <p>This method can be used to work around bugs in the enterprise events API where some enterprise event sources
+     * don't correctly map to a BoxResource.Info. In this case, this method can be used to access the raw JSON
+     * directly.</p>
+     *
+     * @return the JSON representation of the source of this event.
+     */
+    public JsonObject getSourceJSON() {
+        return this.sourceJSON;
     }
 
     /**
@@ -55,8 +74,15 @@ public class BoxEvent extends BoxResource {
 
         String memberName = member.getName();
         if (memberName.equals("source")) {
-            this.sourceInfo = BoxResource.parseInfo(this.getAPI(), value.asObject());
-
+            // Parsing the source might fail due to a bug in the enterprise event stream where the API returns JSON that
+            // doesn't correctly map to a BoxResource.Info. If this happens, we set the sourceInfo to null and expect
+            // the caller to use the getSourceJSON() method instead.
+            try {
+                this.sourceInfo = BoxResource.parseInfo(this.getAPI(), value.asObject());
+            } catch (Exception e) {
+                this.sourceInfo = null;
+            }
+            this.sourceJSON = JsonObject.unmodifiableObject(value.asObject());
         } else if (memberName.equals("event_type")) {
             String stringValue = value.asString();
             for (Type t : Type.values()) {
@@ -209,6 +235,211 @@ public class BoxEvent extends BoxResource {
         /**
          * An admin role changed for a user.
          */
-        CHANGE_ADMIN_ROLE;
+        CHANGE_ADMIN_ROLE,
+
+        /**
+         * A user was added to a group. This is an enterprise-only event.
+         */
+        GROUP_ADD_USER,
+
+        /**
+         * A user was created. This is an enterprise-only event.
+         */
+        NEW_USER,
+
+        /**
+         * A group was created. This is an enterprise-only event.
+         */
+        GROUP_CREATION,
+
+        /**
+         * A group was deleted. This is an enterprise-only event.
+         */
+        GROUP_DELETION,
+
+        /**
+         * A user was deleted. This is an enterprise-only event.
+         */
+        DELETE_USER,
+
+        /**
+         * A group was edited. This is an enterprise-only event.
+         */
+        GROUP_EDITED,
+
+        /**
+         * A user was edited. This is an enterprise-only event.
+         */
+        EDIT_USER,
+
+        /**
+         * A group was granted access to a folder. This is an enterprise-only event.
+         */
+        GROUP_ADD_FOLDER,
+
+        /**
+         * A user was removed from a group. This is an enterprise-only event.
+         */
+        GROUP_REMOVE_USER,
+
+        /**
+         * A group had its access to a folder removed. This is an enterprise-only event.
+         */
+        GROUP_REMOVE_FOLDER,
+
+        /**
+         * An administrator logged in. This is an enterprise-only event.
+         */
+        ADMIN_LOGIN,
+
+        /**
+         * A device was associated with a user. This is an enterprise-only event.
+         */
+        ADD_DEVICE_ASSOCIATION,
+
+        /**
+         * There was a failed login attempt. This is an enterprise-only event.
+         */
+        FAILED_LOGIN,
+
+        /**
+         * There was a successful login. This is an enterprise-only event.
+         */
+        LOGIN,
+
+        /**
+         * A user's OAuth2 access token was refreshed. This is an enterprise-only event.
+         */
+        USER_AUTHENTICATE_OAUTH2_TOKEN_REFRESH,
+
+        /**
+         * A device was disassociated with a user. This is an enterprise-only event.
+         */
+        REMOVE_DEVICE_ASSOCIATION,
+
+        /**
+         * A user agreed to the terms of service. This is an enterprise-only event.
+         */
+        TERMS_OF_SERVICE_AGREE,
+
+        /**
+         * A user rejected the terms of service. This is an enterprise-only event.
+         */
+        TERMS_OF_SERVICE_REJECT,
+
+        /**
+         * An item was copied. This is an enterprise-only event.
+         */
+        COPY,
+
+        /**
+         * An item was deleted. This is an enterprise-only event.
+         */
+        DELETE,
+
+        /**
+         * An item was downloaded. This is an enterprise-only event.
+         */
+        DOWNLOAD,
+
+        /**
+         * An item was edited. This is an enterprise-only event.
+         */
+        EDIT,
+
+        /**
+         * An item was locked. This is an enterprise-only event.
+         */
+        LOCK,
+
+        /**
+         * An item was moved. This is an enterprise-only event.
+         */
+        MOVE,
+
+        /**
+         * An item was previewed. This is an enterprise-only event.
+         */
+        PREVIEW,
+
+        /**
+         * An item was renamed. This is an enterprise-only event.
+         */
+        RENAME,
+
+        /**
+         * An item was set to be auto-deleted. This is an enterprise-only event.
+         */
+        STORAGE_EXPIRATION,
+
+        /**
+         * An item was undeleted. This is an enterprise-only event.
+         */
+        UNDELETE,
+
+        /**
+         * An item was unlocked. This is an enterprise-only event.
+         */
+        UNLOCK,
+
+        /**
+         * An item was uploaded. This is an enterprise-only event.
+         */
+        UPLOAD,
+
+        /**
+         * An shared link was created for an item. This is an enterprise-only event.
+         */
+        SHARE,
+
+        /**
+         * The shared link for an item was updated. This is an enterprise-only event.
+         */
+        ITEM_SHARED_UPDATE,
+
+        /**
+         * The expiration time for a shared link was extended. This is an enterprise-only event.
+         */
+        UPDATE_SHARE_EXPIRATION,
+
+        /**
+         * The expiration time was set for a shared link. This is an enterprise-only event.
+         */
+        SHARE_EXPIRATION,
+
+        /**
+         * The shared link for an item was REMOVE_DEVICE_ASSOCIATION. This is an enterprise-only event.
+         */
+        UNSHARE,
+
+        /**
+         * A user accepted a collaboration invite. This is an enterprise-only event.
+         */
+        COLLABORATION_ACCEPT,
+
+        /**
+         * A user's collaboration role was changed. This is an enterprise-only event.
+         */
+        COLLABORATION_ROLE_CHANGE,
+
+        /**
+         * The expiration time for a collaboration was extended. This is an enterprise-only event.
+         */
+        UPDATE_COLLABORATION_EXPIRATION,
+
+        /**
+         * A collaboration was removed from a folder. This is an enterprise-only event.
+         */
+        COLLABORATION_REMOVE,
+
+        /**
+         * A user was invited to collaborate on a folder. This is an enterprise-only event.
+         */
+        COLLABORATION_INVITE,
+
+        /**
+         * An expiration time was set for a collaboration. This is an enterprise-only event.
+         */
+        COLLABORATION_EXPIRATION;
     }
 }

--- a/src/main/java/com/box/sdk/EventLog.java
+++ b/src/main/java/com/box/sdk/EventLog.java
@@ -1,0 +1,211 @@
+package com.box.sdk;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+import com.eclipsesource.json.JsonArray;
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+
+/**
+ * A log of events that were retrieved from the events endpoint.
+ *
+ * <p>An EventLog cannot be instantiated directly. Instead, use one of the static methods to retrieve a log of events.
+ * Unlike the {@link EventStream} class, EventLog doesn't support retrieving events in real-time.
+ * </p>
+ */
+public class EventLog implements Iterable<BoxEvent> {
+    private static final int ENTERPRISE_LIMIT = 500;
+    private static final URLTemplate ENTERPRISE_EVENT_URL_TEMPLATE = new URLTemplate("events?stream_type=admin_logs&"
+        + "limit=" + ENTERPRISE_LIMIT + "&created_after=%s&created_before=%s");
+
+    private final int chunkSize;
+    private final int limit;
+    private final long nextStreamPosition;
+    private final long streamPosition;
+    private final Set<BoxEvent> set;
+
+    private Date startDate;
+    private Date endDate;
+
+    EventLog(BoxAPIConnection api, JsonObject json, long streamPosition, int limit) {
+        this.streamPosition = streamPosition;
+        this.limit = limit;
+        this.nextStreamPosition = Long.parseLong(json.get("next_stream_position").asString());
+        this.chunkSize = json.get("chunk_size").asInt();
+
+        this.set = new HashSet<BoxEvent>(this.chunkSize);
+        JsonArray entries = json.get("entries").asArray();
+        for (JsonValue entry : entries) {
+            this.set.add(new BoxEvent(api, entry.asObject()));
+        }
+    }
+
+    /**
+     * Gets all the enterprise events that occurred within a specified date range.
+     * @param  api    the API connection to use.
+     * @param  after  the lower bound on the timestamp of the events returned.
+     * @param  before the upper bound on the timestamp of the events returned.
+     * @param  types  an optional list of event types to filter by.
+     * @return        a log of all the events that met the given criteria.
+     */
+    public static EventLog getEnterpriseEvents(BoxAPIConnection api, Date after, Date before, BoxEvent.Type... types) {
+        return getEnterpriseEvents(api, 0, after, before, types);
+    }
+
+    /**
+     * Gets all the enterprise events that occurred within a specified date range, starting from a given position
+     * within the event stream.
+     * @param  api      the API connection to use.
+     * @param  position the starting position of the event stream.
+     * @param  after    the lower bound on the timestamp of the events returned.
+     * @param  before   the upper bound on the timestamp of the events returned.
+     * @param  types    an optional list of event types to filter by.
+     * @return          a log of all the events that met the given criteria.
+     */
+    public static EventLog getEnterpriseEvents(BoxAPIConnection api, long position, Date after, Date before,
+        BoxEvent.Type... types) {
+
+        String afterString = BoxDateFormat.format(after);
+        String beforeString = BoxDateFormat.format(before);
+        URL url = ENTERPRISE_EVENT_URL_TEMPLATE.build(api.getBaseURL(), afterString, beforeString);
+
+        if (position != 0 || types.length > 0) {
+            QueryStringBuilder queryBuilder = new QueryStringBuilder(url.getQuery());
+
+            if (position != 0) {
+                queryBuilder.appendParam("stream_position", position);
+            }
+
+            StringBuilder filterBuilder = new StringBuilder();
+            for (BoxEvent.Type filterType : types) {
+                filterBuilder.append(filterType.name());
+                filterBuilder.append(',');
+            }
+            filterBuilder.deleteCharAt(filterBuilder.length() - 1);
+            queryBuilder.appendParam("event_type", filterBuilder.toString());
+
+            try {
+                url = queryBuilder.addToURL(url);
+            } catch (MalformedURLException e) {
+                throw new BoxAPIException("Couldn't append a query string to the provided URL.");
+            }
+        }
+
+        BoxAPIRequest request = new BoxAPIRequest(api, url, "GET");
+        BoxJSONResponse response = (BoxJSONResponse) request.send();
+        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        EventLog log = new EventLog(api, responseJSON, position, ENTERPRISE_LIMIT);
+        log.setStartDate(after);
+        log.setEndDate(before);
+        return log;
+    }
+
+    void setStartDate(Date startDate) {
+        this.startDate = startDate;
+    }
+
+    void setEndDate(Date endDate) {
+        this.endDate = endDate;
+    }
+
+    /**
+     * Returns an iterator over the events in this log.
+     * @return an iterator over the events in this log.
+     */
+    @Override
+    public Iterator<BoxEvent> iterator() {
+        return this.set.iterator();
+    }
+
+    /**
+     * Gets the date of the earliest event in this log.
+     *
+     * <p>The value returned by this method corresponds to the <code>created_after</code> URL parameter that was used
+     * when retrieving the events in this EventLog.</p>
+     *
+     * @return the date of the earliest event in this log.
+     */
+    public Date getStartDate() {
+        return this.startDate;
+    }
+
+    /**
+     * Gets the date of the latest event in this log.
+     *
+     * <p>The value returned by this method corresponds to the <code>created_before</code> URL parameter that was used
+     * when retrieving the events in this EventLog.</p>
+     *
+     * @return the date of the latest event in this log.
+     */
+    public Date getEndDate() {
+        return this.endDate;
+    }
+
+    /**
+     * Gets the maximum number of events that this event log could contain given its start date, end date, and stream
+     * position.
+     *
+     * <p>The value returned by this method corresponds to the <code>limit</code> URL parameter that was used when
+     * retrieving the events in this EventLog.</p>
+     *
+     * @return the maximum number of events.
+     */
+    public int getLimit() {
+        return this.limit;
+    }
+
+    /**
+     * Gets the starting position of the events in this log within the event stream.
+     *
+     * <p>The value returned by this method corresponds to the <code>stream_position</code> URL parameter that was used
+     * when retrieving the events in this EventLog.</p>
+     *
+     * @return the starting position within the event stream.
+     */
+    public long getStreamPosition() {
+        return this.streamPosition;
+    }
+
+    /**
+     * Gets the next position within the event stream for retrieving subsequent events.
+     *
+     * <p>The value returned by this method corresponds to the <code>next_stream_position</code> field returned by the
+     * API's events endpoint.</p>
+     *
+     * @return the next position within the event stream.
+     */
+    public long getNextStreamPosition() {
+        return this.nextStreamPosition;
+    }
+
+    /**
+     * Gets the number of events in this log, including duplicate events.
+     *
+     * <p>The chunk size may not be representative of the number of events returned by this EventLog's iterator because
+     * the iterator will automatically ignore duplicate events.</p>
+     *
+     * <p>The value returned by this method corresponds to the <code>chunk_size</code> field returned by the API's
+     * events endpoint.</p>
+     *
+     * @return the number of events, including duplicates.
+     */
+    public int getChunkSize() {
+        return this.chunkSize;
+    }
+
+    /**
+     * Gets the number of events in this list, excluding duplicate events.
+     *
+     * <p>The size is guaranteed to be representative of the number of events returned by this EventLog's iterator.</p>
+     *
+     * @return the number of events, excluding duplicates.
+     */
+    public int getSize() {
+        return this.set.size();
+    }
+}

--- a/src/test/java/com/box/sdk/EventLogTest.java
+++ b/src/test/java/com/box/sdk/EventLogTest.java
@@ -1,0 +1,26 @@
+package com.box.sdk;
+
+import java.util.Date;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class EventLogTest {
+    @Test
+    @Category(IntegrationTest.class)
+    public void getEnterpriseEventsReturnsAtLeastOneEvent() {
+        BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
+        Date after = new Date(0L);
+        Date before = new Date(System.currentTimeMillis());
+        EventLog events = EventLog.getEnterpriseEvents(api, after, before);
+
+        assertThat(events.getSize(), is(not(0)));
+        assertThat(events.getStartDate(), is(equalTo(after)));
+        assertThat(events.getEndDate(), is(equalTo(before)));
+    }
+}


### PR DESCRIPTION
The EventLog class provides methods for retrieving static logs of
events. Unlike the EventStream, an EventLog isn't updated in real-time.
For now it only provides a way of retrieving enterprise events, since
those aren't available in real-time via EventStream.

It's also worth noting that there's a bug in the Box events endpoint
where some enterprise event sources don't map correctly to a
BoxResource. In the cases where this happens, the `getSourceInfo()` will
return null, and a new a `getSourceJSON()` method can be used to access
the event source JSON directly.

Closes #81.