### PR TITLE
Improve saving and restoring BoxAPIConnections

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIConnectionListener.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnectionListener.java
@@ -7,6 +7,22 @@ public interface BoxAPIConnectionListener {
 
     /**
      * Called when the Box API connection refreshes its tokens.
+     *
+     * <p>The provided connection is guaranteed to not be auto-refreshed or modified by another listener until this
+     * method returns.</p>
+     *
+     * @param api the API connection that was refreshed.
      */
-    void onRefresh();
+    void onRefresh(BoxAPIConnection api);
+
+    /**
+     * Called when an error occurs while attempting to refresh the Box API connection's tokens.
+     *
+     * <p>The provided connection is guaranteed to not be auto-refreshed or modified by another listener until this
+     * method returns.</p>
+     *
+     * @param api   the API connection that encountered an error.
+     * @param error the error that occurred.
+     */
+    void onError(BoxAPIConnection api, BoxAPIException error);
 }


### PR DESCRIPTION
This change adds a `save()` method and a static `restore(String)` method
to BoxAPIConnection. These methods are meant to simplify the process of
saving the state of a connection and then restoring it at a later time.

The `save()` method serializes the state of BoxAPIConnection to a JSON
string which can persisted. The `restore(String)` method takes a JSON
string and reconstructs a BoxAPIConnection using the saved state.

BoxAPIConnectionListener has also had an
`onError(BoxAPIConnection, BoxAPIException)` callback added so that
connection errors can be more easily handled. The `onRefresh()` method
also now receives a BoxAPIConnection object that can be used to save the
newly updated state of the connection.

Closes #104 and fixes #82.