### PR TITLE
Parse path collections as BoxFolder.Info

### DIFF
--- a/src/main/java/com/box/sdk/BoxItem.java
+++ b/src/main/java/com/box/sdk/BoxItem.java
@@ -131,7 +131,7 @@ public abstract class BoxItem extends BoxResource {
         private Date modifiedAt;
         private String description;
         private long size;
-        private List<BoxFolder> pathCollection;
+        private List<BoxFolder.Info> pathCollection;
         private BoxUser.Info createdBy;
         private BoxUser.Info modifiedBy;
         private Date trashedAt;
@@ -237,7 +237,7 @@ public abstract class BoxItem extends BoxResource {
          * Gets the path of folders to the item, starting at the root.
          * @return the path of folders to the item.
          */
-        public List<BoxFolder> getPathCollection() {
+        public List<BoxFolder.Info> getPathCollection() {
             return this.pathCollection;
         }
 
@@ -417,14 +417,15 @@ public abstract class BoxItem extends BoxResource {
             }
         }
 
-        private List<BoxFolder> parsePathCollection(JsonObject jsonObject) {
+        private List<BoxFolder.Info> parsePathCollection(JsonObject jsonObject) {
             int count = jsonObject.get("total_count").asInt();
-            List<BoxFolder> pathCollection = new ArrayList<BoxFolder>(count);
+            List<BoxFolder.Info> pathCollection = new ArrayList<BoxFolder.Info>(count);
             JsonArray entries = jsonObject.get("entries").asArray();
             for (JsonValue value : entries) {
                 JsonObject entry = value.asObject();
                 String id = entry.get("id").asString();
-                pathCollection.add(new BoxFolder(getAPI(), id));
+                BoxFolder folder = new BoxFolder(getAPI(), id);
+                pathCollection.add(folder.new Info(entry));
             }
 
             return pathCollection;

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -147,13 +147,13 @@ public class BoxFolderTest {
         String actualCreatedByID = info.getCreatedBy().getID();
         String actualParentFolderID = info.getParent().getID();
         String actualParentFolderName = info.getParent().getName();
-        List<BoxFolder> actualPathCollection = info.getPathCollection();
+        List<BoxFolder.Info> actualPathCollection = info.getPathCollection();
 
         assertThat(expectedName, equalTo(actualName));
         assertThat(expectedCreatedByID, equalTo(actualCreatedByID));
         assertThat(expectedParentFolderID, equalTo(actualParentFolderID));
         assertThat(expectedParentFolderName, equalTo(actualParentFolderName));
-        assertThat(actualPathCollection, hasItem(rootFolder));
+        assertThat(actualPathCollection, hasItem(Matchers.<BoxFolder.Info>hasProperty("ID", equalTo("0"))));
         assertThat(info.getPermissions(), is(equalTo(EnumSet.allOf(BoxFolder.Permission.class))));
         assertThat(info.getItemStatus(), is(equalTo("active")));
 


### PR DESCRIPTION
When getting info about a folder, its `path_collection` field should be
parsed as a collection of BoxFolder.Info instead of BoxFolder. This way
additional fields (such as the folder's name) can be returned.

Fixes #105.