### PR TITLE
Handle groups when retrieving and creating collabs

### DIFF
--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -70,6 +70,8 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
 
         if (collaborator instanceof BoxUser) {
             accessibleByField.add("type", "user");
+        } else if (collaborator instanceof BoxGroup) {
+            accessibleByField.add("type", "group");
         } else {
             throw new IllegalArgumentException("The given collaborator is of an unknown type.");
         }


### PR DESCRIPTION
Since the "group" type wasn't being handled when creating a new
collaboration, an IllegalArgumentException would be thrown. This fix
handles group types correctly and will successfully create group-based
collaborations.

When retreiving collaborations, the JSON was parsed as a list of users
instead of a list of users or groups. This led to BoxUser.Info objects
being returned with incorrect or unpopulated fields. This fix makes it
so the "type" field is checked for each item in the list, and the JSON
gets parsed into its appropriate type.

Fixes #116.