### PR TITLE
Add some additional fields to BoxEvent

### DIFF
--- a/src/main/java/com/box/sdk/BoxEvent.java
+++ b/src/main/java/com/box/sdk/BoxEvent.java
@@ -1,5 +1,8 @@
 package com.box.sdk;
 
+import java.text.ParseException;
+import java.util.Date;
+
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
 
@@ -10,6 +13,12 @@ public class BoxEvent extends BoxResource {
     private BoxResource.Info sourceInfo;
     private BoxEvent.Type type;
     private JsonObject sourceJSON;
+    private Date createdAt;
+    private String ipAddress;
+    private JsonObject additionalDetails;
+    private BoxCollaborator.Info accessibleBy;
+    private BoxUser.Info createdBy;
+    private String sessionID;
 
     /**
      * Constructs a BoxEvent from a JSON string.
@@ -66,6 +75,62 @@ public class BoxEvent extends BoxResource {
         return this.type;
     }
 
+
+    /**
+     * Gets the time that this event was created.
+     * @return the time that this event was created.
+     */
+    public Date getCreatedAt() {
+        return this.createdAt;
+    }
+
+    /**
+     * Gets the IP address of the user that triggered this event.
+     * @return the IP address of the user that triggered this event.
+     */
+    public String getIPAddress() {
+        return this.ipAddress;
+    }
+
+    /**
+     * Gets a JSON object containing additional details about this event.
+     *
+     * <p>The fields and data within the returned JSON object will vary depending on the type of the event.</p>
+     *
+     * @return a JSON object containing additional details about this event.
+     */
+    public JsonObject getAdditionalDetails() {
+        return this.additionalDetails;
+    }
+
+    /**
+     * Gets info about the collaborator who was given access to a folder within the current enterprise.
+     *
+     * <p>This field is only populated when the event is related to a collaboration that occurred within an enterprise.
+     * </p>
+     *
+     * @return info about the collaborator who was given access to a folder within the current enterprise.
+     */
+    public BoxCollaborator.Info getAccessibleBy() {
+        return this.accessibleBy;
+    }
+
+    /**
+     * Gets info about the user that triggered this event.
+     * @return info about the user that triggered this event.
+     */
+    public BoxUser.Info getCreatedBy() {
+        return this.createdBy;
+    }
+
+    /**
+     * Gets the session ID of the user that triggered this event.
+     * @return the session ID of the user that triggered this event.
+     */
+    public String getSessionID() {
+        return this.sessionID;
+    }
+
     void parseJsonMember(JsonObject.Member member) {
         JsonValue value = member.getValue();
         if (value.isNull()) {
@@ -95,6 +160,22 @@ public class BoxEvent extends BoxResource {
             if (this.type == null) {
                 this.type = Type.UNKNOWN;
             }
+        } else if (memberName.equals("created_at")) {
+            try {
+                this.createdAt = BoxDateFormat.parse(value.asString());
+            } catch (ParseException e) {
+                assert false : "A ParseException indicates a bug in the SDK.";
+            }
+        } else if (memberName.equals("ip_address")) {
+            this.ipAddress = value.asString();
+        } else if (memberName.equals("additional_details")) {
+            this.additionalDetails = value.asObject();
+        } else if (memberName.equals("accessible_by")) {
+            this.accessibleBy = (BoxCollaborator.Info) BoxResource.parseInfo(this.getAPI(), value.asObject());
+        } else if (memberName.equals("created_by")) {
+            this.createdBy = (BoxUser.Info) BoxResource.parseInfo(this.getAPI(), value.asObject());
+        } else if (memberName.equals("session_id")) {
+            this.sessionID = value.asString();
         }
     }
 

--- a/src/test/java/com/box/sdk/BoxEventTest.java
+++ b/src/test/java/com/box/sdk/BoxEventTest.java
@@ -1,10 +1,16 @@
 package com.box.sdk;
 
+import java.text.ParseException;
+
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import com.eclipsesource.json.JsonObject;
 
 public class BoxEventTest {
     @Test
@@ -15,5 +21,75 @@ public class BoxEventTest {
         BoxEvent event = new BoxEvent(null, eventJSON);
 
         assertThat(event.getType(), is(BoxEvent.Type.UNKNOWN));
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void newBoxEventShouldParseAllFieldsCorrectly() throws ParseException {
+        final String eventID = "non-empty event ID";
+        final String sessionID = "non-empty session ID";
+        final String userID = "non-empty user ID";
+        final String userName = "non-empty user name";
+        final String userLogin = "non-empty user login";
+        final String createdAt = "2014-12-18T16:25:15-08:00";
+        final String ipAddress = "non-empty IP";
+        final String detailsType = "non-empty details type";
+        final boolean isPerformedByAdmin = true;
+
+        JsonObject eventJSON = new JsonObject()
+            .add("event_id", eventID)
+            .add("session_id", sessionID)
+            .add("created_by", new JsonObject()
+                .add("type", "user")
+                .add("id", userID)
+                .add("name", userName)
+                .add("login", userLogin))
+            .add("created_at", createdAt)
+            .add("ip_address", ipAddress)
+            .add("additional_details", new JsonObject()
+                .add("type", detailsType)
+                .add("is_performed_by_admin", isPerformedByAdmin))
+            .add("accessible_by", new JsonObject()
+                .add("type", "user")
+                .add("id", userID)
+                .add("name", userName)
+                .add("login", userLogin));
+
+        BoxEvent event = new BoxEvent(null, eventJSON);
+        assertEquals(eventID, event.getID());
+        assertEquals(sessionID, event.getSessionID());
+        assertEquals(userID, event.getCreatedBy().getID());
+        assertEquals(userName, event.getCreatedBy().getName());
+        assertEquals(userLogin, event.getCreatedBy().getLogin());
+        assertEquals(BoxDateFormat.parse(createdAt), event.getCreatedAt());
+        assertEquals(ipAddress, event.getIPAddress());
+        assertEquals(detailsType, event.getAdditionalDetails().get("type").asString());
+        assertEquals(isPerformedByAdmin, event.getAdditionalDetails().get("is_performed_by_admin").asBoolean());
+        assertEquals(userID, event.getAccessibleBy().getID());
+        assertEquals(userName, event.getAccessibleBy().getName());
+        assertEquals(userLogin, ((BoxUser.Info) event.getAccessibleBy()).getLogin());
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void newBoxEventShouldParseAccessibleByFieldCorrectlyWhenItIsAGroup() throws ParseException {
+        final String eventID = "non-empty event ID";
+        final String groupID = "non-empty group ID";
+        final String groupName = "non-empty group name";
+
+        JsonObject eventJSON = new JsonObject()
+            .add("event_id", eventID)
+            .add("accessible_by", new JsonObject()
+                .add("type", "group")
+                .add("id", groupID)
+                .add("name", groupName));
+
+        BoxEvent event = new BoxEvent(null, eventJSON);
+        assertEquals(eventID, event.getID());
+
+        assertTrue(event.getAccessibleBy() instanceof BoxGroup.Info);
+        BoxGroup.Info parsedGroupInfo = (BoxGroup.Info) event.getAccessibleBy();
+        assertEquals(groupID, parsedGroupInfo.getID());
+        assertEquals(groupName, parsedGroupInfo.getName());
     }
 }


### PR DESCRIPTION
Add getters for the "created_at", "created_by", and "session_id" fields.
There are also getters added for some undocumented fields that may show
up in enterprise events. These fields are "ip_address",
"additional_details", and "accessible_by".

The "additional_details" field doesn't have a known schema, so it has to
be exposed as a raw `JsonObject` (similar to what had to be done for the
"source" field). This may no longer be necessary once the bugs in the
enterprise events stream are fixed.