### PR TITLE
Fix OAuth race condition when refreshing

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -507,4 +507,26 @@ public class BoxAPIConnection {
             .add("maxRequestAttempts", this.maxRequestAttempts);
         return state.toString();
     }
+
+    String lockAccessToken() {
+        if (this.autoRefresh && this.canRefresh() && this.needsRefresh()) {
+            this.refreshLock.writeLock().lock();
+            try {
+                if (this.needsRefresh()) {
+                    this.refresh();
+                }
+                this.refreshLock.readLock().lock();
+            } finally {
+                this.refreshLock.writeLock().unlock();
+            }
+        } else {
+            this.refreshLock.readLock().lock();
+        }
+
+        return this.accessToken;
+    }
+
+    void unlockAccessToken() {
+        this.refreshLock.readLock().unlock();
+    }
 }

--- a/src/main/java/com/box/sdk/SharedLinkAPIConnection.java
+++ b/src/main/java/com/box/sdk/SharedLinkAPIConnection.java
@@ -116,6 +116,16 @@ class SharedLinkAPIConnection extends BoxAPIConnection {
         this.wrappedConnection.refresh();
     }
 
+    @Override
+    String lockAccessToken() {
+        return this.wrappedConnection.lockAccessToken();
+    }
+
+    @Override
+    void unlockAccessToken() {
+        this.wrappedConnection.unlockAccessToken();
+    }
+
     /**
      * Gets the shared link used for accessing shared items.
      * @return the shared link used for accessing shared items.


### PR DESCRIPTION
This change introduces an access token read lock that can be used to
prevent the access token from being refreshed before a request is sent.

When calling `BoxAPIConnection.getAccessToken()`, the access token is
only locked until it is read and returned. This means that a request can
be sent with an invalid access token if a refresh occurred between the
time when `getAccessToken()` was called and the request was sent.

The new `lockAccessToken()` and `unlockAccessToken()` methods allow for
requests to keep the token locked until they're finished being sent.
These methods are package-private for now, since their misuse can easily
cause deadlocks.