### PR TITLE
Update docs around saving/restoring proxy settings

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -543,6 +543,10 @@ public class BoxAPIConnection {
     /**
      * Saves the state of this connection to a string so that it can be persisted and restored at a later time.
      *
+     * <p>Note that proxy settings aren't automatically saved or restored. This is mainly due to security concerns
+     * around persisting proxy authentication details to the state string. If your connection uses a proxy, you will
+     * have to manually configure it again after restoring the connection.</p>
+     *
      * @see    #restore
      * @return the state of this connection.
      */


### PR DESCRIPTION
Configured proxies aren't saved or restored with
BoxAPIConnection#save() or BoxAPIConnection#restore(String). This is
intentional because:

1. We don't have a clean way of serializing the Proxy object to JSON.
2. If the proxy has a password, it would be unsafe to persist it to the
   saved state string.

This change updates the javadocs so it's clear that proxy settings must
be manually reconfigured after restoring an API connection.

Fixes #143.