### PR TITLE
App User Key Id support and version update.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ To run the project, first provide following in `src/example/java/com/box/sdk/exa
 * Client Id: From application's [developer console](https://cloud.app.box.com/developers/services).
 * Client Secret: From application's [developer console](https://cloud.app.box.com/developers/services).
 * Enterprise Id: From application's [developer console](https://cloud.app.box.com/developers/services).
+* Public key Id: From application's [developer console](https://cloud.app.box.com/developers/services).
 * Private key file name with path: Corresponding to the public key uploaded in application's [developer console](https://cloud.app.box.com/developers/services).
 * Private key password (if any): Password for the private key.
 * Name of App User: This will be used as the name of the newly created App User.
@@ -83,6 +84,7 @@ public final class CreateAppUser {
     private static final String CLIENT_ID = "";
     private static final String CLIENT_SECRET = "";
     private static final String ENTERPRISE_ID = "";
+    private static final String PUBLIC_KEY_ID = "";
     private static final String PRIVATE_KEY_FILE = "";
     private static final String PRIVATE_KEY_PASSWORD = "";
     private static final String APP_USER_NAME = "";
@@ -102,7 +104,8 @@ This project will retrieve the information of the given App User and will list t
 To run the project, first provide following in `src/example/java/com/box/sdk/example/CreateAppUser.java`.
 * Client Id: From application's [developer console](https://cloud.app.box.com/developers/services).
 * Client Secret: From application's [developer console](https://cloud.app.box.com/developers/services).
-* User Id: Id of the user whose data will be accessed 
+* User Id: Id of the user whose data will be accessed.
+* Public key Id: From application's [developer console](https://cloud.app.box.com/developers/services).
 * Private key file name with path: Corresponding to the public key uploaded in application's [developer console](https://cloud.app.box.com/developers/services).
 * Private key password (if any): Password for the private key.
 
@@ -112,6 +115,7 @@ public final class AccessAsAppUser {
     private static final String CLIENT_ID = "";
     private static final String CLIENT_SECRET = "";
     private static final String USER_ID = "";
+    private static final String PUBLIC_KEY_ID = "";
     private static final String PRIVATE_KEY_FILE = "";
     private static final String PRIVATE_KEY_PASSWORD = "";
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ sourceCompatibility = 1.6
 
 group = 'com.box'
 archivesBaseName = 'box-java-sdk'
-version = '1.1.0'
+version = '1.2.0-SNAPSHOT'
 
 repositories {
     mavenCentral()

--- a/src/example/java/com/box/sdk/example/AccessAsAppUser.java
+++ b/src/example/java/com/box/sdk/example/AccessAsAppUser.java
@@ -11,12 +11,14 @@ import com.box.sdk.BoxFolder;
 import com.box.sdk.BoxItem;
 import com.box.sdk.BoxUser;
 import com.box.sdk.EncryptionAlgorithm;
+import com.box.sdk.JWTEncryptionPreferences;
 
 public final class AccessAsAppUser {
 
     private static final String CLIENT_ID = "";
     private static final String CLIENT_SECRET = "";
     private static final String USER_ID = "";
+    private static final String PUBLIC_KEY_ID = "";
     private static final String PRIVATE_KEY_FILE = "";
     private static final String PRIVATE_KEY_PASSWORD = "";
     private static final int MAX_DEPTH = 1;
@@ -29,8 +31,14 @@ public final class AccessAsAppUser {
 
         String privateKey = new String(Files.readAllBytes(Paths.get(PRIVATE_KEY_FILE)));
 
+        JWTEncryptionPreferences encryptionPref = new JWTEncryptionPreferences();
+        encryptionPref.setPublicKeyID(PUBLIC_KEY_ID);
+        encryptionPref.setPrivateKey(privateKey);
+        encryptionPref.setPrivateKeyPassword(PRIVATE_KEY_PASSWORD);
+        encryptionPref.setEncryptionAlgorithm(EncryptionAlgorithm.RSA_SHA_256);
+
         BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppUserConnection(USER_ID, CLIENT_ID,
-                CLIENT_SECRET, privateKey, PRIVATE_KEY_PASSWORD, EncryptionAlgorithm.RSA_SHA_512);
+                CLIENT_SECRET, encryptionPref);
 
         BoxUser.Info userInfo = BoxUser.getCurrentUser(api).getInfo();
         System.out.format("Welcome, %s!\n\n", userInfo.getName());

--- a/src/example/java/com/box/sdk/example/CreateAppUser.java
+++ b/src/example/java/com/box/sdk/example/CreateAppUser.java
@@ -9,12 +9,14 @@ import java.util.logging.Logger;
 import com.box.sdk.BoxDeveloperEditionAPIConnection;
 import com.box.sdk.BoxUser;
 import com.box.sdk.EncryptionAlgorithm;
+import com.box.sdk.JWTEncryptionPreferences;
 
 public final class CreateAppUser {
 
     private static final String CLIENT_ID = "";
     private static final String CLIENT_SECRET = "";
     private static final String ENTERPRISE_ID = "";
+    private static final String PUBLIC_KEY_ID = "";
     private static final String PRIVATE_KEY_FILE = "";
     private static final String PRIVATE_KEY_PASSWORD = "";
     private static final String APP_USER_NAME = "";
@@ -27,14 +29,16 @@ public final class CreateAppUser {
 
         String privateKey = new String(Files.readAllBytes(Paths.get(PRIVATE_KEY_FILE)));
 
-        BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(
-            ENTERPRISE_ID, CLIENT_ID, CLIENT_SECRET, privateKey, PRIVATE_KEY_PASSWORD, EncryptionAlgorithm.RSA_SHA_256);
+        JWTEncryptionPreferences encryptionPref = new JWTEncryptionPreferences();
+        encryptionPref.setPublicKeyID(PUBLIC_KEY_ID);
+        encryptionPref.setPrivateKey(privateKey);
+        encryptionPref.setPrivateKeyPassword(PRIVATE_KEY_PASSWORD);
+        encryptionPref.setEncryptionAlgorithm(EncryptionAlgorithm.RSA_SHA_256);
 
-        BoxUser eAdmin = BoxUser.getCurrentUser(api);
-        System.out.format("User Id of enterprise admin user is %s\n\n", eAdmin.getID());
+        BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(
+            ENTERPRISE_ID, CLIENT_ID, CLIENT_SECRET, encryptionPref);
 
         BoxUser.Info user = BoxUser.createAppUser(api, APP_USER_NAME);
         System.out.format("User created with name %s and id %s\n\n", APP_USER_NAME, user.getID());
-
     }
 }

--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -83,7 +83,7 @@ public class BoxAPIConnection {
         this.autoRefresh = true;
         this.maxRequestAttempts = DEFAULT_MAX_ATTEMPTS;
         this.refreshLock = new ReentrantReadWriteLock();
-        this.userAgent = "Box Java SDK v1.1.0";
+        this.userAgent = "Box Java SDK v1.2.0-SNAPSHOT";
         this.listeners = new ArrayList<BoxAPIConnectionListener>();
     }
 

--- a/src/main/java/com/box/sdk/JWTEncryptionPreferences.java
+++ b/src/main/java/com/box/sdk/JWTEncryptionPreferences.java
@@ -1,0 +1,76 @@
+package com.box.sdk;
+
+/**
+ * Contains the encryption preferences for JWT assertion.
+ */
+
+public class JWTEncryptionPreferences {
+    private String publicKeyID;
+    private String privateKey;
+    private String privateKeyPassword;
+    private EncryptionAlgorithm encryptionAlgorithm;
+
+    /**
+     * Returns the ID for public key for validating the JWT signature.
+     * @return the publicKeyID.
+     */
+    public String getPublicKeyID() {
+        return this.publicKeyID;
+    }
+
+    /**
+     * Sets the ID for public key for validating the JWT signature.
+     * @param publicKeyID the publicKeyID to set.
+     */
+    public void setPublicKeyID(String publicKeyID) {
+        this.publicKeyID = publicKeyID;
+    }
+
+    /**
+     * Returns the private key for generating the JWT signature.
+     * @return the privateKey.
+     */
+    public String getPrivateKey() {
+        return this.privateKey;
+    }
+
+    /**
+     * Sets the private key for generating the JWT signature.
+     * @param privateKey the privateKey to set.
+     */
+    public void setPrivateKey(String privateKey) {
+        this.privateKey = privateKey;
+    }
+
+    /**
+     * Returns the password for the private key.
+     * @return the privateKeyPassword.
+     */
+    public String getPrivateKeyPassword() {
+        return this.privateKeyPassword;
+    }
+
+    /**
+     * Sets the password for the private key.
+     * @param privateKeyPassword the privateKeyPassword to set.
+     */
+    public void setPrivateKeyPassword(String privateKeyPassword) {
+        this.privateKeyPassword = privateKeyPassword;
+    }
+
+    /**
+     * Returns the type of encryption algorithm for JWT.
+     * @return the encryptionAlgorithm.
+     */
+    public EncryptionAlgorithm getEncryptionAlgorithm() {
+        return this.encryptionAlgorithm;
+    }
+
+    /**
+     * Sets the type of encryption algorithm for JWT.
+     * @param encryptionAlgorithm the encryptionAlgorithm to set.
+     */
+    public void setEncryptionAlgorithm(EncryptionAlgorithm encryptionAlgorithm) {
+        this.encryptionAlgorithm = encryptionAlgorithm;
+    }
+}

--- a/src/test/java/com/box/sdk/BoxAPIConnectionTest.java
+++ b/src/test/java/com/box/sdk/BoxAPIConnectionTest.java
@@ -220,8 +220,13 @@ public class BoxAPIConnectionTest {
         final String privateKey = TestConfig.getPrivateKey();
         final String privateKeyPassword = TestConfig.getPrivateKeyPassword();
 
+        JWTEncryptionPreferences encryptionPref = new JWTEncryptionPreferences();
+        encryptionPref.setPrivateKey(privateKey);
+        encryptionPref.setPrivateKeyPassword(privateKeyPassword);
+        encryptionPref.setEncryptionAlgorithm(EncryptionAlgorithm.RSA_SHA_256);
+
         BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(enterpriseId,
-            clientId, clientSecret, privateKey, privateKeyPassword, EncryptionAlgorithm.RSA_SHA_256);
+            clientId, clientSecret, encryptionPref);
 
         assertThat(api.getAccessToken(), not(equalTo(null)));
 
@@ -254,16 +259,20 @@ public class BoxAPIConnectionTest {
         final String privateKey = TestConfig.getPrivateKey();
         final String privateKeyPassword = TestConfig.getPrivateKeyPassword();
 
+        JWTEncryptionPreferences encryptionPref = new JWTEncryptionPreferences();
+        encryptionPref.setPrivateKey(privateKey);
+        encryptionPref.setPrivateKeyPassword(privateKeyPassword);
+        encryptionPref.setEncryptionAlgorithm(EncryptionAlgorithm.RSA_SHA_256);
+
         BoxDeveloperEditionAPIConnection appAuthConnection = BoxDeveloperEditionAPIConnection
-            .getAppEnterpriseConnection(enterpriseId, clientId, clientSecret, privateKey, privateKeyPassword,
-                EncryptionAlgorithm.RSA_SHA_256);
+            .getAppEnterpriseConnection(enterpriseId, clientId, clientSecret, encryptionPref);
 
         final String name = "app user name two";
         BoxUser.Info createdUserInfo = BoxUser.createAppUser(appAuthConnection, name);
         final String appUserId = createdUserInfo.getID();
 
         BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppUserConnection(appUserId,
-            clientId, clientSecret, privateKey, privateKeyPassword, EncryptionAlgorithm.RSA_SHA_256);
+            clientId, clientSecret, encryptionPref);
         BoxUser appUser = new BoxUser(api, appUserId);
 
         assertThat(api.getAccessToken(), not(equalTo(null)));


### PR DESCRIPTION
The coding style check was not allowing to add another parameter by hitting the limit of 7 parameters. Hence separated all JWT encryption preferences into a separate param class for easy passing around.