### PR TITLE
Don't parse created_by if user id is null. Closes #189.

### DIFF
--- a/src/main/java/com/box/sdk/BoxEvent.java
+++ b/src/main/java/com/box/sdk/BoxEvent.java
@@ -173,7 +173,14 @@ public class BoxEvent extends BoxResource {
         } else if (memberName.equals("accessible_by")) {
             this.accessibleBy = (BoxCollaborator.Info) BoxResource.parseInfo(this.getAPI(), value.asObject());
         } else if (memberName.equals("created_by")) {
-            this.createdBy = (BoxUser.Info) BoxResource.parseInfo(this.getAPI(), value.asObject());
+            // Parsing the `created_by` object fails if the user is unknown. In this case the API returns a user object
+            // with the `id` property set to null. If this happens, we set the createdBy to null.
+            JsonObject object = value.asObject();
+            if (object.get("id").isString()) {
+                this.createdBy = (BoxUser.Info) BoxResource.parseInfo(this.getAPI(), object);
+            } else {
+                this.createdBy = null;
+            }
         } else if (memberName.equals("session_id")) {
             this.sessionID = value.asString();
         }


### PR DESCRIPTION
If the `created_by` user `id` is null (not a string), i.e., the user is unknown, don't attempt to parse it and set the `createdBy` field to null. Currently this code fails with an exception instead as described in the issue.