### PR TITLE
Fix collaboration getInfo() method. Closes #204.

### DIFF
--- a/src/main/java/com/box/sdk/BoxCollaboration.java
+++ b/src/main/java/com/box/sdk/BoxCollaboration.java
@@ -63,7 +63,7 @@ public class BoxCollaboration extends BoxResource {
      */
     public Info getInfo() {
         BoxAPIConnection api = this.getAPI();
-        URL url = COLLABORATIONS_URL_TEMPLATE.build(api.getBaseURL());
+        URL url = COLLABORATION_URL_TEMPLATE.build(api.getBaseURL(), this.getID());
 
         BoxAPIRequest request = new BoxAPIRequest(api, url, "GET");
         BoxJSONResponse response = (BoxJSONResponse) request.send();


### PR DESCRIPTION
getInfo() should be making a call to /collaborations/{id} if it's
retrieving information about a collaboration. Old method was making a
call to /collaborations resulting in a 400 error as the endpoint
/collaborations does not accept a GET without a collaboration id or
?status=pending