### PR TITLE
Fix ClassCastException when giving away ownership. Closes #147

### DIFF
--- a/src/main/java/com/box/sdk/BoxCollaboration.java
+++ b/src/main/java/com/box/sdk/BoxCollaboration.java
@@ -81,9 +81,13 @@ public class BoxCollaboration extends BoxResource {
 
         BoxJSONRequest request = new BoxJSONRequest(api, url, "PUT");
         request.setBody(info.getPendingChanges());
-        BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject jsonObject = JsonObject.readFrom(response.getJSON());
-        info.update(jsonObject);
+        BoxAPIResponse boxAPIResponse = request.send();
+
+        if (boxAPIResponse instanceof BoxJSONResponse) {
+            BoxJSONResponse response = (BoxJSONResponse) boxAPIResponse;
+            JsonObject jsonObject = JsonObject.readFrom(response.getJSON());
+            info.update(jsonObject);
+        }
     }
 
     /**


### PR DESCRIPTION
When you give away ownership with the pattern:
```
BoxCollaboration.Info newCollaborationInfo = folder.collaborate(userName, BoxCollaboration.Role.EDITOR);
newCollaborationInfo.setRole(BoxCollaboration.Role.OWNER);
BoxCollaboration bc = newCollaborationInfo.getResource();
bc.updateInfo(newCollaborationInfo);
```

It throws a ClassCastException because BoxCollaboration.java is expecting BoxJSONResponse. But, giving away ownership is a BoxAPIResponse because the content returned is:
```
PUT https://api.box.com/2.0/collaborations/123456789
HTTP/1.1 204 No Content
Age: 0
Date: Tue, 16 Feb 2016 21:45:50 GMT
Content-Length: 0
Connection: keep-alive
Server: ATS
Cache-Control: no-cache, no-storenull
```

While this patch handles the ClassCastException, it does nothing to update the `info` argument, unlike the typical JSON response would. 

If that is a problem, please let me know what I need to do to fix it. I couldn't find a way to force it to update `info` by repolling the API.