### PR TITLE
Timezone issue

### DIFF
--- a/src/main/java/com/box/sdk/EventLog.java
+++ b/src/main/java/com/box/sdk/EventLog.java
@@ -7,8 +7,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
-import org.apache.commons.lang.time.DateUtils;
-
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
@@ -74,17 +72,20 @@ public class EventLog implements Iterable<BoxEvent> {
 
         URL url = ENTERPRISE_EVENT_URL_TEMPLATE.build(api.getBaseURL());
 
-        if (position != null || types.length > 0 || after != null || before!= null) {
+        if (position != null || types.length > 0 || after != null
+            || before != null) {
             QueryStringBuilder queryBuilder = new QueryStringBuilder(url.getQuery());
 
             if (after != null) {
-            	queryBuilder.appendParam("created_after", BoxDateFormat.format(after));
+                queryBuilder.appendParam("created_after",
+                    BoxDateFormat.format(after));
             }
-            
+
             if (before != null) {
-            	queryBuilder.appendParam("created_before", BoxDateFormat.format(before));
+                queryBuilder.appendParam("created_before",
+                    BoxDateFormat.format(before));
             }
-            
+
             if (position != null) {
                 queryBuilder.appendParam("stream_position", position);
             }

--- a/src/main/java/com/box/sdk/EventLog.java
+++ b/src/main/java/com/box/sdk/EventLog.java
@@ -7,6 +7,8 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
+import org.apache.commons.lang.time.DateUtils;
+
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
@@ -21,7 +23,7 @@ import com.eclipsesource.json.JsonValue;
 public class EventLog implements Iterable<BoxEvent> {
     private static final int ENTERPRISE_LIMIT = 500;
     private static final URLTemplate ENTERPRISE_EVENT_URL_TEMPLATE = new URLTemplate("events?stream_type=admin_logs&"
-        + "limit=" + ENTERPRISE_LIMIT + "&created_after=%s&created_before=%s");
+        + "limit=" + ENTERPRISE_LIMIT);
 
     private final int chunkSize;
     private final int limit;
@@ -70,13 +72,19 @@ public class EventLog implements Iterable<BoxEvent> {
     public static EventLog getEnterpriseEvents(BoxAPIConnection api, String position, Date after, Date before,
         BoxEvent.Type... types) {
 
-        String afterString = BoxDateFormat.format(after);
-        String beforeString = BoxDateFormat.format(before);
-        URL url = ENTERPRISE_EVENT_URL_TEMPLATE.build(api.getBaseURL(), afterString, beforeString);
+        URL url = ENTERPRISE_EVENT_URL_TEMPLATE.build(api.getBaseURL());
 
-        if (position != null || types.length > 0) {
+        if (position != null || types.length > 0 || after != null || before!= null) {
             QueryStringBuilder queryBuilder = new QueryStringBuilder(url.getQuery());
 
+            if (after != null) {
+            	queryBuilder.appendParam("created_after", BoxDateFormat.format(after));
+            }
+            
+            if (before != null) {
+            	queryBuilder.appendParam("created_before", BoxDateFormat.format(before));
+            }
+            
             if (position != null) {
                 queryBuilder.appendParam("stream_position", position);
             }

--- a/src/test/java/com/box/sdk/EventLogTest.java
+++ b/src/test/java/com/box/sdk/EventLogTest.java
@@ -1,20 +1,19 @@
 package com.box.sdk;
 
+import java.util.Date;
+import java.util.TimeZone;
+
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
-import java.util.Date;
-import java.util.TimeZone;
-
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 public class EventLogTest {
-	
-	
-	@Test
+
+    @Test
     @Category(IntegrationTest.class)
     public void getEnterpriseEventsReturnsAtLeastOneEvent() {
         BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
@@ -26,8 +25,8 @@ public class EventLogTest {
         assertThat(events.getStartDate(), is(equalTo(after)));
         assertThat(events.getEndDate(), is(equalTo(before)));
     }
-	
-	@Test
+
+    @Test
     @Category(IntegrationTest.class)
     public void getEnterpriseEventsGmtPlus530() {
         BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
@@ -41,5 +40,5 @@ public class EventLogTest {
         assertThat(events.getStartDate(), is(equalTo(after)));
         assertThat(events.getEndDate(), is(equalTo(before)));
     }
-    
+
 }

--- a/src/test/java/com/box/sdk/EventLogTest.java
+++ b/src/test/java/com/box/sdk/EventLogTest.java
@@ -1,17 +1,20 @@
 package com.box.sdk;
 
-import java.util.Date;
-
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 
+import java.util.Date;
+import java.util.TimeZone;
+
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 public class EventLogTest {
-    @Test
+	
+	
+	@Test
     @Category(IntegrationTest.class)
     public void getEnterpriseEventsReturnsAtLeastOneEvent() {
         BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
@@ -23,4 +26,20 @@ public class EventLogTest {
         assertThat(events.getStartDate(), is(equalTo(after)));
         assertThat(events.getEndDate(), is(equalTo(before)));
     }
+	
+	@Test
+    @Category(IntegrationTest.class)
+    public void getEnterpriseEventsGmtPlus530() {
+        BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
+        System.setProperty("user.timezone", "Asia/Calcutta");
+        TimeZone.setDefault(null);
+        Date after = new Date(0L);
+        Date before = new Date(System.currentTimeMillis());
+        EventLog events = EventLog.getEnterpriseEvents(api, after, before);
+
+        assertThat(events.getSize(), is(not(0)));
+        assertThat(events.getStartDate(), is(equalTo(after)));
+        assertThat(events.getEndDate(), is(equalTo(before)));
+    }
+    
 }


### PR DESCRIPTION
Fixed #131 & #198 , by removing the date after and before from ENTERPRISE_EVENT_URL_TEMPLATE and added to queryBuilder.

This way the '+' sign in the timezone will get URLencoded properly.

Fixed the errors.