### PR TITLE
Search tests and fixes

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -163,7 +163,6 @@
 
         <!-- Checks for common coding problems               -->
         <!-- See http://checkstyle.sf.net/config_coding.html -->
-        <module name="AvoidInlineConditionals"/>
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>

--- a/src/main/java/com/box/sdk/BoxDateFormat.java
+++ b/src/main/java/com/box/sdk/BoxDateFormat.java
@@ -4,6 +4,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * Contains methods for parsing and formatting dates for use with the Box API.
@@ -12,7 +13,9 @@ public final class BoxDateFormat {
     private static final ThreadLocal<DateFormat> THREAD_LOCAL_DATE_FORMAT = new ThreadLocal<DateFormat>() {
         @Override
         protected DateFormat initialValue() {
-            return new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+            sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+            return sdf;
         }
     };
 

--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -355,20 +355,20 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         fieldJSON.add("name", uploadParams.getName());
         fieldJSON.add("parent", parentIdJSON);
 
+        if (uploadParams.getCreated() != null) {
+            fieldJSON.add("content_created_at", BoxDateFormat.format(uploadParams.getCreated()));
+        }
+
+        if (uploadParams.getModified() != null) {
+            fieldJSON.add("content_modified_at", BoxDateFormat.format(uploadParams.getModified()));
+        }
+
         request.putField("attributes", fieldJSON.toString());
 
         if (uploadParams.getSize() > 0) {
             request.setFile(uploadParams.getContent(), uploadParams.getName(), uploadParams.getSize());
         } else {
             request.setFile(uploadParams.getContent(), uploadParams.getName());
-        }
-
-        if (uploadParams.getCreated() != null) {
-            request.putField("content_created_at", uploadParams.getCreated());
-        }
-
-        if (uploadParams.getModified() != null) {
-            request.putField("content_modified_at", uploadParams.getModified());
         }
 
         BoxJSONResponse response;

--- a/src/main/java/com/box/sdk/BoxSearchParameters.java
+++ b/src/main/java/com/box/sdk/BoxSearchParameters.java
@@ -254,6 +254,8 @@ public class BoxSearchParameters {
             if (((String) paramValue).trim().equalsIgnoreCase("")) {
                 isNullOrEmpty = true;
             }
+        } else if (paramValue instanceof List) {
+            return ((List) paramValue).isEmpty();
         }
         return isNullOrEmpty;
     }
@@ -284,7 +286,8 @@ public class BoxSearchParameters {
         for (String item : list) {
             csvStr += "," + item;
         }
-        return csvStr.substring(1);
+
+        return csvStr.length() > 1 ? csvStr.substring(1) : csvStr;
     }
     /**
      * Get the Query Paramaters to be used for search request.
@@ -308,7 +311,7 @@ public class BoxSearchParameters {
             builder.appendParam("scope", this.scope);
         }
         //Acceptable Value: "jpg,png"
-        if (this.fileExtensions != null) {
+        if (!this.isNullOrEmpty(this.fileExtensions)) {
             builder.appendParam("file_extensions", this.listToCSV(this.fileExtensions));
         }
         //Created Date Range: From Date - To Date
@@ -324,15 +327,15 @@ public class BoxSearchParameters {
             builder.appendParam("size_range", this.sizeRange.buildRangeString());
         }
         //Owner Id's
-        if (this.ownerUserIds != null) {
+        if (!this.isNullOrEmpty(this.ownerUserIds)) {
             builder.appendParam("owner_user_ids", this.listToCSV(this.ownerUserIds));
         }
         //Ancestor ID's
-        if (this.ancestorFolderIds != null) {
+        if (!this.isNullOrEmpty(this.ancestorFolderIds)) {
             builder.appendParam("ancestor_folder_ids", this.listToCSV(this.ancestorFolderIds));
         }
         //Content Types: "name, description"
-        if (this.contentTypes != null) {
+        if (!this.isNullOrEmpty(this.contentTypes)) {
             builder.appendParam("content_types", this.listToCSV(this.contentTypes));
         }
         //Type of File: "file,folder,web_link"
@@ -348,7 +351,7 @@ public class BoxSearchParameters {
             builder.appendParam("mdfilters", this.formatBoxMetadataFilterRequest().toString());
         }
         //Fields
-        if (this.fields != null) {
+        if (!this.isNullOrEmpty(this.fields)) {
             builder.appendParam("fields", this.listToCSV(this.fields));
         }
         return builder;

--- a/src/main/java/com/box/sdk/BoxSearchParameters.java
+++ b/src/main/java/com/box/sdk/BoxSearchParameters.java
@@ -3,6 +3,7 @@ import java.util.List;
 
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
+
 /**
  * Used to Setup Box Search Parameters
  *
@@ -13,7 +14,6 @@ import com.eclipsesource.json.JsonObject;
  */
 public class BoxSearchParameters {
     private String query;
-    private String keyword;
     private List<String> fields;
     private String scope;
     private List<String> fileExtensions;
@@ -44,7 +44,6 @@ public class BoxSearchParameters {
      */
     public boolean clearParameters() {
         this.query = null;
-        this.keyword = null;
         this.fields = null;
         this.scope = null;
         this.fileExtensions = null;
@@ -72,20 +71,6 @@ public class BoxSearchParameters {
      */
     public void setQuery(String query) {
         this.query = query;
-    }
-    /**
-     * Get existing keyword String that is being used.
-     * @return this.keyword String.
-     */
-    public String getKeyword() {
-        return this.keyword;
-    }
-    /**
-     * Set keyword string for that will be used for searching.
-     * @param keyword String.
-     */
-    public void setKeyword(String keyword) {
-        this.keyword = keyword;
     }
     /**
      * Get the existing fields that are used for the search criteria.
@@ -256,14 +241,6 @@ public class BoxSearchParameters {
         this.metadataFilter = metadataFilter;
     }
     /**
-     * Formated String is returned.
-     * @param    Object that will be printed.
-     * @return this.String
-     */
-    private String printParam(Object obj)    {
-        return obj.toString().replaceAll("[\\[\\]]", "");
-    }
-    /**
      * Checks String to see if the parameter is null.
      * @param    paramValue Object that will be checked if null.
      * @return this.true if the parameter that is being checked is not null
@@ -296,6 +273,19 @@ public class BoxSearchParameters {
 
         return boxMetadataFilterRequestArray;
     }
+
+    /**
+     * Concat a List into a CSV String.
+     * @param list list to concat
+     * @return csv string
+     */
+    private String listToCSV(List<String> list) {
+        String csvStr = "";
+        for (String item : list) {
+            csvStr += "," + item;
+        }
+        return csvStr.substring(1);
+    }
     /**
      * Get the Query Paramaters to be used for search request.
      * @return this.QueryStringBuilder.
@@ -303,17 +293,23 @@ public class BoxSearchParameters {
     public QueryStringBuilder getQueryParameters() {
         QueryStringBuilder builder = new QueryStringBuilder();
 
+        if (this.isNullOrEmpty(this.query) && this.metadataFilter == null) {
+            throw new BoxAPIException(
+                "BoxSearchParameters requires either a search query or Metadata filter to be set."
+            );
+        }
+
         //Set the query of the search
         if (!this.isNullOrEmpty(this.query)) {
             builder.appendParam("query", this.query);
         }
         //Set the scope of the search
         if (!this.isNullOrEmpty(this.scope)) {
-            builder.appendParam("scope", this.printParam(this.scope));
+            builder.appendParam("scope", this.scope);
         }
         //Acceptable Value: "jpg,png"
         if (this.fileExtensions != null) {
-            builder.appendParam("file_extensions", this.printParam(this.fileExtensions));
+            builder.appendParam("file_extensions", this.listToCSV(this.fileExtensions));
         }
         //Created Date Range: From Date - To Date
         if ((this.createdRange != null)) {
@@ -329,27 +325,31 @@ public class BoxSearchParameters {
         }
         //Owner Id's
         if (this.ownerUserIds != null) {
-            builder.appendParam("owner_user_ids", this.printParam(this.ownerUserIds));
+            builder.appendParam("owner_user_ids", this.listToCSV(this.ownerUserIds));
         }
         //Ancestor ID's
         if (this.ancestorFolderIds != null) {
-            builder.appendParam("ancestor_folder_ids", this.printParam(this.ancestorFolderIds));
+            builder.appendParam("ancestor_folder_ids", this.listToCSV(this.ancestorFolderIds));
         }
         //Content Types: "name, description"
         if (this.contentTypes != null) {
-            builder.appendParam("content_types", this.printParam(this.contentTypes));
+            builder.appendParam("content_types", this.listToCSV(this.contentTypes));
         }
         //Type of File: "file,folder,web_link"
         if (this.type != null) {
-            builder.appendParam("type", this.printParam(this.type));
+            builder.appendParam("type", this.type);
         }
         //Trash Content
         if (!this.isNullOrEmpty(this.trashContent)) {
-            builder.appendParam("trash_content", this.printParam(this.trashContent));
+            builder.appendParam("trash_content", this.trashContent);
         }
         //Metadata filters
         if (this.metadataFilter != null) {
             builder.appendParam("mdfilters", this.formatBoxMetadataFilterRequest().toString());
+        }
+        //Fields
+        if (this.fields != null) {
+            builder.appendParam("fields", this.listToCSV(this.fields));
         }
         return builder;
     }

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -3,10 +3,7 @@ package com.box.sdk;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.text.SimpleDateFormat;
-import java.util.Collection;
-import java.util.Date;
-import java.util.EnumSet;
-import java.util.List;
+import java.util.*;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
@@ -310,12 +307,14 @@ public class BoxFolderTest {
         BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
         BoxFolder rootFolder = BoxFolder.getRootFolder(api);
         SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         Date created = new Date(1415318114);
         Date modified = new Date(1315318114);
         final String fileContent = "Test file";
         InputStream stream = new ByteArrayInputStream(fileContent.getBytes(StandardCharsets.UTF_8));
-        FileUploadParams params = new FileUploadParams().setName("Test File.txt").setContent(stream)
+        FileUploadParams params = new FileUploadParams()
+            .setName("[uploadFileWithCreatedAndModifiedDatesSucceeds] Test File.txt").setContent(stream)
             .setModified(modified).setCreated(created);
         BoxFile.Info info = rootFolder.uploadFile(params);
         BoxFile uploadedFile = info.getResource();

--- a/src/test/java/com/box/sdk/BoxSearchParametersTest.java
+++ b/src/test/java/com/box/sdk/BoxSearchParametersTest.java
@@ -102,6 +102,18 @@ public class BoxSearchParametersTest {
 
     @Test
     @Category(UnitTest.class)
+    public void shouldCorrectlyHandleSettingAndGettingEmptyContentTypesParam() {
+        final List<String> contentTypes = new ArrayList<String>();
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.setContentTypes(contentTypes);
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(queryParams.toString(), "?query=query");
+    }
+
+    @Test
+    @Category(UnitTest.class)
     public void shouldCorrectlySetAndGetScopeParam() {
         BoxSearchParameters searchParams = new BoxSearchParameters();
         searchParams.setScope("enterprise");

--- a/src/test/java/com/box/sdk/BoxSearchParametersTest.java
+++ b/src/test/java/com/box/sdk/BoxSearchParametersTest.java
@@ -5,6 +5,7 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.TimeZone;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -136,9 +137,10 @@ public class BoxSearchParametersTest {
     @Category(UnitTest.class)
     public void shouldCorrectlySetAndGetCreatedRangeParam() {
         BoxSearchParameters searchParams = new BoxSearchParameters();
-        SimpleDateFormat sdf = new SimpleDateFormat("M-dd-yyyy hh:mm:ss");
-        String createdFromDateString = "01-31-2016 00:00:00";
-        String createdToDateString = "04-01-2016 00:00:00";
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        String createdFromDateString = "2016-01-01T00:00:00+0000";
+        String createdToDateString = "2016-04-01T00:00:00+0000";
 
         try {
             Date createdFromDate = sdf.parse(createdFromDateString);
@@ -152,7 +154,7 @@ public class BoxSearchParametersTest {
 
         Assert.assertEquals(
             queryParams.toString(),
-            "?query=query&created_at_range=2016-01-31T00%3a00%3a00-0800%2c2016-04-01T00%3a00%3a00-0700"
+            "?query=query&created_at_range=2016-01-01T00%3a00%3a00%2b0000%2c2016-04-01T00%3a00%3a00%2b0000"
         );
     }
 
@@ -160,9 +162,10 @@ public class BoxSearchParametersTest {
     @Category(UnitTest.class)
     public void shouldCorrectlySetAndGetUpdatedRangeParam() {
         BoxSearchParameters searchParams = new BoxSearchParameters();
-        SimpleDateFormat sdf = new SimpleDateFormat("M-dd-yyyy hh:mm:ss");
-        String updatedFromDateString = "01-31-2016 00:00:00";
-        String updatedToDateString = "04-01-2016 00:00:00";
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        String updatedFromDateString = "2016-01-01T00:00:00+0000";
+        String updatedToDateString = "2016-04-01T00:00:00+0000";
 
         try {
             Date updatedFromDate = sdf.parse(updatedFromDateString);
@@ -176,7 +179,7 @@ public class BoxSearchParametersTest {
 
         Assert.assertEquals(
             queryParams.toString(),
-            "?query=query&updated_at_range=2016-01-31T00%3a00%3a00-0800%2c2016-04-01T00%3a00%3a00-0700"
+            "?query=query&updated_at_range=2016-01-01T00%3a00%3a00%2b0000%2c2016-04-01T00%3a00%3a00%2b0000"
         );
     }
 

--- a/src/test/java/com/box/sdk/BoxSearchParametersTest.java
+++ b/src/test/java/com/box/sdk/BoxSearchParametersTest.java
@@ -1,0 +1,207 @@
+package com.box.sdk;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+public class BoxSearchParametersTest {
+    @Test(expected = BoxAPIException.class)
+    @Category(UnitTest.class)
+    public void searchWithoutQueryAndMetadataThrowsError() {
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.getQueryParameters();
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetQueryParam() {
+        final String query = "A Query";
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.setQuery(query);
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(queryParams.toString(), "?query=A+Query");
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetFieldParam() {
+        final List<String> fields = new ArrayList<String>();
+        fields.add("field1");
+        fields.add("field2");
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.setFields(fields);
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(queryParams.toString(), "?query=query&fields=field1%2cfield2");
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetFileExtensionsParam() {
+        final List<String> fields = new ArrayList<String>();
+        fields.add("pdf");
+        fields.add("doc");
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.setFileExtensions(fields);
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(queryParams.toString(), "?query=query&file_extensions=pdf%2cdoc");
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetOwnerUserIdsParam() {
+        final List<String> owners = new ArrayList<String>();
+        owners.add("123");
+        owners.add("456");
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.setOwnerUserIds(owners);
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(queryParams.toString(), "?query=query&owner_user_ids=123%2c456");
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetAncestorFolderIdsParam() {
+        final List<String> folderIds = new ArrayList<String>();
+        folderIds.add("123");
+        folderIds.add("456");
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.setAncestorFolderIds(folderIds);
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(queryParams.toString(), "?query=query&ancestor_folder_ids=123%2c456");
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetContentTypesParam() {
+        final List<String> contentTypes = new ArrayList<String>();
+        contentTypes.add("description");
+        contentTypes.add("file_content");
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.setContentTypes(contentTypes);
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(queryParams.toString(), "?query=query&content_types=description%2cfile_content");
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetScopeParam() {
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.setScope("enterprise");
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(queryParams.toString(), "?query=query&scope=enterprise");
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetTypeParam() {
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.setType("file");
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(queryParams.toString(), "?query=query&type=file");
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetTrashContentParam() {
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        searchParams.setTrashContent("trashed_only");
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(queryParams.toString(), "?query=query&trash_content=trashed_only");
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetCreatedRangeParam() {
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        SimpleDateFormat sdf = new SimpleDateFormat("M-dd-yyyy hh:mm:ss");
+        String createdFromDateString = "01-31-2016 00:00:00";
+        String createdToDateString = "04-01-2016 00:00:00";
+
+        try {
+            Date createdFromDate = sdf.parse(createdFromDateString);
+            Date createdToDate = sdf.parse(createdToDateString);
+            DateRange createdRange = new DateRange(createdFromDate, createdToDate);
+            searchParams.setCreatedRange(createdRange);
+        } catch (ParseException e) { /* no op */ }
+
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(
+            queryParams.toString(),
+            "?query=query&created_at_range=2016-01-31T00%3a00%3a00-0800%2c2016-04-01T00%3a00%3a00-0700"
+        );
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetUpdatedRangeParam() {
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        SimpleDateFormat sdf = new SimpleDateFormat("M-dd-yyyy hh:mm:ss");
+        String updatedFromDateString = "01-31-2016 00:00:00";
+        String updatedToDateString = "04-01-2016 00:00:00";
+
+        try {
+            Date updatedFromDate = sdf.parse(updatedFromDateString);
+            Date updatedToDate = sdf.parse(updatedToDateString);
+            DateRange updatedRange = new DateRange(updatedFromDate, updatedToDate);
+            searchParams.setUpdatedRange(updatedRange);
+        } catch (ParseException e) { /* no op */ }
+
+        searchParams.setQuery("query");
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(
+            queryParams.toString(),
+            "?query=query&updated_at_range=2016-01-31T00%3a00%3a00-0800%2c2016-04-01T00%3a00%3a00-0700"
+        );
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void shouldCorrectlySetAndGetMetadataFilterParam() {
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+        BoxMetadataFilter metadataFilter = new BoxMetadataFilter();
+        metadataFilter.setScope("enterprise");
+        metadataFilter.setTemplateKey("test");
+
+        SizeRange sizeRange = new SizeRange(12, 19);
+        metadataFilter.addNumberRangeFilter("testnumber", sizeRange);
+
+        metadataFilter.addFilter("test", "example");
+
+        searchParams.setMetadataFilter(metadataFilter);
+
+        QueryStringBuilder queryParams = searchParams.getQueryParameters();
+
+        Assert.assertEquals(
+            queryParams.toString(),
+            "?mdfilters=%5b%7b%22templateKey%22%3a%22test%22%2c%22scope%22%3a%22enterprise"
+                + "%22%2c%22filters%22%3a%7b%22testnumber%22%3a%7b%22gt%22%3a12%2c%22lt"
+                + "%22%3a19%7d%2c%22test%22%3a%22example%22%7d%7d%5d"
+        );
+    }
+}

--- a/src/test/java/com/box/sdk/BoxSearchTest.java
+++ b/src/test/java/com/box/sdk/BoxSearchTest.java
@@ -1,0 +1,85 @@
+package com.box.sdk;
+
+import static java.net.URLEncoder.encode;
+import java.io.UnsupportedEncodingException;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+
+public class BoxSearchTest {
+    @Rule
+    public final WireMockRule wireMockRule = new WireMockRule(8080);
+
+    @Test
+    @Category(UnitTest.class)
+    public void searchWithQueryRequestsCorrectFields() {
+        String query = "A query";
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setBaseURL("http://localhost:8080/");
+
+        try {
+            stubFor(get(urlPathEqualTo("/search"))
+                    .withQueryParam("query", WireMock.equalTo(encode(query, "UTF-8")))
+                    .withQueryParam("limit", WireMock.equalTo("10"))
+                    .withQueryParam("offset", WireMock.equalTo("10"))
+                    .willReturn(aResponse()
+                            .withHeader("Content-Type", "application/json")
+                            .withBody("{\"total_count\": 1, \"offset\": 10, \"limit\": 10, \"entries\":"
+                                    + "[{\"type\": \"file\", \"id\": \"0\"}]}")));
+        } catch (UnsupportedEncodingException e) { /* no op */ }
+
+        BoxSearch boxSearch = new BoxSearch(api);
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+
+        searchParams.setQuery(query);
+
+        PartialCollection<BoxItem.Info> searchResults = boxSearch.searchRange(10, 10, searchParams);
+
+        assertThat(searchResults.size(), is(1));
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void searchWithMetadataRequestsCorrectFiltersAndFields() {
+        final String filters = "%5b%7b%22templateKey%22%3a%22test%22%2c%22"
+                + "scope%22%3a%22enterprise%22%2c%22filters%22%3a%7b%22"
+                + "number%22%3a%7b%22gt%22%3a12%2c%22lt%22%3a19%7d%2c%22test"
+                + "%22%3a%22example%22%7d%7d%5d";
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setBaseURL("http://localhost:8080/");
+
+        stubFor(get(urlPathEqualTo("/search"))
+                .withQueryParam("type", WireMock.equalTo("file"))
+                .withQueryParam("mdfilters", WireMock.equalTo(filters))
+                .withQueryParam("limit", WireMock.equalTo("10"))
+                .withQueryParam("offset", WireMock.equalTo("10"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"total_count\": 1, \"offset\": 10, \"limit\": 10, \"entries\":"
+                                + "[{\"type\": \"file\", \"id\": \"0\"}]}")));
+
+        BoxSearch boxSearch = new BoxSearch(api);
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+
+        searchParams.setType("file");
+        BoxMetadataFilter metadataFilter = new BoxMetadataFilter();
+        metadataFilter.setScope("enterprise");
+        metadataFilter.setTemplateKey("test");
+        SizeRange sizeRange = new SizeRange(12, 19);
+        metadataFilter.addNumberRangeFilter("number", sizeRange);
+        metadataFilter.addFilter("test", "example");
+        searchParams.setMetadataFilter(metadataFilter);
+
+        PartialCollection<BoxItem.Info> searchResults = boxSearch.searchRange(10, 10, searchParams);
+
+        assertThat(searchResults.size(), is(1));
+    }
+}

--- a/src/test/java/com/box/sdk/BoxTaskTest.java
+++ b/src/test/java/com/box/sdk/BoxTaskTest.java
@@ -2,7 +2,9 @@ package com.box.sdk;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -24,7 +26,12 @@ public class BoxTaskTest {
 
         InputStream uploadStream = new ByteArrayInputStream(fileBytes);
         BoxFile uploadedFile = rootFolder.uploadFile(uploadStream, fileName).getResource();
-        Date dueAt = new Date();
+
+        Calendar calendar = new GregorianCalendar();
+        calendar.set(Calendar.SECOND, 0);
+        calendar.set(Calendar.MILLISECOND, 0);
+        Date dueAt = calendar.getTime();
+
         BoxTask.Info taskInfo = uploadedFile.addTask(BoxTask.Action.REVIEW, originalMessage, dueAt);
 
         BoxTask task = taskInfo.getResource();


### PR DESCRIPTION
Adding unit tests for search functionality (Decided against any integration tests due to the search indexing delay). 
Removed the `keyword` param which, as far as I can tell, is not valid.
Added a check to ensure either a `query` or a `metadata filter` is provided when searching.
Converted `BoxDateFormatter` to use UCT time

@codyebberson @gcurtis @rschaller-box 