### PR TITLE
Use URLEncoder class for encoding query params

### DIFF
--- a/src/main/java/com/box/sdk/QueryStringBuilder.java
+++ b/src/main/java/com/box/sdk/QueryStringBuilder.java
@@ -1,7 +1,9 @@
 package com.box.sdk;
 
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
 
 class QueryStringBuilder {
     private final StringBuilder stringBuilder;
@@ -62,79 +64,10 @@ class QueryStringBuilder {
     }
 
     private String encode(String unencoded) {
-        StringBuilder encodedBuilder = new StringBuilder();
-        for (int i = 0, n = unencoded.length(); i < n; i++) {
-            char c = unencoded.charAt(i);
-            switch (c) {
-                case ' ':
-                    encodedBuilder.append('+');
-                    break;
-                case '!':
-                    encodedBuilder.append("%21");
-                    break;
-                case '"':
-                    encodedBuilder.append("%22");
-                    break;
-                case '#':
-                    encodedBuilder.append("%23");
-                    break;
-                case '$':
-                    encodedBuilder.append("%24");
-                    break;
-                case '&':
-                    encodedBuilder.append("%26");
-                    break;
-                case '\'':
-                    encodedBuilder.append("%27");
-                    break;
-                case '(':
-                    encodedBuilder.append("%28");
-                    break;
-                case ')':
-                    encodedBuilder.append("%29");
-                    break;
-                case '+':
-                    encodedBuilder.append("%2b");
-                    break;
-                case ',':
-                    encodedBuilder.append("%2c");
-                    break;
-                case '/':
-                    encodedBuilder.append("%2f");
-                    break;
-                case ':':
-                    encodedBuilder.append("%3a");
-                    break;
-                case ';':
-                    encodedBuilder.append("%3b");
-                    break;
-                case '=':
-                    encodedBuilder.append("%3d");
-                    break;
-                case '?':
-                    encodedBuilder.append("%3f");
-                    break;
-                case '@':
-                    encodedBuilder.append("%40");
-                    break;
-                case '[':
-                    encodedBuilder.append("%5b");
-                    break;
-                case ']':
-                    encodedBuilder.append("%5d");
-                    break;
-                case '{':
-                    encodedBuilder.append("%7b");
-                    break;
-                case '}':
-                    encodedBuilder.append("%7d");
-                    break;
-                default:
-                    encodedBuilder.append(c);
-                    break;
-            }
+        try {
+            return URLEncoder.encode(unencoded, "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            throw new BoxAPIException(ex.getMessage());
         }
-
-        return encodedBuilder.toString();
     }
 }

--- a/src/test/java/com/box/sdk/BoxSearchParametersTest.java
+++ b/src/test/java/com/box/sdk/BoxSearchParametersTest.java
@@ -41,7 +41,7 @@ public class BoxSearchParametersTest {
         searchParams.setQuery("query");
         QueryStringBuilder queryParams = searchParams.getQueryParameters();
 
-        Assert.assertEquals(queryParams.toString(), "?query=query&fields=field1%2cfield2");
+        Assert.assertEquals(queryParams.toString(), "?query=query&fields=field1%2Cfield2");
     }
 
     @Test
@@ -55,7 +55,7 @@ public class BoxSearchParametersTest {
         searchParams.setQuery("query");
         QueryStringBuilder queryParams = searchParams.getQueryParameters();
 
-        Assert.assertEquals(queryParams.toString(), "?query=query&file_extensions=pdf%2cdoc");
+        Assert.assertEquals(queryParams.toString(), "?query=query&file_extensions=pdf%2Cdoc");
     }
 
     @Test
@@ -69,7 +69,7 @@ public class BoxSearchParametersTest {
         searchParams.setQuery("query");
         QueryStringBuilder queryParams = searchParams.getQueryParameters();
 
-        Assert.assertEquals(queryParams.toString(), "?query=query&owner_user_ids=123%2c456");
+        Assert.assertEquals(queryParams.toString(), "?query=query&owner_user_ids=123%2C456");
     }
 
     @Test
@@ -83,7 +83,7 @@ public class BoxSearchParametersTest {
         searchParams.setQuery("query");
         QueryStringBuilder queryParams = searchParams.getQueryParameters();
 
-        Assert.assertEquals(queryParams.toString(), "?query=query&ancestor_folder_ids=123%2c456");
+        Assert.assertEquals(queryParams.toString(), "?query=query&ancestor_folder_ids=123%2C456");
     }
 
     @Test
@@ -97,7 +97,7 @@ public class BoxSearchParametersTest {
         searchParams.setQuery("query");
         QueryStringBuilder queryParams = searchParams.getQueryParameters();
 
-        Assert.assertEquals(queryParams.toString(), "?query=query&content_types=description%2cfile_content");
+        Assert.assertEquals(queryParams.toString(), "?query=query&content_types=description%2Cfile_content");
     }
 
     @Test
@@ -166,7 +166,7 @@ public class BoxSearchParametersTest {
 
         Assert.assertEquals(
             queryParams.toString(),
-            "?query=query&created_at_range=2016-01-01T00%3a00%3a00%2b0000%2c2016-04-01T00%3a00%3a00%2b0000"
+            "?query=query&created_at_range=2016-01-01T00%3A00%3A00%2B0000%2C2016-04-01T00%3A00%3A00%2B0000"
         );
     }
 
@@ -191,7 +191,7 @@ public class BoxSearchParametersTest {
 
         Assert.assertEquals(
             queryParams.toString(),
-            "?query=query&updated_at_range=2016-01-01T00%3a00%3a00%2b0000%2c2016-04-01T00%3a00%3a00%2b0000"
+            "?query=query&updated_at_range=2016-01-01T00%3A00%3A00%2B0000%2C2016-04-01T00%3A00%3A00%2B0000"
         );
     }
 
@@ -214,9 +214,9 @@ public class BoxSearchParametersTest {
 
         Assert.assertEquals(
             queryParams.toString(),
-            "?mdfilters=%5b%7b%22templateKey%22%3a%22test%22%2c%22scope%22%3a%22enterprise"
-                + "%22%2c%22filters%22%3a%7b%22testnumber%22%3a%7b%22gt%22%3a12%2c%22lt"
-                + "%22%3a19%7d%2c%22test%22%3a%22example%22%7d%7d%5d"
+            "?mdfilters=%5B%7B%22templateKey%22%3A%22test%22%2C%22scope%22%3A%22enterprise"
+                    + "%22%2C%22filters%22%3A%7B%22testnumber%22%3A%7B%22gt%22%3A12%2C%22lt"
+                    + "%22%3A19%7D%2C%22test%22%3A%22example%22%7D%7D%5D"
         );
     }
 }

--- a/src/test/java/com/box/sdk/BoxSearchTest.java
+++ b/src/test/java/com/box/sdk/BoxSearchTest.java
@@ -49,10 +49,10 @@ public class BoxSearchTest {
     @Test
     @Category(UnitTest.class)
     public void searchWithMetadataRequestsCorrectFiltersAndFields() {
-        final String filters = "%5b%7b%22templateKey%22%3a%22test%22%2c%22"
-                + "scope%22%3a%22enterprise%22%2c%22filters%22%3a%7b%22"
-                + "number%22%3a%7b%22gt%22%3a12%2c%22lt%22%3a19%7d%2c%22test"
-                + "%22%3a%22example%22%7d%7d%5d";
+        final String filters = "%5B%7B%22templateKey%22%3A%22test%22%2C%22scope%22%3A%22enterprise%22%2C%22"
+                + "filters%22%3A%7B%22number%22%3A%7B%22gt%22%3A12%2C%22lt%22%3A19%7D%2C%22test%22%3A%22"
+                + "example%22%7D%7D%5D";
+
         BoxAPIConnection api = new BoxAPIConnection("");
         api.setBaseURL("http://localhost:8080/");
 


### PR DESCRIPTION
Modifying `QueryStringBuilder` to the `URLEncoder` class