### PR TITLE
Removing Redundant Throws from CheckStyle

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -169,7 +169,7 @@
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows"/>
+        <!-- module name="RedundantThrows"   RedundantThrows was removed with version 6.2  -->
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
 


### PR DESCRIPTION
RedundantThrows was removed with version 6.2 (see https://github.com/checkstyle/checkstyle/issues/473)