### PR TITLE
Allow changing the request HTTP connection object from a RequestInterceptor

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -341,7 +341,7 @@ public class BoxAPIRequest {
     }
 
     private BoxAPIResponse trySend(ProgressListener listener) {
-        createConnection();
+        this.createConnection();
 
         if (this.api != null) {
             RequestInterceptor interceptor = this.api.getRequestInterceptor();
@@ -477,7 +477,7 @@ public class BoxAPIRequest {
      * @return the HttpURLConnection object associated with this request.
      */
     public HttpURLConnection getConnection() {
-        return connection;
+        return this.connection;
     }
 
     private void createConnection() {

--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -40,6 +40,7 @@ public class BoxAPIRequest {
     private final String method;
 
     private URL url;
+    private HttpURLConnection connection;
     private BackoffCounter backoffCounter;
     private int timeout;
     private InputStream body;
@@ -340,6 +341,8 @@ public class BoxAPIRequest {
     }
 
     private BoxAPIResponse trySend(ProgressListener listener) {
+        createConnection();
+        
         if (this.api != null) {
             RequestInterceptor interceptor = this.api.getRequestInterceptor();
             if (interceptor != null) {
@@ -349,8 +352,6 @@ public class BoxAPIRequest {
                 }
             }
         }
-
-        HttpURLConnection connection = this.createConnection();
 
         if (this.bodyLength > 0) {
             connection.setFixedLengthStreamingMode((int) this.bodyLength);
@@ -469,9 +470,13 @@ public class BoxAPIRequest {
             LOGGER.log(Level.FINE, this.toString());
         }
     }
+    
+    public HttpURLConnection getConnection() {
+        return connection;
+    }
 
-    private HttpURLConnection createConnection() {
-        HttpURLConnection connection = null;
+    private void createConnection() {
+        connection = null;
 
         try {
             if (this.api == null || this.api.getProxy() == null) {
@@ -499,8 +504,6 @@ public class BoxAPIRequest {
         for (RequestHeader header : this.headers) {
             connection.addRequestProperty(header.getKey(), header.getValue());
         }
-
-        return connection;
     }
 
     void shouldAuthenticate(boolean shouldAuthenticate) {


### PR DESCRIPTION
For example, to trust self-signed certificates.
