### PR TITLE
Return all results for BoxGroup.getMemberships()

### DIFF
--- a/src/main/java/com/box/sdk/BoxGroupMembershipIterator.java
+++ b/src/main/java/com/box/sdk/BoxGroupMembershipIterator.java
@@ -1,0 +1,34 @@
+package com.box.sdk;
+
+import java.net.URL;
+import java.util.Iterator;
+
+import com.eclipsesource.json.JsonObject;
+
+class BoxGroupMembershipIterator implements Iterator<BoxGroupMembership.Info> {
+    private static final long LIMIT = 1000;
+
+    private final BoxAPIConnection api;
+    private final JSONIterator jsonIterator;
+
+    BoxGroupMembershipIterator(BoxAPIConnection api, URL url) {
+        this.api = api;
+        this.jsonIterator = new JSONIterator(api, url, LIMIT);
+    }
+
+    public boolean hasNext() {
+        return this.jsonIterator.hasNext();
+    }
+
+    public BoxGroupMembership.Info next() {
+        JsonObject nextJSONObject = this.jsonIterator.next();
+        String id = nextJSONObject.get("id").asString();
+
+        BoxGroupMembership group = new BoxGroupMembership(this.api, id);
+        return group.new Info(nextJSONObject);
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
This method wasn't correctly paginating results and only returned the first 100 memberships. This change returns all of them by automatically paging.

Ideally, we'd like to return an Iterator that allows for lazy paging, but that would require a method signature change. This is tracked as a breaking change in #335.

This change was originally authored by Dor Fire, but modified to prevent the backwards-incompatible change.

Fixes #316.