### PR TITLE
Retention Policy assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ You can find guides and tutorials in the `doc` directory.
 * [Tasks](doc/tasks.md)
 * [Collections](doc/collections.md)
 * [Devices](doc/devices.md)
+* [Retention Policies](doc/retention_policies.md)
 
 Javadocs are generated when `gradle javadoc` is run and can be found in
 `build/doc/javadoc`.

--- a/doc/retention_policies.md
+++ b/doc/retention_policies.md
@@ -1,0 +1,126 @@
+Retention Policies
+======
+
+A retention policy blocks permanent deletion of content for a specified amount of time. Admins can create retention policies and then later assign them to specific folders or their entire enterprise.
+
+* [Create Retention Policy](#create-retention-policy)
+* [Get Retention Policy](#get-retention-policy)
+* [Update Retention Policy](#update-retention-policy)
+* [Get Retention Policies](#get-retention-policies)
+* [Get Retention Policy Assignments](#get-retention-policy-assignments)
+* [Create Retention Policy Assignment](#create-retention-policy-assignment)
+* [Get Retention Policy Assignment](#get-retention-policy-assignment)
+
+
+Create Retention Policy
+--------------
+
+The static [`createIndefinitePolicy(BoxAPIConnection, String)`][create-indefinite-retention-policy] method will let you create a new indefinite retention policy with a specified name.
+
+```java
+BoxRetentionPolicy.createIndefinitePolicy(api, name);
+```
+
+The static [`createFinitePolicy(BoxAPIConnection, String, int, String)`][create-finite-retention-policy] method will let you create a new finite retention policy with a specified name, amount of time to apply the retention policy (in days) and a disposition action. the disposition action can be "permanently_delete" or "remove_retention".
+
+```java
+BoxRetentionPolicy.createFinitePolicy(api, name, length, action);
+```
+
+[create-indefinite-retention-policy]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#createIndefinitePolicy(com.box.sdk.BoxAPIConnection,%20java.lang.String)
+[create-finite-retention-policy]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#createIndefinitePolicy(com.box.sdk.BoxAPIConnection,%20java.lang.String,%20java.lang.int,%20java.lang.String)
+
+Get Retention Policy
+--------------
+
+Calling [`getInfo(String...)`][get-info] will return a BoxRetentionPolicy.Info object containing information about the retention policy. If necessary to retrieve limited set of fields, it is possible to specify them using param.
+
+```java
+BoxRetentionPolicy policy = new BoxRetentionPolicy(api, id);
+policy.getInfo("policy_name", "status");
+```
+
+[get-info]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#getInfo(java.lang.String...)
+
+Update Retention Policy
+--------------
+
+Updating a retention policy's information is done by calling [`updateInfo(BoxRetentionPolicy.Info)`][update-info].
+
+```java
+BoxRetentionPolicy policy = new BoxRetentionPolicy(api, id);
+BoxRetentionPolicy.Info policyInfo = policy.new Info();
+policyInfo.addPendingChange("policy_name", "new policy name");
+policy.updateInfo(policyInfo);
+```
+
+[update-info]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#updateInfo(com.box.sdk.BoxRetentionPolicy.Info)
+
+Get Retention Policies
+--------------
+
+Calling the static [`getAll(BoxAPIConnection, String...)`][get-retention-policies] will return an iterable that will page through all of the retention policies.
+It is possible to specify filter for the name of retention policy, filter for the type of the policy, filter for the id of user, limit of items per single response and fields to retrieve by calling the static [`getAll(String, String, String, int, BoxAPIConnection, String...)`][get-retention-policies-with-fields] method.
+
+```java
+Iterable<BoxRetentionPolicy.Info> policies = BoxRetentionPolicy.getAll(api);
+for (BoxRetentionPolicy.Info policyInfo : policies) {
+	// Do something with the retention policy.
+}
+```
+
+[get-retention-policies]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#getAll(com.box.sdk.BoxAPIConnection,%20java.lang.String...)
+[get-retention-policies-with-fields]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#getAll(java.lang.String,%20java.lang.String,%20java.lang.String,%20int,%20com.box.sdk.BoxAPIConnection,%20java.lang.String...)
+
+Get Retention Policy Assignments
+--------------
+
+Calling [`getAllAssignments(String...)`][get-all-assignments] will return an iterable that will page through all of the assignments of the retention policy. It is possible to specify maximum number of items per single response and fields to retrieve by calling [`getFolderAssignments(int, String...)`][get-all-assignments-with-params].
+If it is necessary to retrieve only assignments of certain type, you can call [`getFolderAssignments(int, String...)`][get-folder-assignments] or [`getEnterpriseAssignments(int, String...)`][get-enterprise-assignments].
+
+```java
+BoxRetentionPolicy policy = new BoxRetentionPolicy(api, id);
+Iterable<BoxRetentionPolicyAssignment.Info> allAssignments = BoxRetentionPolicy.getAllAssignments("assigned_by");
+Iterable<BoxRetentionPolicyAssignment.Info> folderAssignments = BoxRetentionPolicy.getFolderAssignments(50, "assigned_by");
+Iterable<BoxRetentionPolicyAssignment.Info> enterpriseAssignments = BoxRetentionPolicy.getEnterpriseAssignments();
+for (BoxRetentionPolicyAssignments.Info assignmentInfo : allAssignments) {
+	// Do something with the assignment.
+}
+for (BoxRetentionPolicyAssignments.Info assignmentInfo : folderAssignments) {
+	// Do something with the assignment.
+}
+for (BoxRetentionPolicyAssignments.Info assignmentInfo : enterpriseAssignments) {
+	// Do something with the assignment.
+}
+```
+
+[get-all-assignments]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#getAllAssignments(java.lang.String...)
+[get-all-assignments-with-params]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#getAllAssignments(int,%20java.lang.String...)
+[get-folder-assignments]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#getFolderAssignments(int,%20java.lang.String...)
+[get-enterprise-assignments]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#getEnterpiseAssignments(int,%20java.lang.String...)
+
+Create Retention Policy Assignment
+--------------
+To create new retention policy assignment call [`assignTo(BoxFolder)`][create-assignment] method, or [`assignToEnterprise()`][create-assignment-to-enterprise] to assign retention policy to enterprise.
+
+```java
+BoxRetentionPolicy policy = new BoxRetentionPolicy(api, policyID);
+BoxRetentionPolicyAssignment.Info enterpriseAssignmentInfo = policy.assignToEnterprise();
+BoxFolder folder = new BoxFolder(api, folderID);
+BoxRetentionPolicyAssignment.Info folderAssignmentInfo = policy.assignTo(folder);
+```
+
+[create-assignment]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#assignTo(com.box.sdk.BoxFolder)
+[create-assignment-to-enterprise]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicy.html#assignToEnterprise()
+
+Get Retention Policy Assignment
+--------------
+
+Calling [`getInfo(String...)`][get-assignment] will return a BoxRetentionPolicyAssignment.Info object containing information about the retention policy assignment.
+
+```java
+BoxRetentionPolicyAssignment assignment = new BoxRetentionPolicyAssignment(api, id);
+BoxRetentionPolicyAssignment.Info assignmentInfo = assignment.getInfo("assigned_to");
+```
+
+[get-assignment]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRetentionPolicyAssignment.html#getInfo(java.lang.String...)

--- a/src/main/java/com/box/sdk/BoxResource.java
+++ b/src/main/java/com/box/sdk/BoxResource.java
@@ -54,6 +54,8 @@ public abstract class BoxResource {
         result.put(getResourceType(BoxWebHook.class), BoxWebHook.class);
         result.put(getResourceType(BoxCollection.class), BoxCollection.class);
         result.put(getResourceType(BoxDevicePin.class), BoxDevicePin.class);
+        result.put(getResourceType(BoxRetentionPolicy.class), BoxRetentionPolicy.class);
+        result.put(getResourceType(BoxRetentionPolicyAssignment.class), BoxRetentionPolicyAssignment.class);
         return Collections.unmodifiableMap(result);
     }
 

--- a/src/main/java/com/box/sdk/BoxRetentionPolicy.java
+++ b/src/main/java/com/box/sdk/BoxRetentionPolicy.java
@@ -1,0 +1,500 @@
+package com.box.sdk;
+
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Date;
+
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+
+/**
+ * Represents a retention policy.
+ * A retention policy blocks permanent deletion of content for a specified amount of time.
+ * Admins can create retention policies and then later assign them to specific folders or their entire enterprise.
+ *
+ * @see <a href="https://docs.box.com/reference#retention-policy-object">Box retention policy</a>
+ *
+ * <p>Unless otherwise noted, the methods in this class can throw an unchecked {@link BoxAPIException} (unchecked
+ * meaning that the compiler won't force you to handle it) if an error occurs. If you wish to implement custom error
+ * handling for errors related to the Box REST API, you should capture this exception explicitly.</p>
+ */
+@BoxResourceType("retention_policy")
+public class BoxRetentionPolicy extends BoxResource {
+
+    /**
+     *  Will cause the content retained by the policy to be permanently deleted.
+     */
+    public static final String ACTION_PERMANENTLY_DELETE = "permanently_delete";
+
+    /**
+     * Will lift the retention policy from the content, allowing it to be deleted by users.
+     */
+    public static final String ACTION_REMOVE_RETENTION = "remove_retention";
+
+    /**
+     * Status corresponding to active retention policy.
+     */
+    public static final String STATUS_ACTIVE = "active";
+
+    /**
+     * Status corresponding to retired retention policy.
+     */
+    public static final String STATUS_RETIRED = "retired";
+
+    /**
+     * Type for finite retention policies. Finite retention policies has the duration.
+     */
+    private static final String TYPE_FINITE = "finite";
+
+    /**
+     * Type for indefinite retention policies. Indefinite retention policies can have only "remove_retention"
+     * assigned action.
+     */
+    private static final String TYPE_INDEFINITE = "indefinite";
+
+    /**
+     * The default limit of entries per response.
+     */
+    private static final int DEFAULT_LIMIT = 100;
+
+    /**
+     * The URL template used for operation with retention policies.
+     */
+    private static final URLTemplate RETENTION_POLICIES_URL_TEMPLATE = new URLTemplate("retention_policies");
+
+    /**
+     * The URL template used for operation with retention policy with given ID.
+     */
+    private static final URLTemplate POLICY_URL_TEMPLATE = new URLTemplate("retention_policies/%s");
+
+    /**
+     * The URL template used for operation with retention policy assignments.
+     */
+    private static final URLTemplate ASSIGNMENTS_URL_TEMPLATE = new URLTemplate("retention_policies/%s/assignments");
+
+    /**
+     * Constructs a retention policy for a resource with a given ID.
+     *
+     * @param api the API connection to be used by the resource.
+     * @param id  the ID of the resource.
+     */
+    public BoxRetentionPolicy(BoxAPIConnection api, String id) {
+        super(api, id);
+    }
+
+    /**
+     * Used to create a new indefinite retention policy.
+     * @param api the API connection to be used by the created user.
+     * @param name the name of the retention policy.
+     * @return the created retention policy's info.
+     */
+    public static BoxRetentionPolicy.Info createIndefinitePolicy(BoxAPIConnection api, String name) {
+        return createRetentionPolicy(api, name, TYPE_INDEFINITE, 0, ACTION_REMOVE_RETENTION);
+    }
+
+    /**
+     * Used to create a new finite retention policy.
+     * @param api the API connection to be used by the created user.
+     * @param name the name of the retention policy.
+     * @param length the duration in days that the retention policy will be active for after being assigned to content.
+     * @param action the disposition action can be "permanently_delete" or "remove_retention".
+     * @return the created retention policy's info.
+     */
+    public static BoxRetentionPolicy.Info createFinitePolicy(BoxAPIConnection api, String name, int length,
+                                                                      String action) {
+        return createRetentionPolicy(api, name, TYPE_FINITE, length, action);
+    }
+
+    /**
+     * Used to create a new retention policy.
+     * @param api the API connection to be used by the created user.
+     * @param name the name of the retention policy.
+     * @param type the type of the retention policy. Can be "finite" or "indefinite".
+     * @param length the duration in days that the retention policy will be active for after being assigned to content.
+     * @param action the disposition action can be "permanently_delete" or "remove_retention".
+     * @return the created retention policy's info.
+     */
+    private static BoxRetentionPolicy.Info createRetentionPolicy(BoxAPIConnection api, String name, String type,
+                                                                int length, String action) {
+        URL url = RETENTION_POLICIES_URL_TEMPLATE.build(api.getBaseURL());
+        BoxJSONRequest request = new BoxJSONRequest(api, url, "POST");
+        JsonObject requestJSON = new JsonObject()
+                .add("policy_name", name)
+                .add("policy_type", type)
+                .add("disposition_action", action);
+        if (!type.equals(TYPE_INDEFINITE)) {
+            requestJSON.add("retention_length", length);
+        }
+        request.setBody(requestJSON.toString());
+        BoxJSONResponse response = (BoxJSONResponse) request.send();
+        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        BoxRetentionPolicy createdPolicy = new BoxRetentionPolicy(api, responseJSON.get("id").asString());
+        return createdPolicy.new Info(responseJSON);
+    }
+
+    /**
+     * Returns iterable with all folder assignments of this retention policy.
+     * @param fields the fields to retrieve.
+     * @return an iterable containing all folder assignments.
+     */
+    public Iterable<BoxRetentionPolicyAssignment.Info> getFolderAssignments(String ... fields) {
+        return this.getFolderAssignments(DEFAULT_LIMIT, fields);
+    }
+
+    /**
+     * Returns iterable with all folder assignments of this retention policy.
+     * @param limit the limit of entries per response. The default value is 100.
+     * @param fields the fields to retrieve.
+     * @return an iterable containing all folder assignments.
+     */
+    public Iterable<BoxRetentionPolicyAssignment.Info> getFolderAssignments(int limit, String ... fields) {
+        return this.getAssignments(BoxRetentionPolicyAssignment.TYPE_FOLDER, limit, fields);
+    }
+
+    /**
+     * Returns iterable with all enterprise assignments of this retention policy.
+     * @param fields the fields to retrieve.
+     * @return an iterable containing all enterprise assignments.
+     */
+    public Iterable<BoxRetentionPolicyAssignment.Info> getEnterpriseAssignments(String ... fields) {
+        return this.getEnterpriseAssignments(DEFAULT_LIMIT, fields);
+    }
+
+    /**
+     * Returns iterable with all enterprise assignments of this retention policy.
+     * @param limit the limit of entries per response. The default value is 100.
+     * @param fields the fields to retrieve.
+     * @return an iterable containing all enterprise assignments.
+     */
+    public Iterable<BoxRetentionPolicyAssignment.Info> getEnterpriseAssignments(int limit, String ... fields) {
+        return this.getAssignments(BoxRetentionPolicyAssignment.TYPE_ENTERPRISE, limit, fields);
+    }
+
+    /**
+     * Returns iterable with all assignments of this retention policy.
+     * @param fields the fields to retrieve.
+     * @return an iterable containing all assignments.
+     */
+    public Iterable<BoxRetentionPolicyAssignment.Info> getAllAssignments(String ... fields) {
+        return this.getAllAssignments(DEFAULT_LIMIT, fields);
+    }
+
+    /**
+     * Returns iterable with all assignments of this retention policy.
+     * @param limit the limit of entries per response. The default value is 100.
+     * @param fields the fields to retrieve.
+     * @return an iterable containing all assignments.
+     */
+    public Iterable<BoxRetentionPolicyAssignment.Info> getAllAssignments(int limit, String ... fields) {
+        return this.getAssignments(null, limit, fields);
+    }
+
+    /**
+     * Returns iterable with all assignments of given type of this retention policy.
+     * @param type the type of the retention policy assignment to retrieve. Can either be "folder" or "enterprise".
+     * @param limit the limit of entries per response. The default value is 100.
+     * @param fields the fields to retrieve.
+     * @return an iterable containing all assignments of given type.
+     */
+    private Iterable<BoxRetentionPolicyAssignment.Info> getAssignments(String type, int limit, String ... fields) {
+        QueryStringBuilder queryString = new QueryStringBuilder();
+        if (type != null) {
+            queryString.appendParam("type", type);
+        }
+        if (fields.length > 0) {
+            queryString.appendParam("fields", fields);
+        }
+        URL url = ASSIGNMENTS_URL_TEMPLATE.buildWithQuery(getAPI().getBaseURL(), queryString.toString(), getID());
+        return new BoxResourceIterable<BoxRetentionPolicyAssignment.Info>(getAPI(), url, limit) {
+
+            @Override
+            protected BoxRetentionPolicyAssignment.Info factory(JsonObject jsonObject) {
+                BoxRetentionPolicyAssignment assignment
+                    = new BoxRetentionPolicyAssignment(getAPI(), jsonObject.get("id").asString());
+                return assignment.new Info(jsonObject);
+            }
+
+        };
+    }
+
+    /**
+     * Assigns this retention policy to folder.
+     * @param folder the folder to assign policy to.
+     * @return info about created assignment.
+     */
+    public BoxRetentionPolicyAssignment.Info assignTo(BoxFolder folder) {
+        return BoxRetentionPolicyAssignment.createAssignmentToFolder(this.getAPI(), this.getID(), folder.getID());
+    }
+
+    /**
+     * Assigns this retention policy to the current enterprise.
+     * @return info about created assignment.
+     */
+    public BoxRetentionPolicyAssignment.Info assignToEnterprise() {
+        return BoxRetentionPolicyAssignment.createAssignmentToEnterprise(this.getAPI(), this.getID());
+    }
+
+    /**
+     * Updates the information about this retention policy with any info fields that have been modified locally.
+     * @param info the updated info.
+     */
+    public void updateInfo(BoxRetentionPolicy.Info info) {
+        URL url = POLICY_URL_TEMPLATE.build(this.getAPI().getBaseURL(), this.getID());
+        BoxJSONRequest request = new BoxJSONRequest(this.getAPI(), url, "PUT");
+        request.setBody(info.getPendingChanges());
+        BoxJSONResponse response = (BoxJSONResponse) request.send();
+        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        info.update(responseJSON);
+    }
+
+    /**
+     * Returns information about this retention policy.
+     * @param fields the fields to retrieve.
+     * @return information about this retention policy.
+     */
+    public BoxRetentionPolicy.Info getInfo(String ... fields) {
+        QueryStringBuilder builder = new QueryStringBuilder();
+        if (fields.length > 0) {
+            builder.appendParam("fields", fields);
+        }
+        URL url = POLICY_URL_TEMPLATE.buildWithQuery(this.getAPI().getBaseURL(), builder.toString(), this.getID());
+        BoxAPIRequest request = new BoxAPIRequest(this.getAPI(), url, "GET");
+        BoxJSONResponse response = (BoxJSONResponse) request.send();
+        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        return new Info(responseJSON);
+    }
+
+
+    /**
+     * Returns all the retention policies.
+     * @param api the API connection to be used by the resource.
+     * @param fields the fields to retrieve.
+     * @return an iterable with all the retention policies.
+     */
+    public static Iterable<BoxRetentionPolicy.Info> getAll(final BoxAPIConnection api, String ... fields) {
+        return getAll(null, null, null, DEFAULT_LIMIT, api, fields);
+    }
+
+    /**
+     * Returns all the retention policies with specified filters.
+     * @param name a name to filter the retention policies by. A trailing partial match search is performed.
+     *             Set to null if no name filtering is required.
+     * @param type a policy type to filter the retention policies by. Set to null if no type filtering is required.
+     * @param userID a user id to filter the retention policies by. Set to null if no type filtering is required.
+     * @param limit the limit of items per single response. The default value is 100.
+     * @param api the API connection to be used by the resource.
+     * @param fields the fields to retrieve.
+     * @return an iterable with all the retention policies met search conditions.
+     */
+    public static Iterable<BoxRetentionPolicy.Info> getAll(
+            String name, String type, String userID, int limit, final BoxAPIConnection api, String ... fields) {
+        QueryStringBuilder queryString = new QueryStringBuilder();
+        if (name != null) {
+            queryString.appendParam("policy_name", name);
+        }
+        if (type != null) {
+            queryString.appendParam("policy_type", type);
+        }
+        if (userID != null) {
+            queryString.appendParam("created_by_user_id", userID);
+        }
+        if (fields.length > 0) {
+            queryString.appendParam("fields", fields);
+        }
+        URL url = RETENTION_POLICIES_URL_TEMPLATE.buildWithQuery(api.getBaseURL(), queryString.toString());
+        return new BoxResourceIterable<BoxRetentionPolicy.Info>(api, url, limit) {
+
+            @Override
+            protected BoxRetentionPolicy.Info factory(JsonObject jsonObject) {
+                BoxRetentionPolicy policy = new BoxRetentionPolicy(api, jsonObject.get("id").asString());
+                return policy.new Info(jsonObject);
+            }
+
+        };
+    }
+
+    /**
+     * Contains information about the retention policy.
+     */
+    public class Info extends BoxResource.Info {
+
+        /**
+         * @see #getPolicyName()
+         */
+        private String policyName;
+
+        /**
+         * @see #getPolicyType()
+         */
+        private String policyType;
+
+        /**
+         * @see #getRetentionLength()
+         */
+        private int retentionLength;
+
+        /**
+         * @see #getDispositionAction()
+         */
+        private String dispositionAction;
+
+        /**
+         * @see #getStatus()
+         */
+        private String status;
+
+        /**
+         * @see #getCreatedBy()
+         */
+        private BoxUser.Info createdBy;
+
+        /**
+         * @see #getCreatedAt()
+         */
+        private Date createdAt;
+
+        /**
+         * @see #getModifiedAt()
+         */
+        private Date modifiedAt;
+
+        /**
+         * Constructs an empty Info object.
+         */
+        public Info() {
+            super();
+        }
+
+        /**
+         * Constructs an Info object by parsing information from a JSON string.
+         * @param  json the JSON string to parse.
+         */
+        public Info(String json) {
+            super(json);
+        }
+
+        /**
+         * Constructs an Info object using an already parsed JSON object.
+         * @param  jsonObject the parsed JSON object.
+         */
+        Info(JsonObject jsonObject) {
+            super(jsonObject);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public BoxResource getResource() {
+            return BoxRetentionPolicy.this;
+        }
+
+        /**
+         * Gets the name given to the retention policy.
+         * @return name given to the retention policy.
+         */
+        public String getPolicyName() {
+            return this.policyName;
+        }
+
+        /**
+         * Gets the type of the retention policy.
+         * A retention policy type can either be "finite",
+         * where a specific amount of time to retain the content is known upfront,
+         * or "indefinite", where the amount of time to retain the content is still unknown.
+         * @return the type of the retention policy.
+         */
+        public String getPolicyType() {
+            return this.policyType;
+        }
+
+        /**
+         * Gets the length of the retention policy. This length specifies the duration
+         * in days that the retention policy will be active for after being assigned to content.
+         * @return the length of the retention policy.
+         */
+        public int getRetentionLength() {
+            return this.retentionLength;
+        }
+
+        /**
+         * Gets the disposition action of the retention policy.
+         * This action can be "permanently_delete", or "remove_retention".
+         * @return the disposition action of the retention policy.
+         */
+        public String getDispositionAction() {
+            return this.dispositionAction;
+        }
+
+        /**
+         * Gets the status of the retention policy.
+         * The status can be "active" or "retired".
+         * @return the status of the retention policy.
+         */
+        public String getStatus() {
+            return this.status;
+        }
+
+        /**
+         * Gets info about the user created the retention policy.
+         * @return info about the user created the retention policy.
+         */
+        public BoxUser.Info getCreatedBy() {
+            return this.createdBy;
+        }
+
+        /**
+         * Gets the time that the retention policy was created.
+         * @return the time that the retention policy was created.
+         */
+        public Date getCreatedAt() {
+            return this.createdAt;
+        }
+
+        /**
+         * Gets the time that the retention policy was last modified.
+         * @return the time that the retention policy was last modified.
+         */
+        public Date getModifiedAt() {
+            return this.modifiedAt;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        void parseJSONMember(JsonObject.Member member) {
+            super.parseJSONMember(member);
+            String memberName = member.getName();
+            JsonValue value = member.getValue();
+            try {
+                if (memberName.equals("policy_name")) {
+                    this.policyName = value.asString();
+                } else if (memberName.equals("policy_type")) {
+                    this.policyType = value.asString();
+                } else if (memberName.equals("retention_length")) {
+                    this.retentionLength = value.asInt();
+                } else if (memberName.equals("disposition_action")) {
+                    this.dispositionAction = value.asString();
+                } else if (memberName.equals("status")) {
+                    this.status = value.asString();
+                } else if (memberName.equals("created_by")) {
+                    JsonObject userJSON = value.asObject();
+                    if (this.createdBy == null) {
+                        String userID = userJSON.get("id").asString();
+                        BoxUser user = new BoxUser(getAPI(), userID);
+                        this.createdBy = user.new Info(userJSON);
+                    } else {
+                        this.createdBy.update(userJSON);
+                    }
+                } else if (memberName.equals("created_at")) {
+                    this.createdAt = BoxDateFormat.parse(value.asString());
+                } else if (memberName.equals("modified_at")) {
+                    this.modifiedAt = BoxDateFormat.parse(value.asString());
+                }
+            } catch (ParseException e) {
+                assert false : "A ParseException indicates a bug in the SDK.";
+            }
+        }
+    }
+}

--- a/src/main/java/com/box/sdk/BoxRetentionPolicyAssignment.java
+++ b/src/main/java/com/box/sdk/BoxRetentionPolicyAssignment.java
@@ -1,0 +1,253 @@
+package com.box.sdk;
+
+import java.net.URL;
+import java.text.ParseException;
+import java.util.Date;
+
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+
+/**
+ * Represents a retention policy assignment.
+ *
+ * <p>Unless otherwise noted, the methods in this class can throw an unchecked {@link BoxAPIException} (unchecked
+ * meaning that the compiler won't force you to handle it) if an error occurs. If you wish to implement custom error
+ * handling for errors related to the Box REST API, you should capture this exception explicitly.</p>
+ */
+@BoxResourceType("retention_policy_assignment")
+public class BoxRetentionPolicyAssignment extends BoxResource {
+
+    /**
+     * Type for folder policy assignment.
+     */
+    public static final String TYPE_FOLDER = "folder";
+
+    /**
+     * Type for enterprise policy assignment.
+     */
+    public static final String TYPE_ENTERPRISE = "enterprise";
+
+    /**
+     * The URL template used for operation with retention policy assignments.
+     */
+    private static final URLTemplate ASSIGNMENTS_URL_TEMPLATE = new URLTemplate("retention_policy_assignments");
+
+    /**
+     * The URL template used for operation with retention policy assignment with given ID.
+     */
+    private static final URLTemplate RETENTION_POLICY_ASSIGNMENT_URL_TEMPLATE
+        = new URLTemplate("retention_policy_assignments/%s");
+
+    /**
+     * Constructs a BoxResource for a resource with a given ID.
+     *
+     * @param api the API connection to be used by the resource.
+     * @param id  the ID of the resource.
+     */
+    public BoxRetentionPolicyAssignment(BoxAPIConnection api, String id) {
+        super(api, id);
+    }
+
+    /**
+     * Assigns retention policy with givenID to the enterprise.
+     * @param api the API connection to be used by the created assignment.
+     * @param policyID id of the assigned retention policy.
+     * @return info about created assignment.
+     */
+    public static BoxRetentionPolicyAssignment.Info createAssignmentToEnterprise(BoxAPIConnection api,
+                                                                                 String policyID) {
+        return createAssignment(api, policyID, new JsonObject().add("type", TYPE_ENTERPRISE));
+    }
+
+    /**
+     * Assigns retention policy with givenID to the folder.
+     * @param api the API connection to be used by the created assignment.
+     * @param policyID id of the assigned retention policy.
+     * @param folderID id of the folder to assign policy to.
+     * @return info about created assignment.
+     */
+    public static BoxRetentionPolicyAssignment.Info createAssignmentToFolder(BoxAPIConnection api, String policyID,
+                                                                             String folderID) {
+        return createAssignment(api, policyID, new JsonObject().add("type", TYPE_FOLDER).add("id", folderID));
+    }
+
+    /**
+     * Assigns retention policy with givenID to folder or enterprise.
+     * @param api the API connection to be used by the created assignment.
+     * @param policyID id of the assigned retention policy.
+     * @param assignTo object representing folder or enterprise to assign policy to.
+     * @return info about created assignment.
+     */
+    private static BoxRetentionPolicyAssignment.Info createAssignment(BoxAPIConnection api, String policyID,
+                                                                      JsonObject assignTo) {
+        URL url = ASSIGNMENTS_URL_TEMPLATE.build(api.getBaseURL());
+        BoxJSONRequest request = new BoxJSONRequest(api, url, "POST");
+
+        JsonObject requestJSON = new JsonObject()
+                .add("policy_id", policyID)
+                .add("assign_to", assignTo);
+        request.setBody(requestJSON.toString());
+        BoxJSONResponse response = (BoxJSONResponse) request.send();
+        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        BoxRetentionPolicyAssignment createdAssignment
+            = new BoxRetentionPolicyAssignment(api, responseJSON.get("id").asString());
+        return createdAssignment.new Info(responseJSON);
+    }
+
+    /**
+     * @param fields the fields to retrieve.
+     * @return information about this retention policy assignment.
+     */
+    public BoxRetentionPolicyAssignment.Info getInfo(String ... fields) {
+        QueryStringBuilder builder = new QueryStringBuilder();
+        if (fields.length > 0) {
+            builder.appendParam("fields", fields);
+        }
+        URL url = RETENTION_POLICY_ASSIGNMENT_URL_TEMPLATE.buildWithQuery(
+                this.getAPI().getBaseURL(), builder.toString(), this.getID());
+        BoxAPIRequest request = new BoxAPIRequest(this.getAPI(), url, "GET");
+        BoxJSONResponse response = (BoxJSONResponse) request.send();
+        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        return new Info(responseJSON);
+    }
+
+    /**
+     * Contains information about the retention policy.
+     */
+    public class Info extends BoxResource.Info {
+
+        /**
+         * @see #getRetentionPolicy()
+         */
+        private BoxRetentionPolicy.Info retentionPolicy;
+
+        /**
+         * @see #getAssignedBy()
+         */
+        private BoxUser.Info assignedBy;
+
+        /**
+         * @see #getAssignedAt()
+         */
+        private Date assignedAt;
+
+        /**
+         * @see #getAssignedToType()
+         */
+        private String assignedToType;
+
+        /**
+         * @see #getAssignedToID()
+         */
+        private String assignedToID;
+
+        /**
+         * Constructs an empty Info object.
+         */
+        public Info() {
+            super();
+        }
+
+        /**
+         * Constructs an Info object by parsing information from a JSON string.
+         * @param  json the JSON string to parse.
+         */
+        public Info(String json) {
+            super(json);
+        }
+
+        /**
+         * Constructs an Info object using an already parsed JSON object.
+         * @param  jsonObject the parsed JSON object.
+         */
+        Info(JsonObject jsonObject) {
+            super(jsonObject);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public BoxResource getResource() {
+            return BoxRetentionPolicyAssignment.this;
+        }
+
+        /**
+         * @return the retention policy that has been assigned to this content.
+         */
+        public BoxRetentionPolicy.Info getRetentionPolicy() {
+            return this.retentionPolicy;
+        }
+
+        /**
+         * @return the info about the user that created the retention policy assignment.
+         */
+        public BoxUser.Info getAssignedBy() {
+            return this.assignedBy;
+        }
+
+        /**
+         * @return the time that the retention policy assignment was created.
+         */
+        public Date getAssignedAt() {
+            return this.assignedAt;
+        }
+
+        /**
+         * @return type of the content that is under retention. Can either be "enterprise" or "folder".
+         */
+        public String getAssignedToType() {
+            return this.assignedToType;
+        }
+
+        /**
+         * @return id of the folder that is under retention.
+         */
+        public String getAssignedToID() {
+            return this.assignedToID;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        void parseJSONMember(JsonObject.Member member) {
+            super.parseJSONMember(member);
+            String memberName = member.getName();
+            JsonValue value = member.getValue();
+            try {
+                if (memberName.equals("retention_policy")) {
+                    JsonObject policyJSON = value.asObject();
+                    if (this.retentionPolicy == null) {
+                        String policyID = policyJSON.get("id").asString();
+                        BoxRetentionPolicy policy = new BoxRetentionPolicy(getAPI(), policyID);
+                        this.retentionPolicy = policy.new Info(policyJSON);
+                    } else {
+                        this.retentionPolicy.update(policyJSON);
+                    }
+                } else if (memberName.equals("assigned_to")) {
+                    JsonObject assignmentJSON = value.asObject();
+                    this.assignedToType = assignmentJSON.get("type").asString();
+                    if (this.assignedToType.equals(TYPE_FOLDER)) {
+                        this.assignedToID = assignmentJSON.get("id").asString();
+                    } else {
+                        this.assignedToID = null;
+                    }
+                } else if (memberName.equals("assigned_by")) {
+                    JsonObject userJSON = value.asObject();
+                    if (this.assignedBy == null) {
+                        String userID = userJSON.get("id").asString();
+                        BoxUser user = new BoxUser(getAPI(), userID);
+                        this.assignedBy = user.new Info(userJSON);
+                    } else {
+                        this.assignedBy.update(userJSON);
+                    }
+                } else if (memberName.equals("assigned_at")) {
+                    this.assignedAt = BoxDateFormat.parse(value.asString());
+                }
+            } catch (ParseException e) {
+                assert false : "A ParseException indicates a bug in the SDK.";
+            }
+        }
+    }
+}

--- a/src/test/java/com/box/sdk/BoxRetentionPolicyAssignmentTest.java
+++ b/src/test/java/com/box/sdk/BoxRetentionPolicyAssignmentTest.java
@@ -1,0 +1,208 @@
+package com.box.sdk;
+
+import java.text.ParseException;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.eclipsesource.json.JsonObject;
+
+/**
+ * {@link BoxRetentionPolicyAssignment} related unit tests.
+ */
+public class BoxRetentionPolicyAssignmentTest {
+
+    /**
+     * Unit test for {@link BoxRetentionPolicyAssignment#createAssignmentToEnterprise(BoxAPIConnection, String)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testCreateAssignmentToEnterpriseSendsCorrectJson() {
+        final String id = "0";
+        final String type = "enterprise";
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new JSONRequestInterceptor() {
+            @Override
+            protected BoxAPIResponse onJSONRequest(BoxJSONRequest request, JsonObject json) {
+                Assert.assertEquals("https://api.box.com/2.0/retention_policy_assignments",
+                        request.getUrl().toString());
+                Assert.assertEquals(id, json.get("policy_id").asString());
+                Assert.assertEquals(type, json.get("assign_to").asObject().get("type").asString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"id\": \"0\"}";
+                    }
+                };
+            }
+        });
+
+        BoxRetentionPolicyAssignment.createAssignmentToEnterprise(api, id);
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicyAssignment#createAssignmentToFolder(BoxAPIConnection, String, String)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testCreateAssignmentToFolderSendsCorrectJson() {
+        final String id = "0";
+        final String type = "folder";
+        final String folderID = "1";
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new JSONRequestInterceptor() {
+            @Override
+            protected BoxAPIResponse onJSONRequest(BoxJSONRequest request, JsonObject json) {
+                Assert.assertEquals("https://api.box.com/2.0/retention_policy_assignments",
+                        request.getUrl().toString());
+                Assert.assertEquals(id, json.get("policy_id").asString());
+                Assert.assertEquals(type, json.get("assign_to").asObject().get("type").asString());
+                Assert.assertEquals(folderID, json.get("assign_to").asObject().get("id").asString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"id\": \"0\"}";
+                    }
+                };
+            }
+        });
+
+        BoxRetentionPolicyAssignment.createAssignmentToFolder(api, id, folderID);
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicyAssignment#createAssignmentToFolder(BoxAPIConnection, String, String)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testCreateAssignmentParseAllFieldsCorrectly() throws ParseException {
+        final String id = "3233225";
+        final String policyID = "32131";
+        final String policyName = "TaxDocuments";
+        final String assignedToType = "folder";
+        final String assignedToID = "99922219";
+        final String assignedByID = "123456789";
+        final String assignedByName = "Sean";
+        final String assignedByLogin = "sean@box.com";
+        final Date assignedAt = BoxDateFormat.parse("2015-07-20T14:28:09-07:00");
+
+        final JsonObject fakeJSONResponse = JsonObject.readFrom("{     \n"
+                + "  \"type\": \"retention_policy_assignment\",     \n"
+                + "  \"id\": \"3233225\",     \n"
+                + "  \"retention_policy\": {         \n"
+                + "    \"type\": \"retention_policy\",         \n"
+                + "    \"id\": \"32131\",         \n"
+                + "    \"policy_name\": \"TaxDocuments\"     \n"
+                + "  },\n"
+                + "  \"assigned_to\": {\n"
+                + "    \"type\": \"folder\",         \n"
+                + "    \"id\": \"99922219\"     \n"
+                + "  },     \n"
+                + "  \"assigned_by\": {         \n"
+                + "    \"type\": \"user\",        \n"
+                + "    \"id\": \"123456789\",        \n"
+                + "    \"name\": \"Sean\",        \n"
+                + "    \"login\": \"sean@box.com\"    \n"
+                + "  },    \n"
+                + "  \"assigned_at\": \"2015-07-20T14:28:09-07:00\"\n"
+                + "}");
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(JSONRequestInterceptor.respondWith(fakeJSONResponse));
+
+        BoxRetentionPolicyAssignment.Info info
+            = BoxRetentionPolicyAssignment.createAssignmentToFolder(api, policyID, assignedToID);
+        Assert.assertEquals(id, info.getID());
+        Assert.assertEquals(policyID, info.getRetentionPolicy().getID());
+        Assert.assertEquals(policyName, info.getRetentionPolicy().getPolicyName());
+        Assert.assertEquals(assignedToType, info.getAssignedToType());
+        Assert.assertEquals(assignedToID, info.getAssignedToID());
+        Assert.assertEquals(assignedByID, info.getAssignedBy().getID());
+        Assert.assertEquals(assignedByName, info.getAssignedBy().getName());
+        Assert.assertEquals(assignedByLogin, info.getAssignedBy().getLogin());
+        Assert.assertEquals(assignedAt, info.getAssignedAt());
+    }
+
+
+    /**
+     * Unit test for {@link BoxRetentionPolicyAssignment#getInfo(String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetInfoSendsCorrectRequest() {
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                Assert.assertEquals("https://api.box.com/2.0/retention_policy_assignments/0?fields=assigned_to",
+                        request.getUrl().toString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"id\": \"0\"}";
+                    }
+                };
+            }
+        });
+
+        BoxRetentionPolicyAssignment assignment = new BoxRetentionPolicyAssignment(api, "0");
+        assignment.getInfo("assigned_to");
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicyAssignment#getInfo(String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetInfoParseAllFieldsCorrectly() throws ParseException {
+        final String id = "3233225";
+        final String policyID = "32131";
+        final String policyName = "TaxDocuments";
+        final String assignedToType = "folder";
+        final String assignedToID = "99922219";
+        final String assignedByID = "123456789";
+        final String assignedByName = "Sean";
+        final String assignedByLogin = "sean@box.com";
+        final Date assignedAt = BoxDateFormat.parse("2015-07-20T14:28:09-07:00");
+
+        final JsonObject fakeJSONResponse = JsonObject.readFrom("{     \n"
+                + "  \"type\": \"retention_policy_assignment\",    \n"
+                + "  \"id\": \"3233225\",    \n"
+                + "  \"retention_policy\": {   \n"
+                + "    \"type\": \"retention_policy\",    \n"
+                + "    \"id\": \"32131\",   \n"
+                + "    \"policy_name\": \"TaxDocuments\"\n"
+                + "  },    \n"
+                + "  \"assigned_to\": {  \n"
+                + "    \"type\": \"folder\",   \n"
+                + "    \"id\": \"99922219\"   \n"
+                + "  },   \n"
+                + "  \"assigned_by\": {  \n"
+                + "    \"type\": \"user\",    \n"
+                + "    \"id\": \"123456789\",  \n"
+                + "    \"name\": \"Sean\",     \n"
+                + "    \"login\": \"sean@box.com\"     \n"
+                + "  },     \n"
+                + "  \"assigned_at\": \"2015-07-20T14:28:09-07:00\" \n"
+                + "}");
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(JSONRequestInterceptor.respondWith(fakeJSONResponse));
+
+        BoxRetentionPolicyAssignment assignment = new BoxRetentionPolicyAssignment(api, id);
+        BoxRetentionPolicyAssignment.Info info = assignment.getInfo();
+        Assert.assertEquals(id, info.getID());
+        Assert.assertEquals(policyID, info.getRetentionPolicy().getID());
+        Assert.assertEquals(policyName, info.getRetentionPolicy().getPolicyName());
+        Assert.assertEquals(assignedToType, info.getAssignedToType());
+        Assert.assertEquals(assignedToID, info.getAssignedToID());
+        Assert.assertEquals(assignedByID, info.getAssignedBy().getID());
+        Assert.assertEquals(assignedByName, info.getAssignedBy().getName());
+        Assert.assertEquals(assignedByLogin, info.getAssignedBy().getLogin());
+        Assert.assertEquals(assignedAt, info.getAssignedAt());
+    }
+}

--- a/src/test/java/com/box/sdk/BoxRetentionPolicyTest.java
+++ b/src/test/java/com/box/sdk/BoxRetentionPolicyTest.java
@@ -1,0 +1,549 @@
+package com.box.sdk;
+
+import java.text.ParseException;
+import java.util.Date;
+import java.util.Iterator;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.eclipsesource.json.JsonObject;
+
+/**
+ * {@link BoxRetentionPolicy} related unit tests.
+ */
+public class BoxRetentionPolicyTest {
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#createIndefinitePolicy(BoxAPIConnection, String)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testCreateIndefinitePolicySendsCorrectJson() {
+        final String name = "non-empty name";
+        final String type = "indefinite";
+        final String action = BoxRetentionPolicy.ACTION_REMOVE_RETENTION;
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new JSONRequestInterceptor() {
+            @Override
+            protected BoxAPIResponse onJSONRequest(BoxJSONRequest request, JsonObject json) {
+                Assert.assertEquals("https://api.box.com/2.0/retention_policies", request.getUrl().toString());
+                Assert.assertEquals(name, json.get("policy_name").asString());
+                Assert.assertEquals(type, json.get("policy_type").asString());
+                Assert.assertEquals(action, json.get("disposition_action").asString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"id\": \"0\"}";
+                    }
+                };
+            }
+        });
+
+        BoxRetentionPolicy.createIndefinitePolicy(api, name);
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#createFinitePolicy(BoxAPIConnection, String, int, String)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testCreateFinitePolicySendsCorrectJson() {
+        final String name = "non-empty name";
+        final String type = "finite";
+        final String action = BoxRetentionPolicy.ACTION_PERMANENTLY_DELETE;
+        final int length = 1;
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new JSONRequestInterceptor() {
+            @Override
+            protected BoxAPIResponse onJSONRequest(BoxJSONRequest request, JsonObject json) {
+                Assert.assertEquals("https://api.box.com/2.0/retention_policies", request.getUrl().toString());
+                Assert.assertEquals(name, json.get("policy_name").asString());
+                Assert.assertEquals(type, json.get("policy_type").asString());
+                Assert.assertEquals(action, json.get("disposition_action").asString());
+                Assert.assertEquals(length, json.get("retention_length").asInt());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"id\": \"0\"}";
+                    }
+                };
+            }
+        });
+
+        BoxRetentionPolicy.createFinitePolicy(api, name, length, action);
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#createFinitePolicy(BoxAPIConnection, String, int, String)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testCreatePolicyParseAllFieldsCorrectly() throws ParseException {
+        final String id = "123456789";
+        final String name = "Tax Documents";
+        final String type = "finite";
+        final int length = 365;
+        final String action = BoxRetentionPolicy.ACTION_PERMANENTLY_DELETE;
+        final String status = "active";
+        final String userID = "11993747";
+        final String userName = "Sean";
+        final String userLogin = "sean@box.com";
+        final Date createdAt = BoxDateFormat.parse("2015-05-01T11:12:54-07:00");
+        final Date modifiedAt = null;
+
+        final JsonObject fakeJSONResponse = JsonObject.readFrom("{\n"
+                + "  \"type\": \"retention_policy\",\n"
+                + "  \"id\": \"123456789\",\n"
+                + "  \"policy_name\": \"Tax Documents\",\n"
+                + "  \"policy_type\": \"finite\",\n"
+                + "  \"retention_length\": 365,\n"
+                + "  \"disposition_action\": \"permanently_delete\",\n"
+                + "  \"status\": \"active\",\n"
+                + "  \"created_by\": {\n"
+                + "    \"type\": \"user\",\n"
+                + "    \"id\": \"11993747\",\n"
+                + "    \"name\": \"Sean\",\n"
+                + "    \"login\": \"sean@box.com\"\n"
+                + "  },\n"
+                + "  \"created_at\": \"2015-05-01T11:12:54-07:00\",\n"
+                + "  \"modified_at\": null \n"
+                + "}");
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(JSONRequestInterceptor.respondWith(fakeJSONResponse));
+
+        BoxRetentionPolicy.Info info = BoxRetentionPolicy.createFinitePolicy(api, name, length, action);
+        Assert.assertEquals(id, info.getID());
+        Assert.assertEquals(name, info.getPolicyName());
+        Assert.assertEquals(type, info.getPolicyType());
+        Assert.assertEquals(length, info.getRetentionLength());
+        Assert.assertEquals(action, info.getDispositionAction());
+        Assert.assertEquals(status, info.getStatus());
+        Assert.assertEquals(userID, info.getCreatedBy().getID());
+        Assert.assertEquals(userName, info.getCreatedBy().getName());
+        Assert.assertEquals(userLogin, info.getCreatedBy().getLogin());
+        Assert.assertEquals(createdAt, info.getCreatedAt());
+        Assert.assertEquals(modifiedAt, info.getModifiedAt());
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#updateInfo(BoxRetentionPolicy.Info)} )}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testUpdateInfoSendsCorrectJson() {
+        final String name = "Non-empty name";
+        final String action = BoxRetentionPolicy.ACTION_REMOVE_RETENTION;
+        final String status = BoxRetentionPolicy.STATUS_RETIRED;
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new JSONRequestInterceptor() {
+            @Override
+            protected BoxAPIResponse onJSONRequest(BoxJSONRequest request, JsonObject json) {
+                Assert.assertEquals("https://api.box.com/2.0/retention_policies/0", request.getUrl().toString());
+                Assert.assertEquals(name, json.get("policy_name").asString());
+                Assert.assertEquals(action, json.get("disposition_action").asString());
+                Assert.assertEquals(status, json.get("status").asString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{}";
+                    }
+                };
+            }
+        });
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(api, "0");
+        BoxRetentionPolicy.Info info = policy.new Info();
+        info.addPendingChange("policy_name", name);
+        info.addPendingChange("disposition_action", action);
+        info.addPendingChange("status", status);
+        policy.updateInfo(info);
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#updateInfo(BoxRetentionPolicy.Info)} )}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testUpdateInfoParseAllFieldsCorrectly() throws ParseException {
+        final String id = "123456789";
+        final String name = "Tax Documents";
+        final String type = "finite";
+        final int length = 365;
+        final String action = BoxRetentionPolicy.ACTION_REMOVE_RETENTION;
+        final String status = "active";
+        final String userID = "11993747";
+        final String userName = "Sean";
+        final String userLogin = "sean@box.com";
+        final Date createdAt = BoxDateFormat.parse("2015-05-01T11:12:54-07:00");
+        final Date modifiedAt = BoxDateFormat.parse("2015-06-08T11:11:50-07:00");
+
+        final JsonObject fakeJSONResponse = JsonObject.readFrom("{     \n"
+                + "  \"type\": \"retention_policy\",     \n"
+                + "  \"id\": \"123456789\",     \n"
+                + "  \"policy_name\": \"Tax Documents\", \n"
+                + "  \"policy_type\": \"finite\",     \n"
+                + "  \"retention_length\": 365,     \n"
+                + "  \"disposition_action\": \"remove_retention\",  \n"
+                + "  \"status\": \"active\",     \n"
+                + "  \"created_by\": {\n"
+                + "    \"type\": \"user\",\n"
+                + "    \"id\": \"11993747\",\n"
+                + "    \"name\": \"Sean\",\n"
+                + "    \"login\": \"sean@box.com\"\n"
+                + "  },\n"
+                + "  \"created_at\": \"2015-05-01T11:12:54-07:00\",\n"
+                + "  \"modified_at\": \"2015-06-08T11:11:50-07:00\" \n"
+                + "}");
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(JSONRequestInterceptor.respondWith(fakeJSONResponse));
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(api, "123456789");
+        BoxRetentionPolicy.Info info = policy.new Info();
+        info.addPendingChange("policy_name", name);
+        policy.updateInfo(info);
+        Assert.assertEquals(id, info.getID());
+        Assert.assertEquals(name, info.getPolicyName());
+        Assert.assertEquals(type, info.getPolicyType());
+        Assert.assertEquals(length, info.getRetentionLength());
+        Assert.assertEquals(action, info.getDispositionAction());
+        Assert.assertEquals(status, info.getStatus());
+        Assert.assertEquals(userID, info.getCreatedBy().getID());
+        Assert.assertEquals(userName, info.getCreatedBy().getName());
+        Assert.assertEquals(userLogin, info.getCreatedBy().getLogin());
+        Assert.assertEquals(createdAt, info.getCreatedAt());
+        Assert.assertEquals(modifiedAt, info.getModifiedAt());
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#getInfo(String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetInfoSendsCorrectRequest() {
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                Assert.assertEquals("https://api.box.com/2.0/retention_policies/0?fields=policy_name%2Cstatus",
+                        request.getUrl().toString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"id\": \"0\"}";
+                    }
+                };
+            }
+        });
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(api, "0");
+        policy.getInfo("policy_name", "status");
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#getInfo(String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetInfoParseAllFieldsCorrectly() throws ParseException {
+        final String id = "123456789";
+        final String name = "Tax Documents";
+        final String type = "finite";
+        final int length = 365;
+        final String action = BoxRetentionPolicy.ACTION_REMOVE_RETENTION;
+        final String status = "active";
+        final String userID = "11993747";
+        final String userName = "Sean";
+        final String userLogin = "sean@box.com";
+        final Date createdAt = BoxDateFormat.parse("2015-05-01T11:12:54-07:00");
+        final Date modifiedAt = BoxDateFormat.parse("2015-06-08T11:11:50-07:00");
+
+        final JsonObject fakeJSONResponse = JsonObject.readFrom("{\n"
+                + "  \"type\": \"retention_policy\",     \n"
+                + "  \"id\": \"123456789\",     \n"
+                + "  \"policy_name\": \"Tax Documents\",  \n"
+                + "  \"policy_type\": \"finite\",     \n"
+                + "  \"retention_length\": 365,     \n"
+                + "  \"disposition_action\": \"remove_retention\",  \n"
+                + "  \"status\": \"active\",     \n"
+                + "  \"created_by\": {\n"
+                + "    \"type\": \"user\",\n"
+                + "    \"id\": \"11993747\",\n"
+                + "    \"name\": \"Sean\",\n"
+                + "    \"login\": \"sean@box.com\"\n"
+                + "  },\n"
+                + "  \"created_at\": \"2015-05-01T11:12:54-07:00\",\n"
+                + "  \"modified_at\": \"2015-06-08T11:11:50-07:00\" \n"
+                + "}");
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(JSONRequestInterceptor.respondWith(fakeJSONResponse));
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(api, "123456789");
+        BoxRetentionPolicy.Info info = policy.getInfo();
+        Assert.assertEquals(id, info.getID());
+        Assert.assertEquals(name, info.getPolicyName());
+        Assert.assertEquals(type, info.getPolicyType());
+        Assert.assertEquals(length, info.getRetentionLength());
+        Assert.assertEquals(action, info.getDispositionAction());
+        Assert.assertEquals(status, info.getStatus());
+        Assert.assertEquals(userID, info.getCreatedBy().getID());
+        Assert.assertEquals(userName, info.getCreatedBy().getName());
+        Assert.assertEquals(userLogin, info.getCreatedBy().getLogin());
+        Assert.assertEquals(createdAt, info.getCreatedAt());
+        Assert.assertEquals(modifiedAt, info.getModifiedAt());
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#getAll(String, String, String, int, BoxAPIConnection, String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetAllSendsCorrectRequestWithParams() {
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                Assert.assertEquals("https://api.box.com/2.0/retention_policies?"
+                                + "policy_name=any_name&policy_type=any_type&created_by_user_id=any_user&"
+                                + "fields=status&limit=100",
+                        request.getUrl().toString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"entries\": []}";
+                    }
+                };
+            }
+        });
+
+        Iterator<BoxRetentionPolicy.Info> iterator =
+                BoxRetentionPolicy.getAll("any_name", "any_type", "any_user", 100, api, "status").iterator();
+        iterator.hasNext();
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#getAll(BoxAPIConnection, String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetAllSendsCorrectRequestWithoutParams() {
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                Assert.assertEquals("https://api.box.com/2.0/retention_policies?limit=100",
+                        request.getUrl().toString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"entries\": []}";
+                    }
+                };
+            }
+        });
+
+        Iterator<BoxRetentionPolicy.Info> iterator = BoxRetentionPolicy.getAll(api).iterator();
+        iterator.hasNext();
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#getAll(BoxAPIConnection, String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetAllParseAllFieldsCorrectly() {
+        final String firstID = "123456789";
+        final String firstName = "TaxDocuments";
+        final String secondID = "987654321";
+        final String secondName = "DutyPapers";
+
+        final JsonObject fakeJSONResponse = JsonObject.readFrom("{\n"
+                + "  \"entries\": [\n"
+                + "    {\n"
+                + "      \"type\": \"retention_policy\",\n"
+                + "      \"id\": \"123456789\",\n"
+                + "      \"policy_name\": \"TaxDocuments\"\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"type\": \"retention_policy\",\n"
+                + "      \"id\": \"987654321\",\n"
+                + "      \"policy_name\": \"DutyPapers\"\n"
+                + "    }\n"
+                + "  ] \n"
+                + "}");
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(JSONRequestInterceptor.respondWith(fakeJSONResponse));
+
+        Iterator<BoxRetentionPolicy.Info> iterator = BoxRetentionPolicy.getAll(api).iterator();
+        BoxRetentionPolicy.Info info = iterator.next();
+        Assert.assertEquals(firstID, info.getID());
+        Assert.assertEquals(firstName, info.getPolicyName());
+        info = iterator.next();
+        Assert.assertEquals(secondID, info.getID());
+        Assert.assertEquals(secondName, info.getPolicyName());
+        Assert.assertEquals(false, iterator.hasNext());
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#getFolderAssignments(String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetFolderAssignmentsSendsCorrectRequest() {
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                Assert.assertEquals(
+                        "https://api.box.com/2.0/retention_policies/0/assignments"
+                                + "?type=folder&fields=assigned_by&limit=100",
+                        request.getUrl().toString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"entries\": []}";
+                    }
+                };
+            }
+        });
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(api, "0");
+        Iterator<BoxRetentionPolicyAssignment.Info> iterator = policy.getFolderAssignments("assigned_by").iterator();
+        iterator.hasNext();
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#getEnterpriseAssignments(String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetEnterpriseAssignmentsSendsCorrectRequest() {
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                Assert.assertEquals(
+                        "https://api.box.com/2.0/retention_policies/0/assignments"
+                                + "?type=enterprise&fields=assigned_by&limit=100",
+                        request.getUrl().toString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"entries\": []}";
+                    }
+                };
+            }
+        });
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(api, "0");
+        Iterator<BoxRetentionPolicyAssignment.Info> iterator
+            = policy.getEnterpriseAssignments("assigned_by").iterator();
+        iterator.hasNext();
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#getAllAssignments(String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetAllAssignmentsSendsCorrectRequest() {
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                Assert.assertEquals(
+                        "https://api.box.com/2.0/retention_policies/0/assignments"
+                                + "?fields=assigned_by&limit=100",
+                        request.getUrl().toString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"entries\": []}";
+                    }
+                };
+            }
+        });
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(api, "0");
+        Iterator<BoxRetentionPolicyAssignment.Info> iterator = policy.getAllAssignments("assigned_by").iterator();
+        iterator.hasNext();
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#getFolderAssignments(String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetFolderAssignmentsParseAllFieldsCorrectly() {
+        final String firstID = "12345678";
+        final String secondID = "23456789";
+
+        final JsonObject fakeJSONResponse = JsonObject.readFrom("{\n"
+                + "  \"entries\": [\n"
+                + "    {\n"
+                + "      \"type\": \"retention_policy_assignment\",\n"
+                + "      \"id\": \"12345678\"\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"type\": \"retention_policy_assignment\",\n"
+                + "      \"id\": \"23456789\"\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}");
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(JSONRequestInterceptor.respondWith(fakeJSONResponse));
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(api, "0");
+        Iterator<BoxRetentionPolicyAssignment.Info> iterator = policy.getFolderAssignments().iterator();
+        BoxRetentionPolicyAssignment.Info info = iterator.next();
+        Assert.assertEquals(firstID, info.getID());
+        info = iterator.next();
+        Assert.assertEquals(secondID, info.getID());
+        Assert.assertEquals(false, iterator.hasNext());
+
+    }
+
+    /**
+     * Unit test for {@link BoxRetentionPolicy#getEnterpriseAssignments(String...)}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testGetEnterpriseAssignmentsParseAllFieldsCorrectly() {
+        final String firstID = "12345678";
+        final String secondID = "23456789";
+
+        final JsonObject fakeJSONResponse = JsonObject.readFrom("{\n"
+                + "  \"entries\": [\n"
+                + "    {\n"
+                + "      \"type\": \"retention_policy_assignment\",\n"
+                + "      \"id\": \"12345678\"\n"
+                + "    },\n"
+                + "    {\n"
+                + "      \"type\": \"retention_policy_assignment\",\n"
+                + "      \"id\": \"23456789\"\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}");
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(JSONRequestInterceptor.respondWith(fakeJSONResponse));
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(api, "0");
+        Iterator<BoxRetentionPolicyAssignment.Info> iterator = policy.getEnterpriseAssignments().iterator();
+        BoxRetentionPolicyAssignment.Info info = iterator.next();
+        Assert.assertEquals(firstID, info.getID());
+        info = iterator.next();
+        Assert.assertEquals(secondID, info.getID());
+        Assert.assertEquals(false, iterator.hasNext());
+    }
+
+}


### PR DESCRIPTION
Create Retention Policy Assignment implemented as assignTo(..) and assignToEnterprise(..) methods of BoxRetentionPolicy object.

Get Retention Policy Assignment implemented as getInfo(..) method of BoxRetentionPolicyAssignment method.

 Get Retention Policy Assignments features implemented as getFolderAssignments(..), getEnterpriceAssignments(..) and getAllAssignments(..) methods of BoxRetentionPolicy object.

Methods are covered with unit tests and documented.
Pull request contains code from [Retention Policies basic features](https://github.com/box/box-java-sdk/pull/317)