### PR TITLE
Fixed and tests for Delete and Promote File Version

### DIFF
--- a/src/main/java/com/box/sdk/BoxFileVersion.java
+++ b/src/main/java/com/box/sdk/BoxFileVersion.java
@@ -19,7 +19,7 @@ public class BoxFileVersion extends BoxResource {
     private static final URLTemplate VERSION_URL_TEMPLATE = new URLTemplate("files/%s/versions/%s");
     private static final int BUFFER_SIZE = 8192;
 
-    private final String fileID;
+    private String fileID;
 
     private String versionID;
     private String sha1;
@@ -44,6 +44,14 @@ public class BoxFileVersion extends BoxResource {
         super(api, jsonObject.get("id").asString());
 
         this.fileID = fileID;
+        this.parseJSON(jsonObject);
+    }
+
+    /**
+     * Method used to update fields with values received from API.
+     * @param jsonObject JSON-encoded info about File Version object.
+     */
+    private void parseJSON(JsonObject jsonObject) {
         for (JsonObject.Member member : jsonObject) {
             JsonValue value = member.getValue();
             if (value.isNull()) {
@@ -76,6 +84,21 @@ public class BoxFileVersion extends BoxResource {
                 assert false : "A ParseException indicates a bug in the SDK.";
             }
         }
+    }
+
+    /**
+     * Used if no or wrong file id was set with constructor.
+     * @param fileID the file id this file version belongs to.
+     */
+    public void setFileID(String fileID) {
+        this.fileID = fileID;
+    }
+
+    /**
+     * @return the file id this file version belongs to.
+     */
+    public String getFileID() {
+        return this.fileID;
     }
 
     /**
@@ -200,7 +223,8 @@ public class BoxFileVersion extends BoxResource {
 
         BoxJSONRequest request = new BoxJSONRequest(this.getAPI(), url, "POST");
         request.setBody(jsonObject.toString());
-        BoxAPIResponse response = request.send();
+        BoxJSONResponse response = (BoxJSONResponse) request.send();
         response.disconnect();
+        this.parseJSON(JsonObject.readFrom(response.getJSON()));
     }
 }

--- a/src/test/java/com/box/sdk/BoxFileVersionTest.java
+++ b/src/test/java/com/box/sdk/BoxFileVersionTest.java
@@ -1,0 +1,120 @@
+package com.box.sdk;
+
+import java.text.ParseException;
+import java.util.Date;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.eclipsesource.json.JsonObject;
+
+/**
+ * {@link BoxFileVersion} related tests.
+ */
+public class BoxFileVersionTest {
+
+    /**
+     * Unit test for {@link BoxFileVersion#delete()}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testDeleteSendsCorrectRequest() {
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                Assert.assertEquals("https://api.box.com/2.0/files/0/versions/1",
+                        request.getUrl().toString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"id\": \"0\"}";
+                    }
+                };
+            }
+        });
+
+        BoxFile file = new BoxFile(api, "0");
+        BoxFileVersion version = new BoxFileVersion(api, new JsonObject().add("id", "1"), file.getID());
+        version.delete();
+    }
+
+    /**
+     * Unit test for {@link BoxFileVersion#promote()}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testPromoteSendsCorrectJSON() {
+        final String type = "file_version";
+        final String id = "1";
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new JSONRequestInterceptor() {
+            @Override
+            protected BoxAPIResponse onJSONRequest(BoxJSONRequest request, JsonObject json) {
+                Assert.assertEquals("https://api.box.com/2.0/files/0/versions/current", request.getUrl().toString());
+                Assert.assertEquals(type, json.get("type").asString());
+                Assert.assertEquals(id, json.get("id").asString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"id\": \"0\"}";
+                    }
+                };
+            }
+        });
+
+        BoxFileVersion version = new BoxFileVersion(api, new JsonObject().add("id", "1"), "0");
+        version.promote();
+    }
+
+    /**
+     * Unit test for {@link BoxFileVersion#promote()}
+     */
+    @Test
+    @Category(UnitTest.class)
+    public void testPromoteParseAllFieldsCorrectly() throws ParseException {
+        final String id = "871399";
+        final String sha1 = "12039d6dd9a7e6eefc78846802e";
+        final String name = "Stark Family Lineage.doc";
+        final long size = 11;
+        final Date createdAt = BoxDateFormat.parse("2013-11-20T13:20:50-08:00");
+        final Date modifiedAt = BoxDateFormat.parse("2013-11-20T13:26:48-08:00");
+        final String modifiedById = "13711334";
+        final String modifiedByName = "Eddard Stark";
+        final String modifiedByLogin = "ned@winterfell.com";
+
+        final JsonObject fakeJSONResponse = JsonObject.readFrom("{\n"
+                + "    \"type\": \"file_version\",\n"
+                + "    \"id\": \"871399\",\n"
+                + "    \"sha1\": \"12039d6dd9a7e6eefc78846802e\",\n"
+                + "    \"name\": \"Stark Family Lineage.doc\",\n"
+                + "    \"size\": 11,\n"
+                + "    \"created_at\": \"2013-11-20T13:20:50-08:00\",\n"
+                + "    \"modified_at\": \"2013-11-20T13:26:48-08:00\",\n"
+                + "    \"modified_by\": {\n"
+                + "        \"type\": \"user\",\n"
+                + "        \"id\": \"13711334\",\n"
+                + "        \"name\": \"Eddard Stark\",\n"
+                + "        \"login\": \"ned@winterfell.com\"\n"
+                + "    }\n"
+                + "}");
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(JSONRequestInterceptor.respondWith(fakeJSONResponse));
+
+        BoxFileVersion version = new BoxFileVersion(api, new JsonObject().add("id", id), "0");
+        version.promote();
+        Assert.assertEquals(id, version.getID());
+        Assert.assertEquals(sha1, version.getSha1());
+        Assert.assertEquals(name, version.getName());
+        Assert.assertEquals(size, version.getSize());
+        Assert.assertEquals(createdAt, version.getCreatedAt());
+        Assert.assertEquals(modifiedAt, version.getModifiedAt());
+        Assert.assertEquals(modifiedById, version.getModifiedBy().getID());
+        Assert.assertEquals(modifiedByName, version.getModifiedBy().getName());
+        Assert.assertEquals(modifiedByLogin, version.getModifiedBy().getLogin());
+
+    }
+}


### PR DESCRIPTION
BoxFileVersion object refactored:
- provided opportunity to set associated file's id not only thru constructor;
-  API response json object, obtained thru promote() call, now parsed to update fields of the object;

Unit tests were added for Delete Old Version and Promote Version (delete() and promote() methods)