### PR TITLE
Allow deserialisation of BoxEvents for WebLinks (413 fix)

### DIFF
--- a/src/main/java/com/box/sdk/BoxResource.java
+++ b/src/main/java/com/box/sdk/BoxResource.java
@@ -61,6 +61,7 @@ public abstract class BoxResource {
         result.put(getResourceType(BoxLegalHoldAssignment.class), BoxLegalHoldAssignment.class);
         result.put(getResourceType(BoxFileVersionLegalHold.class), BoxFileVersionLegalHold.class);
         result.put(getResourceType(BoxFileUploadSession.class), BoxFileUploadSession.class);
+        result.put(getResourceType(BoxWebLink.class), BoxWebLink.class);
 
         return Collections.unmodifiableMap(result);
     }


### PR DESCRIPTION
Added the BoxWebLink to the RESOURCE_CLASS_BY_TYPE map so web_link related BoxEvents can be successfully deserialised and won't have null sourceInfo.

Closes #413