### PR TITLE
Don't allow multiple As-User headers in Box api requests

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -9,6 +9,7 @@ import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -81,7 +82,16 @@ public class BoxAPIRequest {
      * @param key   the header key.
      * @param value the header value.
      */
-    public void addHeader(String key, String value) {
+    public void addHeader(final String key, String value) {
+        if ("As-User".equals(key)) {
+            Iterator<RequestHeader> iterator = this.headers.iterator();
+            while (iterator.hasNext()) {
+                RequestHeader rh = iterator.next();
+                if (rh.getKey().equals(key)) {
+                    iterator.remove();
+                }
+            }
+        }
         this.headers.add(new RequestHeader(key, value));
     }
 


### PR DESCRIPTION
Don't allow people to create duplicate as-user headers.

This can prevent issues when people use setRequestInterceptor to simulate users but accidentally end up with multiple as-users when sharing api connections.

https://github.com/box/box-java-sdk/issues/429

this probably isn't the best way to do it... but it was the easiest for me to prevent people from accidentally getting multiple as-users from the request interceptor stuff.

Failure to do this will result in error message like below if you have more than one as-user specified:

`Cannot make request On Behalf of User is not found "235235233, 2352352352"`