### PR TITLE
Issue #438 and #431 - For API 403 rate limit responses, use the `RetryAfter` header in the retry logic.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ sourceCompatibility = 1.6
 
 group = 'com.box'
 archivesBaseName = 'box-java-sdk'
-version = '2.4.0-SNAPSHOT'
+version = '2.4.0'
 
 repositories {
     mavenCentral()

--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -239,7 +239,7 @@ public class BoxAPIRequest {
                 if (isExceptionWithRetryAfter) {
                     BoxAPIRetryableException retryEx = (BoxAPIRetryableException) apiException;
                     LOGGER.info("Encountered a 403 Error with Retry-After header of " + retryEx.getRetryAfter()
-                            + "s. Sleeping this thread that amount and trying again..");
+                            + "s. Sleeping this thread that amount and trying again.");
                     try {
                         Thread.sleep(retryEx.getRetryAfter() * 1000);
                     } catch (InterruptedException interruptedEx) {
@@ -505,7 +505,7 @@ public class BoxAPIRequest {
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.log(Level.FINE, this.toString());
         } else {
-            LOGGER.log(Level.INFO, "Box API Call Counter {} ", ATOMIC_COUNTER.incrementAndGet());
+            LOGGER.log(Level.INFO, "Box API Call Counter {0}", ATOMIC_COUNTER.incrementAndGet());
         }
     }
 

--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -93,20 +93,26 @@ public class BoxAPIRequest {
 
     /**
      * Adds an HTTP header to this request.
+     *
      * @param key   the header key.
      * @param value the header value.
      */
     public void addHeader(final String key, String value) {
-        if ("As-User".equals(key)) {
-            Iterator<RequestHeader> iterator = this.headers.iterator();
-            while (iterator.hasNext()) {
-                RequestHeader rh = iterator.next();
-                if (rh.getKey().equals(key)) {
-                    iterator.remove();
-                }
+        this.headers.add(new RequestHeader(key, value));
+    }
+
+    /**
+     * Remove an http header from the request.
+     * @param key The header key or keys to remove.
+     */
+    public void removeHeader(final String key) {
+        Iterator<RequestHeader> rhIterator = this.headers.iterator();
+        while (rhIterator.hasNext()) {
+            RequestHeader rh = rhIterator.next();
+            if (rh.getKey().equals(key)) {
+                rhIterator.remove();
             }
         }
-        this.headers.add(new RequestHeader(key, value));
     }
 
     /**

--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -9,6 +9,7 @@ import java.net.MalformedURLException;
 import java.net.ProtocolException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -95,7 +96,16 @@ public class BoxAPIRequest {
      * @param key   the header key.
      * @param value the header value.
      */
-    public void addHeader(String key, String value) {
+    public void addHeader(final String key, String value) {
+        if ("As-User".equals(key)) {
+            Iterator<RequestHeader> iterator = this.headers.iterator();
+            while (iterator.hasNext()) {
+                RequestHeader rh = iterator.next();
+                if (rh.getKey().equals(key)) {
+                    iterator.remove();
+                }
+            }
+        }
         this.headers.add(new RequestHeader(key, value));
     }
 

--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -506,8 +506,8 @@ public class BoxAPIRequest {
     private void logRequest(HttpURLConnection connection) {
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.log(Level.FINE, this.toString());
+            LOGGER.log(Level.FINE, "Box API Call Counter {0}", ATOMIC_COUNTER.incrementAndGet());
         }
-        LOGGER.log(Level.SEVERE, "Box API Call Counter {0}", ATOMIC_COUNTER.incrementAndGet());
     }
 
     private HttpURLConnection createConnection() {

--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -507,7 +507,7 @@ public class BoxAPIRequest {
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.log(Level.FINE, this.toString());
         }
-        LOGGER.log(Level.DEBUG, "Box API Call Counter {0}", ATOMIC_COUNTER.incrementAndGet());
+        LOGGER.log(Level.SEVERE, "Box API Call Counter {0}", ATOMIC_COUNTER.incrementAndGet());
     }
 
     private HttpURLConnection createConnection() {

--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -37,7 +37,7 @@ public class BoxAPIRequest {
     private static final Logger LOGGER = Logger.getLogger(BoxAPIRequest.class.getName());
     private static final int BUFFER_SIZE = 8192;
     private static final int MAX_REDIRECTS = 3;
-    private static AtomicInteger ATOMIC_COUNTER = new AtomicInteger(0);
+    private static final AtomicInteger ATOMIC_COUNTER = new AtomicInteger(0);
 
     private final BoxAPIConnection api;
     private final List<RequestHeader> headers;
@@ -227,11 +227,11 @@ public class BoxAPIRequest {
                 }
                 boolean isExceptionWithRetryAfter = apiException instanceof BoxAPIRetryableException;
                 if (isExceptionWithRetryAfter) {
-                    BoxAPIRetryableException retryEx = (BoxAPIRetryableException)apiException;
+                    BoxAPIRetryableException retryEx = (BoxAPIRetryableException) apiException;
                     LOGGER.info("Encountered a 403 Error with Retry-After header of " + retryEx.getRetryAfter()
                             + "s. Sleeping this thread that amount and trying again..");
                     try {
-                        Thread.sleep(retryEx.getRetryAfter()*1000);
+                        Thread.sleep(retryEx.getRetryAfter() * 1000);
                     } catch (InterruptedException interruptedEx) {
                         Thread.currentThread().interrupt();
                         throw apiException;

--- a/src/main/java/com/box/sdk/BoxAPIResponse.java
+++ b/src/main/java/com/box/sdk/BoxAPIResponse.java
@@ -68,8 +68,9 @@ public class BoxAPIResponse {
             this.logResponse();
             String retryAfterHeader = this.connection.getHeaderField("Retry-After");
             if (retryAfterHeader != null && !retryAfterHeader.trim().isEmpty()) {
-                throw new BoxAPIRetryableException("The API returned an error code: " + this.responseCode, this.responseCode,
-                        this.bodyToString(), Integer.parseInt(retryAfterHeader));
+                throw new BoxAPIRetryableException("The API returned an error code: "
+                        + this.responseCode, this.responseCode, this.bodyToString(),
+                        Integer.parseInt(retryAfterHeader));
             } else {
                 throw new BoxAPIException("The API returned an error code: " + this.responseCode, this.responseCode,
                         this.bodyToString());

--- a/src/main/java/com/box/sdk/BoxAPIResponse.java
+++ b/src/main/java/com/box/sdk/BoxAPIResponse.java
@@ -66,8 +66,15 @@ public class BoxAPIResponse {
 
         if (!isSuccess(this.responseCode)) {
             this.logResponse();
-            throw new BoxAPIException("The API returned an error code: " + this.responseCode, this.responseCode,
-                this.bodyToString());
+            String retryAfterHeader = this.connection.getHeaderField("Retry-After");
+            if (retryAfterHeader != null && !retryAfterHeader.trim().isEmpty()) {
+                throw new BoxAPIRetryableException("The API returned an error code: " + this.responseCode, this.responseCode,
+                        this.bodyToString(), Integer.parseInt(retryAfterHeader));
+            } else {
+                throw new BoxAPIException("The API returned an error code: " + this.responseCode, this.responseCode,
+                        this.bodyToString());
+            }
+
         }
 
         this.logResponse();

--- a/src/main/java/com/box/sdk/BoxAPIRetryableException.java
+++ b/src/main/java/com/box/sdk/BoxAPIRetryableException.java
@@ -1,42 +1,45 @@
 package com.box.sdk;
 
 /**
- * Thrown for rate limit responses: HTTP/1.1 429 Too Many Requests
- *
+ * Thrown for rate limit responses: HTTP/1.1 429 Too Many Requests.
+ * <p>
  * In such a case you will get a special header:
- *
+ * <p>
  * Retry-After: {retry time in seconds}
- *
+ * <p>
  * This class extends the BoxAPIException
  */
 public class BoxAPIRetryableException extends BoxAPIException {
+    private static final long serialVersionUID = 1L;
 
-  int retryAfter;
+    private int retryAfter;
 
-  public BoxAPIRetryableException(String message, int retryAfter) {
-    super(message);
-  }
+    /**
+     * Constructs a BoxAPIRetryableException - these exceptions have a retry after header that they
+     * should wait before being retried.
+     * @param message The error message.
+     * @param retryAfter The number of seconds to retry.
+     * @param responseCode The https status code of the response
+     * @param response String containing the json response of the error.
+     */
+    public BoxAPIRetryableException(String message, int responseCode, String response, int retryAfter) {
+        super(message, responseCode, response);
+        this.retryAfter = retryAfter;
+    }
 
-  public BoxAPIRetryableException(String message, int responseCode, String response, int retryAfter) {
-    super(message, responseCode, response);
-  }
+    /**
+     * Returns the number of seconds you have to wait before trying will be successful.
+     * @return The number of seconds to retry in seconds.
+     */
+    public int getRetryAfter() {
+        return this.retryAfter;
+    }
 
-  public BoxAPIRetryableException(String message, Throwable cause, int retryAfter) {
-    super(message, cause);
-  }
-
-  public BoxAPIRetryableException(String message, int responseCode, String response, Throwable cause, int retryAfter) {
-    super(message, responseCode, response, cause);
-  }
-
-  /**
-   * Returns the number of seconds you have to wait before trying will be successful.
-   */
-  public int getRetryAfter() {
-    return retryAfter;
-  }
-
-  public void setRetryAfter(int retryAfter) {
-    this.retryAfter = retryAfter;
-  }
+    /**
+     * Set the retry after in seconds.
+     * @param retryAfter How long to wait in seconds.
+     */
+    public void setRetryAfter(int retryAfter) {
+        this.retryAfter = retryAfter;
+    }
 }

--- a/src/main/java/com/box/sdk/BoxAPIRetryableException.java
+++ b/src/main/java/com/box/sdk/BoxAPIRetryableException.java
@@ -1,0 +1,42 @@
+package com.box.sdk;
+
+/**
+ * Thrown for rate limit responses: HTTP/1.1 429 Too Many Requests
+ *
+ * In such a case you will get a special header:
+ *
+ * Retry-After: {retry time in seconds}
+ *
+ * This class extends the BoxAPIException
+ */
+public class BoxAPIRetryableException extends BoxAPIException {
+
+  int retryAfter;
+
+  public BoxAPIRetryableException(String message, int retryAfter) {
+    super(message);
+  }
+
+  public BoxAPIRetryableException(String message, int responseCode, String response, int retryAfter) {
+    super(message, responseCode, response);
+  }
+
+  public BoxAPIRetryableException(String message, Throwable cause, int retryAfter) {
+    super(message, cause);
+  }
+
+  public BoxAPIRetryableException(String message, int responseCode, String response, Throwable cause, int retryAfter) {
+    super(message, responseCode, response, cause);
+  }
+
+  /**
+   * Returns the number of seconds you have to wait before trying will be successful.
+   */
+  public int getRetryAfter() {
+    return retryAfter;
+  }
+
+  public void setRetryAfter(int retryAfter) {
+    this.retryAfter = retryAfter;
+  }
+}

--- a/src/main/java/com/box/sdk/BoxEvent.java
+++ b/src/main/java/com/box/sdk/BoxEvent.java
@@ -609,6 +609,11 @@ public class BoxEvent extends BoxResource {
         /**
          * Content Workflow upload policy violation. This is an enterprise-only event.
          */
-        CONTENT_WORKFLOW_UPLOAD_POLICY_VIOLATION;
+        CONTENT_WORKFLOW_UPLOAD_POLICY_VIOLATION,
+
+        /**
+         * Event for file tag updates.
+         */
+        CONTENT_ACCESS;
     }
 }


### PR DESCRIPTION
Addresses https://github.com/box/box-java-sdk/issues/438 The box java sdk needs to have api requests have the ability to honor the RetryAfter header if 403 error code is returned.

When you get a 403 with a `RetryAfter` header it should display a message like this: `Encountered a 403 Error with Retry-After header of 1s. Sleeping this thread that amount and trying again.` then it should sleep the current thread until the time has elapsed before retrying.

I also added in https://github.com/box/box-java-sdk/pull/431

And I added an API count ticker on the FINE logging level for people who need to keep track of exact counts when doing large numbers of api calls during recursive directory file access