### PR TITLE
Ability to set connect and read timeout globally.

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -43,7 +43,8 @@ public class BoxAPIRequest {
 
     private URL url;
     private BackoffCounter backoffCounter;
-    private int timeout;
+    private int connectTimeout;
+    private int readTimeout;
     private InputStream body;
     private long bodyLength;
     private Map<String, List<String>> requestProperties;
@@ -73,6 +74,8 @@ public class BoxAPIRequest {
         this.headers = new ArrayList<RequestHeader>();
         this.backoffCounter = new BackoffCounter(new Time());
         this.shouldAuthenticate = true;
+        this.connectTimeout = BoxGlobalSettings.getConnectTimeout();
+        this.readTimeout = BoxGlobalSettings.getReadTimeout();
 
         this.addHeader("Accept-Encoding", "gzip");
         this.addHeader("Accept-Charset", "utf-8");
@@ -104,14 +107,22 @@ public class BoxAPIRequest {
     }
 
     /**
-     * Sets a timeout for this request in milliseconds.
+     * Sets a Connect timeout for this request in milliseconds.
      * @param timeout the timeout in milliseconds.
      */
-    public void setTimeout(int timeout) {
-        this.timeout = timeout;
+    public void setConnectTimeout(int timeout) {
+        this.connectTimeout = timeout;
     }
 
     /**
+     * Sets a read timeout for this request in milliseconds.
+     * @param timeout the timeout in milliseconds.
+     */
+    public void setReadTimeout(int timeout) {
+        this.readTimeout = timeout;
+    }
+
+  /**
      * Sets whether or not to follow redirects (i.e. Location header)
      * @param followRedirects true to follow, false to not follow
      */
@@ -507,8 +518,8 @@ public class BoxAPIRequest {
             throw new BoxAPIException("Couldn't connect to the Box API because the request's method was invalid.", e);
         }
 
-        connection.setConnectTimeout(this.timeout);
-        connection.setReadTimeout(this.timeout);
+        connection.setConnectTimeout(this.connectTimeout);
+        connection.setReadTimeout(this.readTimeout);
 
         // Don't allow HttpURLConnection to automatically redirect because it messes up the connection pool. See the
         // trySend(ProgressListener) method for how we handle redirects.

--- a/src/main/java/com/box/sdk/BoxGlobalSettings.java
+++ b/src/main/java/com/box/sdk/BoxGlobalSettings.java
@@ -1,0 +1,44 @@
+package com.box.sdk;
+
+/**
+ * Global settings to apply to all API requests.
+ */
+public final class BoxGlobalSettings {
+    private static int connectTimeout = 0;
+    private static int readTimeout = 0;
+
+    private BoxGlobalSettings() {
+    }
+
+    /**
+     * Returns the current global connect timeout.
+     * @return connect timeout
+     */
+    public static int getConnectTimeout() {
+        return connectTimeout;
+    }
+
+    /**
+     * Sets the global connect timeout.
+     * @param connectTimeout timeout in milliseconds
+     */
+    public static void setConnectTimeout(int connectTimeout) {
+        BoxGlobalSettings.connectTimeout = connectTimeout;
+    }
+
+    /**
+     * Returns the current global read timeout.
+     * @return read timeout
+     */
+    public static int getReadTimeout() {
+        return readTimeout;
+    }
+
+    /**
+     * Sets the global read timeout.
+     * @param readTimeout timeout in milliseconds
+     */
+    public static void setReadTimeout(int readTimeout) {
+        BoxGlobalSettings.readTimeout = readTimeout;
+    }
+}

--- a/src/main/java/com/box/sdk/RealtimeServerConnection.java
+++ b/src/main/java/com/box/sdk/RealtimeServerConnection.java
@@ -50,7 +50,8 @@ class RealtimeServerConnection {
             this.retries--;
             try {
                 BoxAPIRequest request = new BoxAPIRequest(this.api, url, "GET");
-                request.setTimeout(this.timeout * 1000);
+                request.setConnectTimeout(this.timeout * 1000);
+                request.setReadTimeout(this.timeout * 1000);
                 this.response = (BoxJSONResponse) request.send();
                 JsonObject jsonObject = JsonObject.readFrom(this.response.getJSON());
                 String message = jsonObject.get("message").asString();


### PR DESCRIPTION
Currently there is no easy way to set the socket timeout's for the Http url connection, since the attributes are on the BoxAPIRequest and BoxAPIRequest's are created in many places internally.