### PR TITLE
Delete redundant response.disconnect() from moveFolderToUser()

### DIFF
--- a/src/main/java/com/box/sdk/BoxUser.java
+++ b/src/main/java/com/box/sdk/BoxUser.java
@@ -442,7 +442,6 @@ public class BoxUser extends BoxCollaborator {
         BoxJSONResponse response = (BoxJSONResponse) request.send();
         JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
         BoxFolder movedFolder = new BoxFolder(this.getAPI(), responseJSON.get("id").asString());
-        response.disconnect();
 
         return movedFolder.new Info(responseJSON);
     }


### PR DESCRIPTION
Summary: please comment out line 407 of the BoxUser.java class in the SDK and attempt again:

response.disconnect();

Explanation: Line 405 of BoxUser.java, which is inside BoxUser.moveFolderToUser(), includes this call:

JsonObject responseJSON = JsonObject.readFrom(response.getJSON());

response.jgetJSON() is defined in the class BoxJSONResponse.java.
```    /**
     * Gets the body of the response as a JSON string. When this method is called, the response's body will be read and
     * the response will be disconnected, meaning that the stream returned by {@link #getBody} can no longer be used.
     * @return the body of the response as a JSON string.
     */
    public String getJSON() {
        if (this.json != null) {
            return this.json;
        }

        InputStreamReader reader = new InputStreamReader(this.getBody(), StandardCharsets.UTF_8);
        StringBuilder builder = new StringBuilder();
        char[] buffer = new char[BUFFER_SIZE];

        try {
            int read = reader.read(buffer, 0, BUFFER_SIZE);
            while (read != -1) {
                builder.append(buffer, 0, read);
                read = reader.read(buffer, 0, BUFFER_SIZE);
            }

            this.disconnect();
            reader.close();
        } catch (IOException e) {
            throw new BoxAPIException("Couldn't connect to the Box API due to a network error.", e);
        }
        this.json = builder.toString();
        return this.json;
    }
```
Note that this method also calls “this.disconnect()“. Since this happens twice (once in response.getJSON(), once in line 407) the second execution throws this exception from BoxAPIResponse.java:
```    public void disconnect() {
        if (this.connection == null) {
            return;
        }

        try {
            if (this.rawInputStream == null) {
                this.rawInputStream = this.connection.getInputStream();
            }

            // We need to manually read from the raw input stream in case there are any remaining bytes. There's a bug
            // where a wrapping GZIPInputStream may not read to the end of a chunked response, causing Java to not
            // return the connection to the connection pool.
            byte[] buffer = new byte[BUFFER_SIZE];
            int n = this.rawInputStream.read(buffer);
            while (n != -1) {
                n = this.rawInputStream.read(buffer);
            }
            this.rawInputStream.close();

            if (this.inputStream != null) {
                this.inputStream.close();
            }
        } catch (IOException e) {
            throw new BoxAPIException("Couldn't finish closing the connection to the Box API due to a network error or "
                + "because the stream was already closed.", e);
        }```