### PR TITLE
Fix MetadataTemplate.updateMetadataTemplate() type error

### DIFF
--- a/src/main/java/com/box/sdk/BatchAPIRequest.java
+++ b/src/main/java/com/box/sdk/BatchAPIRequest.java
@@ -61,7 +61,7 @@ public class BatchAPIRequest extends BoxJSONRequest {
             //If the actual request has a JSON body then add it to vatch request
             if (request instanceof BoxJSONRequest) {
                 BoxJSONRequest jsonRequest = (BoxJSONRequest) request;
-                batchRequest.add("body", jsonRequest.getBodyAsJsonObject());
+                batchRequest.add("body", jsonRequest.getBodyAsJsonValue());
             }
             //Add any headers that are in the request, except Authorization
             if (request.getHeaders() != null) {

--- a/src/main/java/com/box/sdk/BoxJSONRequest.java
+++ b/src/main/java/com/box/sdk/BoxJSONRequest.java
@@ -4,6 +4,7 @@ import java.net.URL;
 
 import com.box.sdk.http.HttpMethod;
 import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
 
 /**
  * Used to make HTTP requests containing JSON to the Box API.
@@ -12,7 +13,7 @@ import com.eclipsesource.json.JsonObject;
  * automatically sets the appropriate "Content-Type" HTTP headers and allows the JSON in the request to be logged.</p>
  */
 public class BoxJSONRequest extends BoxAPIRequest {
-    private JsonObject jsonObject;
+    private JsonValue jsonValue;
 
     /**
      * Constructs an authenticated BoxJSONRequest using a provided BoxAPIConnection.
@@ -53,7 +54,7 @@ public class BoxJSONRequest extends BoxAPIRequest {
     @Override
     public void setBody(String body) {
         super.setBody(body);
-        this.jsonObject = JsonObject.readFrom(body);
+        this.jsonValue = JsonValue.readFrom(body);
     }
 
     /**
@@ -62,7 +63,7 @@ public class BoxJSONRequest extends BoxAPIRequest {
      */
     public void setBody(JsonObject body) {
         super.setBody(body.toString());
-        this.jsonObject = body;
+        this.jsonValue = body;
     }
 
     /**
@@ -70,11 +71,23 @@ public class BoxJSONRequest extends BoxAPIRequest {
      * @return body represented as JsonObject.
      */
     public JsonObject getBodyAsJsonObject() {
-        return this.jsonObject;
+        if (this.jsonValue.isObject()) {
+            return this.jsonValue.asObject();
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets the body of this request as a {@link JsonValue}.
+     * @return body represented as JsonValue
+     */
+    public JsonValue getBodyAsJsonValue() {
+        return this.jsonValue;
     }
 
     @Override
     protected String bodyToString() {
-        return this.jsonObject.toString();
+        return this.jsonValue.toString();
     }
 }

--- a/src/test/java/com/box/sdk/MetadataTemplateTest.java
+++ b/src/test/java/com/box/sdk/MetadataTemplateTest.java
@@ -426,6 +426,50 @@ public class MetadataTemplateTest {
     }
 
     @Test
+    @Category(UnitTest.class)
+    public void testUpdateMetadataTemplateMakesCorrectRequestAndReturnsTemplate() {
+
+        final String responseJSON = "{\n"
+                + "    \"templateKey\": \"customer\",\n"
+                + "    \"scope\": \"enterprise_490685\",\n"
+                + "    \"displayName\": \"Customer\",\n"
+                + "    \"fields\": [\n"
+                + "        {\n"
+                + "            \"type\": \"string\",\n"
+                + "            \"key\": \"customerTeam\",\n"
+                + "            \"displayName\": \"Customer team\",\n"
+                + "            \"hidden\": false\n"
+                + "        }\n"
+                + "     ]\n"
+                + "}";
+
+        final String updateOpJSON = "{\n"
+                + "\"op\":\"editField\",\n"
+                + "\"fieldKey\":\"customerTeam\",\n"
+                + "\"data\":{\"displayName\":\"Customer team\"}}";
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                Assert.assertEquals(
+                        "https://api.box.com/2.0/metadata_templates/global/properties/schema",
+                        request.getUrl().toString());
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return responseJSON;
+                    }
+                };
+            }
+        });
+
+        List<MetadataTemplate.FieldOperation> updates = new ArrayList<MetadataTemplate.FieldOperation>();
+        updates.add(new MetadataTemplate.FieldOperation(updateOpJSON));
+        MetadataTemplate.updateMetadataTemplate(api, "global", "properties", updates);
+    }
+
+    @Test
     @Category(IntegrationTest.class)
     public void getAllMetadataSucceeds() {
         BoxFile uploadedFile = null;


### PR DESCRIPTION
Loosen internal restrictions in BoxJSONRequest to allow for JSON
types other than objects, since metadata template updates use a
JSON array as the top level body.

Fixes #489