### PR TITLE
Add option to pass file SHA-1 hash for upload integrity

### DIFF
--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -493,7 +493,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
             fieldJSON.add("content_modified_at", BoxDateFormat.format(uploadParams.getModified()));
         }
 
-        if (uploadParams.getSHA1() != null) {
+        if (uploadParams.getSHA1() != null && !uploadParams.getSHA1().isEmpty()) {
             request.setContentSHA1(uploadParams.getSHA1());
         }
 

--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -493,6 +493,10 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
             fieldJSON.add("content_modified_at", BoxDateFormat.format(uploadParams.getModified()));
         }
 
+        if (uploadParams.getSHA1() != null) {
+            request.setContentSHA1(uploadParams.getSHA1());
+        }
+
         request.putField("attributes", fieldJSON.toString());
 
         if (uploadParams.getSize() > 0) {

--- a/src/main/java/com/box/sdk/FileUploadParams.java
+++ b/src/main/java/com/box/sdk/FileUploadParams.java
@@ -13,6 +13,7 @@ public class FileUploadParams {
     private Date modified;
     private long size;
     private ProgressListener listener;
+    private String sha1;
 
     /**
      * Constructs a new FileUploadParams with default parameters.
@@ -125,5 +126,23 @@ public class FileUploadParams {
     public FileUploadParams setProgressListener(ProgressListener listener) {
         this.listener = listener;
         return this;
+    }
+
+    /**
+     * Set the SHA-1 hash of the file to ensure it is not corrupted during the upload.
+     * @param sha1 the SHA-1 hash of the file.
+     * @return     this FileUploadParams for chaining.
+     */
+    public FileUploadParams setSHA1(String sha1) {
+        this.sha1 = sha1;
+        return this;
+    }
+
+    /**
+     * Gets the file's SHA-1 hash.
+     * @return the file hash.
+     */
+    public String getSHA1() {
+        return this.sha1;
     }
 }


### PR DESCRIPTION
Added a sha1 attribute to FileUploadParams to enable sending the
expected hash of the file for verification that the file was not
corrupted in transit.

Fixes #328