### PR TITLE
Change wiremock port

### DIFF
--- a/src/test/java/com/box/sdk/BoxAPIRequestTest.java
+++ b/src/test/java/com/box/sdk/BoxAPIRequestTest.java
@@ -17,7 +17,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 public class BoxAPIRequestTest {
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8080);
+    public WireMockRule wireMockRule = new WireMockRule(53620);
 
     @Test
     @Category(UnitTest.class)
@@ -26,7 +26,7 @@ public class BoxAPIRequestTest {
         Time mockTime = mock(Time.class);
         BackoffCounter backoffCounter = new BackoffCounter(mockTime);
 
-        URL url = new URL("http://localhost:8080/");
+        URL url = new URL("http://localhost:53620/");
         BoxAPIRequest request = new BoxAPIRequest(url, "GET");
         request.setBackoffCounter(backoffCounter);
 
@@ -44,7 +44,7 @@ public class BoxAPIRequestTest {
         Time mockTime = mock(Time.class);
         BackoffCounter backoffCounter = new BackoffCounter(mockTime);
 
-        URL url = new URL("http://localhost:8080/");
+        URL url = new URL("http://localhost:53620/");
         BoxAPIRequest request = new BoxAPIRequest(url, "GET");
         request.setBackoffCounter(backoffCounter);
 
@@ -66,7 +66,7 @@ public class BoxAPIRequestTest {
         BoxAPIConnection api = new BoxAPIConnection("");
         api.setMaxRequestAttempts(expectedNumAttempts);
 
-        URL url = new URL("http://localhost:8080/");
+        URL url = new URL("http://localhost:53620/");
         BoxAPIRequest request = new BoxAPIRequest(api, url, "GET");
         request.setBackoffCounter(backoffCounter);
 

--- a/src/test/java/com/box/sdk/BoxCollectionTest.java
+++ b/src/test/java/com/box/sdk/BoxCollectionTest.java
@@ -25,7 +25,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 public class BoxCollectionTest {
 
     @Rule
-    public final WireMockRule wireMockRule = new WireMockRule(8080);
+    public final WireMockRule wireMockRule = new WireMockRule(53620);
 
     @Test
     @Category(UnitTest.class)
@@ -72,7 +72,7 @@ public class BoxCollectionTest {
         final String nameSecond = "Warriors.jpg";
 
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/collections/0/items/"))
                 .willReturn(WireMock.aResponse()
@@ -118,7 +118,7 @@ public class BoxCollectionTest {
     @Category(UnitTest.class)
     public void testGetItemsRequestCorrectFields() {
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/collections/0/items/"))
                 .withQueryParam("fields", WireMock.containing("name"))
@@ -135,7 +135,7 @@ public class BoxCollectionTest {
     @Category(UnitTest.class)
     public void testGetItemsRangeRequestsCorrectOffsetLimitAndFields() {
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         WireMock.stubFor(WireMock.get(WireMock.urlPathEqualTo("/collections/0/items/"))
                 .withQueryParam("offset", WireMock.equalTo("0"))

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -36,7 +36,7 @@ import org.junit.experimental.categories.Category;
 public class BoxFolderTest {
     @SuppressWarnings("checkstyle:wrongOrder")
     @Rule
-    public final WireMockRule wireMockRule = new WireMockRule(8080);
+    public final WireMockRule wireMockRule = new WireMockRule(53620);
 
     @Test
     @Category(UnitTest.class)
@@ -52,7 +52,7 @@ public class BoxFolderTest {
     @Category(UnitTest.class)
     public void createFolderSendsRequestWithRequiredFields() {
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
         BoxFolder rootFolder = BoxFolder.getRootFolder(api);
         String parentFolderID = rootFolder.getID();
         String createdFolderName = "[createFolderSendsRequestWithRequiredFields] Child Folder";
@@ -100,7 +100,7 @@ public class BoxFolderTest {
     @Category(UnitTest.class)
     public void getChildrenRangeRequestsCorrectOffsetLimitAndFields() {
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         stubFor(get(urlPathEqualTo("/folders/0/items/"))
             .withQueryParam("offset", WireMock.equalTo("1"))

--- a/src/test/java/com/box/sdk/BoxGroupMembershipTest.java
+++ b/src/test/java/com/box/sdk/BoxGroupMembershipTest.java
@@ -35,7 +35,7 @@ public class BoxGroupMembershipTest {
      * Wiremock
      */
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8080);
+    public WireMockRule wireMockRule = new WireMockRule(53620);
 
     /**
      * Unit test for {@link BoxGroupMembership#getInfo()}.
@@ -44,7 +44,7 @@ public class BoxGroupMembershipTest {
     @Category(UnitTest.class)
     public void getInfoSendsCorrectRequestAndParsesResponseCorrectly() throws ParseException {
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         final String membershipID = "1";
         final String membershipsURL = "/group_memberships/" + membershipID;
@@ -104,7 +104,7 @@ public class BoxGroupMembershipTest {
     @Category(UnitTest.class)
     public void deleteMembershipSendsCorrectRequest() {
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         final String membershipID = "1";
         final String membershipsURL = "/group_memberships/" + membershipID;

--- a/src/test/java/com/box/sdk/BoxGroupTest.java
+++ b/src/test/java/com/box/sdk/BoxGroupTest.java
@@ -45,7 +45,7 @@ public class BoxGroupTest {
      * Wiremock
      */
     @Rule
-    public WireMockRule wireMockRule = new WireMockRule(8080);
+    public WireMockRule wireMockRule = new WireMockRule(53620);
 
     /**
      * Unit test for {@link BoxGroup#getInfo(String...)}.
@@ -540,7 +540,7 @@ public class BoxGroupTest {
     @Category(UnitTest.class)
     public void createGroupSendsCorrectRequestAndParsesResponseCorrectly() throws ParseException {
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         final String name = "Test Group";
         final String description = "Test group description";
@@ -600,7 +600,7 @@ public class BoxGroupTest {
     @Category(UnitTest.class)
     public void deleteGroupSendsCorrectRequest() {
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         final String groupID = "1";
         final String groupURL = "/groups/" + groupID;

--- a/src/test/java/com/box/sdk/BoxSearchTest.java
+++ b/src/test/java/com/box/sdk/BoxSearchTest.java
@@ -16,14 +16,14 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 public class BoxSearchTest {
     @Rule
-    public final WireMockRule wireMockRule = new WireMockRule(8080);
+    public final WireMockRule wireMockRule = new WireMockRule(53620);
 
     @Test
     @Category(UnitTest.class)
     public void searchWithQueryRequestsCorrectFields() {
         String query = "A query";
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         try {
             stubFor(get(urlPathEqualTo("/search"))
@@ -54,7 +54,7 @@ public class BoxSearchTest {
                 + "example%22%7D%7D%5D";
 
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         stubFor(get(urlPathEqualTo("/search"))
                 .withQueryParam("type", WireMock.equalTo("file"))

--- a/src/test/java/com/box/sdk/BoxUserTest.java
+++ b/src/test/java/com/box/sdk/BoxUserTest.java
@@ -45,7 +45,7 @@ public class BoxUserTest {
      * Wiremock
      */
     @Rule
-    public final WireMockRule wireMockRule = new WireMockRule(8080);
+    public final WireMockRule wireMockRule = new WireMockRule(53620);
 
     /**
      * Unit test for {@link BoxUser#getAllEnterpriseUsers(BoxAPIConnection, String, String...)}.
@@ -56,7 +56,7 @@ public class BoxUserTest {
         final String filterTerm = "login";
         final String name = "enterprise user";
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         stubFor(get(urlPathEqualTo("/users"))
                 .withQueryParam("offset", WireMock.equalTo("0"))
@@ -85,7 +85,7 @@ public class BoxUserTest {
         final String filterTerm = "login";
         final String name = "enterprise user";
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         stubFor(get(urlPathEqualTo("/users"))
                 .withQueryParam("offset", WireMock.equalTo("0"))
@@ -115,7 +115,7 @@ public class BoxUserTest {
         final String filterTerm = "login";
         final String name = "enterprise user";
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         stubFor(get(urlPathEqualTo("/users"))
                 .withQueryParam("offset", WireMock.equalTo("0"))

--- a/src/test/java/com/box/sdk/EventStreamTest.java
+++ b/src/test/java/com/box/sdk/EventStreamTest.java
@@ -23,7 +23,7 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 public class EventStreamTest {
     @Rule
-    public final WireMockRule wireMockRule = new WireMockRule(8080);
+    public final WireMockRule wireMockRule = new WireMockRule(53620);
 
     @Test
     @Category(IntegrationTest.class)
@@ -105,7 +105,7 @@ public class EventStreamTest {
         stubFor(options(urlEqualTo("/events"))
             .willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
-                .withBody("{ \"entries\": [ { \"url\": \"http://localhost:8080" + realtimeServerURL + "\", "
+                .withBody("{ \"entries\": [ { \"url\": \"http://localhost:53620" + realtimeServerURL + "\", "
                     + "\"max_retries\": \"3\", \"retry_timeout\": 60000 } ] }")));
 
         stubFor(get(urlMatching("/events\\?.*stream_position=now.*"))
@@ -114,7 +114,7 @@ public class EventStreamTest {
                 .withBody("{ \"next_stream_position\": " + streamPosition + " }")));
 
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         final EventStream stream = new EventStream(api);
         final Object requestLock = new Object();
@@ -149,7 +149,7 @@ public class EventStreamTest {
         stubFor(options(urlEqualTo("/events"))
             .willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
-                .withBody("{ \"entries\": [ { \"url\": \"http://localhost:8080" + realtimeServerURL + "\", "
+                .withBody("{ \"entries\": [ { \"url\": \"http://localhost:53620" + realtimeServerURL + "\", "
                     + "\"max_retries\": \"3\", \"retry_timeout\": 60000 } ] }")));
 
         stubFor(get(urlMatching("/events\\?.*stream_position=now.*"))
@@ -175,7 +175,7 @@ public class EventStreamTest {
                     + "\"event_id\": \"1\" } ] }")));
 
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
 
         final EventStream stream = new EventStream(api);
         final EventListener eventListener = mock(EventListener.class);

--- a/src/test/java/com/box/sdk/MetadataTemplateTest.java
+++ b/src/test/java/com/box/sdk/MetadataTemplateTest.java
@@ -25,7 +25,7 @@ public class MetadataTemplateTest {
      * Wiremock
      */
     @Rule
-    public final WireMockRule wireMockRule = new WireMockRule(8080);
+    public final WireMockRule wireMockRule = new WireMockRule(53620);
 
     /**
      * Unit test for {@link MetadataTemplate#getMetadataTemplate(BoxAPIConnection, String, String, String...)}.
@@ -75,7 +75,7 @@ public class MetadataTemplateTest {
         final String secondFieldSecondOption = "Accessories";
 
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setBaseURL("http://localhost:8080/");
+        api.setBaseURL("http://localhost:53620/");
         WireMock.stubFor(WireMock.get(WireMock.urlMatching("/metadata_templates/global/properties/schema"))
                 .willReturn(WireMock.aResponse()
                         .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
Changes wiremock in tests to use a private port instead of 8080, which is popular with web servers.

Fixes #60 