### PR TITLE
remove boxfolder search because deprecated

### DIFF
--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -71,10 +71,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
      * Get Items URL Template.
      */
     public static final URLTemplate GET_ITEMS_URL = new URLTemplate("folders/%s/items/");
-    /**
-     * Search URL Template.
-     */
-    public static final URLTemplate SEARCH_URL_TEMPLATE = new URLTemplate("search");
+
     /**
      * Metadata URL Template.
      */
@@ -698,27 +695,6 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
      */
     public Iterable<Metadata> getAllMetadata(String... fields) {
         return Metadata.getAllMetadata(this, fields);
-    }
-
-    /**
-     * This method is deprecated, please use the {@link BoxSearch} class instead.
-     * Searches this folder and all descendant folders using a given queryPlease use BoxSearch Instead.
-     * @param  query the search query.
-     * @return an Iterable containing the search results.
-     */
-    @Deprecated
-    public Iterable<BoxItem.Info> search(final String query) {
-        return new Iterable<BoxItem.Info>() {
-            @Override
-            public Iterator<BoxItem.Info> iterator() {
-                QueryStringBuilder builder = new QueryStringBuilder();
-                builder.appendParam("query", query);
-                builder.appendParam("ancestor_folder_ids", getID());
-
-                URL url = SEARCH_URL_TEMPLATE.buildWithQuery(getAPI().getBaseURL(), builder.toString());
-                return new BoxItemIterator(getAPI(), url);
-            }
-        };
     }
 
     @Override


### PR DESCRIPTION
@mattwiller, not sure the best way to remove this from issue #338. 

This method was already marked @deprecated and this endpoint probably doesn't return what the user expects anymore but is it okay to remove it like we are doing here? Let me know, thanks! 