### PR TITLE
Perform modified retry on JWT auth

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile 'org.bouncycastle:bcpkix-jdk15on:1.52'
     testCompile 'junit:junit:4.11'
     testCompile 'org.hamcrest:hamcrest-library:1.3'
-    testCompile 'com.github.tomakehurst:wiremock:1.52'
+    testCompile 'com.github.tomakehurst:wiremock:2.14.0'
     testCompile 'org.mockito:mockito-core:1.9.5'
     testCompile 'org.slf4j:slf4j-api:1.7.7'
     testCompile 'org.slf4j:slf4j-nop:1.7.7'

--- a/src/main/java/com/box/sdk/BoxAPIException.java
+++ b/src/main/java/com/box/sdk/BoxAPIException.java
@@ -1,5 +1,9 @@
 package com.box.sdk;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Thrown to indicate that an error occurred while communicating with the Box API.
  */
@@ -8,6 +12,7 @@ public class BoxAPIException extends RuntimeException {
 
     private final int responseCode;
     private final String response;
+    private final Map<String, List<String>> headers;
 
     /**
      * Constructs a BoxAPIException with a specified message.
@@ -18,6 +23,7 @@ public class BoxAPIException extends RuntimeException {
 
         this.responseCode = 0;
         this.response = null;
+        this.headers = null;
     }
 
     /**
@@ -32,6 +38,24 @@ public class BoxAPIException extends RuntimeException {
 
         this.responseCode = responseCode;
         this.response = response;
+        this.headers = null;
+    }
+
+    /**
+     * Constructs a BoxAPIException with details about the server's response, including response headers.
+     * @param  message         a message explaining why the exception occurred.
+     * @param  responseCode    the response code returned by the Box server.
+     * @param  responseBody    the response body returned by the Box server.
+     * @param  responseHeaders the response headers returned by the Box server.
+     */
+    public BoxAPIException(String message, int responseCode, String responseBody,
+                           Map<String, List<String>> responseHeaders) {
+        //People are missing the getResponse method we have. So adding it to message
+        super(message + "\n" + responseBody);
+
+        this.responseCode = responseCode;
+        this.response = responseBody;
+        this.headers = responseHeaders;
     }
 
     /**
@@ -44,6 +68,7 @@ public class BoxAPIException extends RuntimeException {
 
         this.responseCode = 0;
         this.response = null;
+        this.headers = null;
     }
 
     /**
@@ -58,6 +83,25 @@ public class BoxAPIException extends RuntimeException {
 
         this.responseCode = responseCode;
         this.response = response;
+        this.headers = null;
+    }
+
+    /**
+     * Constructs a BoxAPIException that includes the response headers.
+     * @param message         a message explaining why the exception occurred.
+     * @param responseCode    the response code returned by the Box server.
+     * @param responseBody    the response body returned by the Box server.
+     * @param responseHeaders the response headers returned by the Box server.
+     * @param cause           an underlying exception.
+     */
+    public BoxAPIException(String message, int responseCode, String responseBody,
+                           Map<String, List<String>> responseHeaders, Throwable cause) {
+
+        super(message, cause);
+
+        this.responseCode = responseCode;
+        this.response = responseBody;
+        this.headers = responseHeaders;
     }
 
     /**
@@ -74,5 +118,17 @@ public class BoxAPIException extends RuntimeException {
      */
     public String getResponse() {
         return this.response;
+    }
+
+    /**
+     * Gets the response headers, if available.
+     * @return the response headers, or empty map if not available.
+     */
+    public Map<String, List<String>> getHeaders() {
+        if (this.headers != null) {
+            return this.headers;
+        } else {
+            return Collections.emptyMap();
+        }
     }
 }

--- a/src/main/java/com/box/sdk/BoxAPIResponse.java
+++ b/src/main/java/com/box/sdk/BoxAPIResponse.java
@@ -82,7 +82,7 @@ public class BoxAPIResponse {
         if (!isSuccess(this.responseCode)) {
             this.logResponse();
             throw new BoxAPIException("The API returned an error code: " + this.responseCode, this.responseCode,
-                this.bodyToString());
+                this.bodyToString(), this.connection.getHeaderFields());
         }
 
         this.logResponse();

--- a/src/main/java/com/box/sdk/BoxDeveloperEditionAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxDeveloperEditionAPIConnection.java
@@ -335,7 +335,7 @@ public class BoxDeveloperEditionAPIConnection extends BoxAPIConnection {
             NumericDate currentTime;
             if (responseDates != null) {
                 String responseDate = responseDates.get(0);
-                SimpleDateFormat dateFormat = new SimpleDateFormat("EEE d MMM yyyy HH:mm:ss 'GMT'");
+                SimpleDateFormat dateFormat = new SimpleDateFormat("EEE d MMM yyyy HH:mm:ss zzz");
                 try {
                     Date date = dateFormat.parse(responseDate);
                     currentTime = NumericDate.fromMilliseconds(date.getTime());

--- a/src/main/java/com/box/sdk/EventStream.java
+++ b/src/main/java/com/box/sdk/EventStream.java
@@ -106,6 +106,7 @@ public class EventStream {
             JsonObject jsonObject = JsonObject.readFrom(response.getJSON());
             initialPosition = jsonObject.get("next_stream_position").asLong();
         } else {
+            assert this.startingPosition >= 0 : "Starting position must be non-negative";
             initialPosition = this.startingPosition;
         }
 

--- a/src/test/java/com/box/sdk/BoxDeveloperEditionAPIConnectionTest.java
+++ b/src/test/java/com/box/sdk/BoxDeveloperEditionAPIConnectionTest.java
@@ -1,0 +1,177 @@
+package com.box.sdk;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import org.jose4j.jwt.JwtClaims;
+import org.jose4j.jwt.consumer.JwtConsumer;
+import org.jose4j.jwt.consumer.JwtConsumerBuilder;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import static com.github.tomakehurst.wiremock.client.WireMock.requestMatching;
+import static com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import com.github.tomakehurst.wiremock.extension.Parameters;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.matching.MatchResult;
+import com.github.tomakehurst.wiremock.matching.RequestMatcherExtension;
+
+/**
+ *
+ */
+public class BoxDeveloperEditionAPIConnectionTest {
+
+    /**
+     * Wiremock
+     */
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(53620);
+
+    @Test
+    @Category(UnitTest.class)
+    public void retriesWithNewJWTAssertionOnErrorResponse() {
+
+        final String baseURL = "http://localhost:53620";
+        final String tokenPath = "/oauth2/token";
+        final String accessToken = "mNr1FrCvOeWiGnwLL0OcTL0Lux5jbyBa";
+
+        JWTEncryptionPreferences prefs = new JWTEncryptionPreferences();
+        prefs.setEncryptionAlgorithm(EncryptionAlgorithm.RSA_SHA_256);
+        // @NOTE(mwiller) 2018-01-16: These are freshly-generated keys which are not used for a real Box
+        // account.  They are safe to use in this unit test.
+        prefs.setPrivateKey("-----BEGIN RSA PRIVATE KEY-----\n"
+                + "Proc-Type: 4,ENCRYPTED\n"
+                + "DEK-Info: AES-256-CBC,11600371FE6B320E75D9144A98B00582\n"
+                + "\n"
+                + "060EECunPUd12iRqq0fxPSPKehzTkhpzxRrhnIKayaqG1Ke3sTVtrFum1tGh5ck7\n"
+                + "AdZa2uaJHgkVSKHjJWpQ30RvgR9o+l2KaQ6vi+4ZDtfQV22cgnR2oHAXs8kXsuMD\n"
+                + "M8AHjQo9MjjWWqdd4pYrc+9x0qjEZMt5w7rYofVDfu81UUdf/4PXm8dKcfZbDPHy\n"
+                + "TlDiHrpTSXWjdVbZrjaFW3yO+c7nF62ez13HP4arhhy0wNtX5TXQKSCMmDt6H91+\n"
+                + "tUlXwodzMGnMhaCtBg/nTYRK9VEdlPIRTiiIiWKyWcfx3C1MrBBUjI/iKmPzn5qQ\n"
+                + "+In5RpUNqjaYNmhLOBjt4/KG/s3bkPFswIiQV8xR4v+K27YqLMAcV3+i/y9qsEcG\n"
+                + "JCg5/ofbrjvuMqW45rcgJrG8aTMNGLS6jm6xfD9boHj415D8q5EdIvp8BxTkpcnp\n"
+                + "NWI71vHcjhXbq4HWgQjlOaol3/aIGk+oO8UL4oqRh1rGOiVCcpCjNImZCbjBRU5s\n"
+                + "+PXTojGOHgxWppCc+j5pXZY65/zusTrZO/2OhkI89Jn1qJv+LEVzD4k2Ed/rj5dm\n"
+                + "9UlHBImiUjJN53iDqS0QibOlasCGy0enu7Iq/n8kQAPog8FoF0CqXxp/33sX+RH2\n"
+                + "htwcqYl9sd5QEQiR6pWrT0H7KvMJXkjhjumka35l0+7cQCQtuNoGRo2z/+P3Ih+O\n"
+                + "gyxjVfdohKMjT7QNv3tIo+rk6C71qGL9x34nCFckxgGjy/88L02KveTxbTvYRUe6\n"
+                + "E6YHaTt66ACfbjMiJzZ5Zb9RQsF3B/bE6rwE81LskLQiXDVFho0BjzvUCPazGWzb\n"
+                + "pIhlfHMCY87ud0a96GMSacJRIszYJT2zQbaEmT2JrbY+jz4dhJ8WiSVavSHnqAgS\n"
+                + "ViEx6IKR8r4/auwheDjhidkYwUMylPYUEzjOM+h76DVficUEPVYKQHYEMcb5j58W\n"
+                + "cLbHcOyct0IWzo5DAuhR+31E0aGchRmBnDgwFAocxoY+G2TCvJPXZXRitps6b7kA\n"
+                + "fwzBr/AEHBcLKXfcExkhzkVY/lltr0zNFUEcDBHdviloBPf6UAqtLpRNDUkXXfs5\n"
+                + "m1qkdkyAjJwRYYv4wA1CSJmTLUTzX9fBr9rsq23eoWbm7ApOaXJ4Ovs8U/GRuvsL\n"
+                + "mtZ2MROiF+ZZMXQ5GeLI3KjUpMJuyAyu6RFHMQvMiY7e+Q2oI0uKX4XFXahiaKaO\n"
+                + "BfxN5b76TAHPrPbLTXj7jN/AgmREAL8MAVlFC1CiWB4c8jWDKQW+QjYCKCcVCyym\n"
+                + "XuQnPR6tSOMXf9gJPgAuvqGoYUdrMgXvKLYv9QKwIuCLriqSePzK/1dwAqkHFiBS\n"
+                + "S4aHNgCcXZJeqKGfihu0/NuW+GEc3nqQZH+7pzhgoc1h0ENR5Yt+52jnxj+jkwb5\n"
+                + "T7W/9WFyw8cid5Y/ikwQ0alyzECdgihwitdTz7++4fLjAUBIP8+yENo4xlsQwcWA\n"
+                + "59UgzfiL6ZkKqTsbARnGAo84PFCFiBt2Js6dD5HRFMAGDzUGvd8I7mkSvpH7DiET\n"
+                + "aJKEjq+qm2vWCmaTufJ+dJf7+Xr1NqPaEdHd08wqUYTOg0KcJUoOiSpeP/hVBJWI\n"
+                + "-----END RSA PRIVATE KEY-----\n");
+        prefs.setPrivateKeyPassword("testkey");
+        prefs.setPublicKeyID("abcdefg");
+
+
+        BoxDeveloperEditionAPIConnection api = new BoxDeveloperEditionAPIConnection("12345",
+                DeveloperEditionEntityType.USER, "foo", "bar", prefs, null);
+        api.setBaseURL(baseURL + "/");
+        api.setTokenURL(baseURL + tokenPath);
+        api.setMaxRequestAttempts(1);
+
+        final String[] jtiClaims = new String[1];
+
+        final BoxDeveloperEditionAPIConnectionTest self = this;
+
+        this.wireMockRule.stubFor(requestMatching(new RequestMatcherExtension() {
+            @Override
+            public MatchResult match(Request request, Parameters parameters) {
+                if (!request.getMethod().equals(RequestMethod.POST) || !request.getUrl().equals(tokenPath)) {
+                    return MatchResult.noMatch();
+                }
+                try {
+                    JwtClaims claims = self.getClaimsFromRequest(request);
+                    jtiClaims[0] = claims.getJwtId();
+                } catch (Exception ex) {
+                    // Do nothing
+                }
+                return MatchResult.exactMatch();
+            }
+        })
+            .inScenario("JWT Retry")
+            .whenScenarioStateIs(STARTED)
+            .willReturn(aResponse()
+                .withStatus(429)
+                .withHeader("Retry-After", "1")
+                .withHeader("Date", "Sat 18 Nov 2017 11:18:00 GMT"))
+            .willSetStateTo("429 sent"));
+
+
+        this.wireMockRule.stubFor(requestMatching(new RequestMatcherExtension() {
+            @Override
+            public MatchResult match(Request request, Parameters parameters) {
+                if (!request.getMethod().equals(RequestMethod.POST) || !request.getUrl().equals(tokenPath)) {
+                    return MatchResult.noMatch();
+                }
+                try {
+                    JwtClaims claims = self.getClaimsFromRequest(request);
+                    String jti = claims.getJwtId();
+                    long expTimestamp = claims.getExpirationTime().getValue();
+
+                    if (expTimestamp != 1511032740L) {
+                        return MatchResult.noMatch();
+                    }
+
+                    if (jti.equals(jtiClaims[0])) {
+                        return MatchResult.noMatch();
+                    }
+                } catch (Exception ex) {
+                    return MatchResult.noMatch();
+                }
+
+                return MatchResult.exactMatch();
+            }
+        })
+            .inScenario("JWT Retry")
+            .whenScenarioStateIs("429 sent")
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody("{\n"
+                        + "   \"access_token\": \"" + accessToken + "\",\n"
+                        + "   \"expires_in\": 4169,\n"
+                        + "   \"restricted_to\": [],\n"
+                        + "   \"token_type\": \"bearer\"\n"
+                        + "}")));
+
+        api.authenticate();
+
+        Assert.assertEquals(accessToken, api.getAccessToken());
+    }
+
+    private JwtClaims getClaimsFromRequest(Request request) throws Exception {
+
+        // Get the JWT out of the request body
+        String body = request.getBodyAsString();
+        String[] tokens = body.split("&");
+        String jwt = null;
+        for (String s : tokens) {
+            String[] parts = s.split("=");
+            if (parts[0] != null && parts[0].equals("assertion") && parts[1] != null) {
+                jwt = parts[1];
+            }
+        }
+        if (jwt == null) {
+            throw new Exception("No jwt assertion found in request body");
+        }
+
+        // Parse out the JWT to verify the claims
+        JwtConsumer jwtConsumer = new JwtConsumerBuilder()
+                .setSkipSignatureVerification()
+                .setSkipAllValidators()
+                .build();
+        return jwtConsumer.processToClaims(jwt);
+    }
+}

--- a/src/test/java/com/box/sdk/BoxDeveloperEditionAPIConnectionTest.java
+++ b/src/test/java/com/box/sdk/BoxDeveloperEditionAPIConnectionTest.java
@@ -3,6 +3,7 @@ package com.box.sdk;
 import com.github.tomakehurst.wiremock.http.RequestListener;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.http.Response;
+import junit.framework.AssertionFailedError;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.consumer.JwtConsumer;
 import org.jose4j.jwt.consumer.JwtConsumerBuilder;
@@ -33,7 +34,7 @@ public class BoxDeveloperEditionAPIConnectionTest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(53620);
 
-    private String jtiClaim;
+    private String jtiClaim = null;
 
     @Test
     @Category(UnitTest.class)
@@ -117,16 +118,14 @@ public class BoxDeveloperEditionAPIConnectionTest {
                     String jti = claims.getJwtId();
                     long expTimestamp = claims.getExpirationTime().getValue();
 
-                    if (expTimestamp != 1511032740L) {
-                        return MatchResult.noMatch();
-                    }
+                    Assert.assertEquals("JWT should have the expected timestamp", 1511032740L, expTimestamp);
+                    Assert.assertNotEquals("JWT should have a new jti claim",
+                            BoxDeveloperEditionAPIConnectionTest.this.jtiClaim, jti);
 
-                    if (jti.equals(BoxDeveloperEditionAPIConnectionTest.this.jtiClaim)) {
-                        return MatchResult.noMatch();
-                    }
+                } catch (AssertionFailedError ex) {
+                    throw ex;
                 } catch (Exception ex) {
                     Assert.fail("Could not parse JWT when request is retried: " + ex.getMessage());
-                    return MatchResult.noMatch();
                 }
 
                 return MatchResult.exactMatch();

--- a/src/test/java/com/box/sdk/BoxDeveloperEditionAPIConnectionTest.java
+++ b/src/test/java/com/box/sdk/BoxDeveloperEditionAPIConnectionTest.java
@@ -118,7 +118,7 @@ public class BoxDeveloperEditionAPIConnectionTest {
                     String jti = claims.getJwtId();
                     long expTimestamp = claims.getExpirationTime().getValue();
 
-                    Assert.assertEquals("JWT should have the expected timestamp", 1511032740L, expTimestamp);
+                    Assert.assertEquals("JWT should have the expected timestamp", 1511003940L, expTimestamp);
                     Assert.assertNotEquals("JWT should have a new jti claim",
                             BoxDeveloperEditionAPIConnectionTest.this.jtiClaim, jti);
 

--- a/src/test/java/com/box/sdk/BoxDeveloperEditionAPIConnectionTest.java
+++ b/src/test/java/com/box/sdk/BoxDeveloperEditionAPIConnectionTest.java
@@ -93,7 +93,6 @@ public class BoxDeveloperEditionAPIConnectionTest {
 
         this.wireMockRule.stubFor(post(urlPathMatching(tokenPath))
             .atPriority(1)
-            .withPostServeAction("save-jti", new Parameters())
             .inScenario("JWT Retry")
             .whenScenarioStateIs(STARTED)
             .willReturn(aResponse()

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -22,7 +22,6 @@ import java.util.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
-import static org.skyscreamer.jsonassert.JSONCompareMode.LENIENT;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -59,7 +58,7 @@ public class BoxFolderTest {
 
         stubFor(post(urlMatching("/folders"))
             .withRequestBody(equalToJson("{ \"name\": \"" + createdFolderName + "\", \"parent\": {\"id\": \""
-                + parentFolderID + "\"} }", LENIENT))
+                + parentFolderID + "\"} }", true, true))
             .willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
                 .withBody("{\"id\": \"0\"}")));

--- a/src/test/java/com/box/sdk/BoxGroupTest.java
+++ b/src/test/java/com/box/sdk/BoxGroupTest.java
@@ -11,7 +11,6 @@ import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static org.skyscreamer.jsonassert.JSONCompareMode.LENIENT;
 
 import org.hamcrest.Matchers;
 import org.junit.Assert;
@@ -590,7 +589,7 @@ public class BoxGroupTest {
 
         verify(postRequestedFor(urlEqualTo("/groups"))
             .withHeader("Content-Type", WireMock.equalTo("application/json"))
-            .withRequestBody(equalToJson(expectedJSON.toString(), LENIENT)));
+            .withRequestBody(equalToJson(expectedJSON.toString(), true, true)));
     }
 
     /**

--- a/src/test/java/com/box/sdk/BoxSearchTest.java
+++ b/src/test/java/com/box/sdk/BoxSearchTest.java
@@ -1,8 +1,5 @@
 package com.box.sdk;
 
-import static java.net.URLEncoder.encode;
-import java.io.UnsupportedEncodingException;
-
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import org.junit.Rule;
@@ -25,16 +22,14 @@ public class BoxSearchTest {
         BoxAPIConnection api = new BoxAPIConnection("");
         api.setBaseURL("http://localhost:53620/");
 
-        try {
-            stubFor(get(urlPathEqualTo("/search"))
-                    .withQueryParam("query", WireMock.equalTo(encode(query, "UTF-8")))
-                    .withQueryParam("limit", WireMock.equalTo("10"))
-                    .withQueryParam("offset", WireMock.equalTo("10"))
-                    .willReturn(aResponse()
-                            .withHeader("Content-Type", "application/json")
-                            .withBody("{\"total_count\": 1, \"offset\": 10, \"limit\": 10, \"entries\":"
-                                    + "[{\"type\": \"file\", \"id\": \"0\"}]}")));
-        } catch (UnsupportedEncodingException e) { /* no op */ }
+        stubFor(get(urlPathEqualTo("/search"))
+                .withQueryParam("query", WireMock.equalTo(query))
+                .withQueryParam("limit", WireMock.equalTo("10"))
+                .withQueryParam("offset", WireMock.equalTo("10"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"total_count\": 1, \"offset\": 10, \"limit\": 10, \"entries\":"
+                                + "[{\"type\": \"file\", \"id\": \"0\"}]}")));
 
         BoxSearch boxSearch = new BoxSearch(api);
         BoxSearchParameters searchParams = new BoxSearchParameters();
@@ -49,9 +44,10 @@ public class BoxSearchTest {
     @Test
     @Category(UnitTest.class)
     public void searchWithMetadataRequestsCorrectFiltersAndFields() {
-        final String filters = "%5B%7B%22templateKey%22%3A%22test%22%2C%22scope%22%3A%22enterprise%22%2C%22"
-                + "filters%22%3A%7B%22number%22%3A%7B%22gt%22%3A12%2C%22lt%22%3A19%7D%2C%22test%22%3A%22"
-                + "example%22%7D%7D%5D";
+
+        final String filters = "[{\"templateKey\":\"test\",\"scope\":\"enterprise\","
+                + "\"filters\":{\"number\":{\"gt\":12,\"lt\":19},\"test\":\"example\"}}]";
+
 
         BoxAPIConnection api = new BoxAPIConnection("");
         api.setBaseURL("http://localhost:53620/");

--- a/src/test/java/com/box/sdk/EventStreamTest.java
+++ b/src/test/java/com/box/sdk/EventStreamTest.java
@@ -113,6 +113,11 @@ public class EventStreamTest {
                 .withHeader("Content-Type", "application/json")
                 .withBody("{ \"next_stream_position\": " + streamPosition + " }")));
 
+        stubFor(get(urlMatching("/realtimeServer.*"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"message\": \"new_change\" }")));
+
         BoxAPIConnection api = new BoxAPIConnection("");
         api.setBaseURL("http://localhost:53620/");
 

--- a/src/test/java/com/box/sdk/EventStreamTest.java
+++ b/src/test/java/com/box/sdk/EventStreamTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -99,7 +100,7 @@ public class EventStreamTest {
     @Test
     @Category(UnitTest.class)
     public void canStopStreamWhileWaitingForAPIResponse() throws InterruptedException {
-        final long streamPosition = 0;
+        final long streamPosition = 123456;
         final String realtimeServerURL = "/realtimeServer?channel=0";
 
         stubFor(options(urlEqualTo("/events"))
@@ -108,10 +109,11 @@ public class EventStreamTest {
                 .withBody("{ \"entries\": [ { \"url\": \"http://localhost:53620" + realtimeServerURL + "\", "
                     + "\"max_retries\": \"3\", \"retry_timeout\": 60000 } ] }")));
 
-        stubFor(get(urlMatching("/events\\?.*stream_position=now.*"))
+        stubFor(get(urlPathMatching("/events"))
+            .withQueryParam("stream_position", WireMock.equalTo("now"))
             .willReturn(aResponse()
                 .withHeader("Content-Type", "application/json")
-                .withBody("{ \"next_stream_position\": " + streamPosition + " }")));
+                .withBody("{ \"next_stream_position\": " + streamPosition + ",\"entries\":[] }")));
 
         stubFor(get(urlMatching("/realtimeServer.*"))
                 .willReturn(aResponse()


### PR DESCRIPTION
If JWT auth fails, attempt a manual retry that:
1. Regenerates the `jti` claim to avoid scenarios where the JWT ID was already consumed
2. Uses the Date header from the API response to calculate the JWT `exp` claim, to avoid issues related to clock drift

Fixes #519
Fixes #475