### PR TITLE
Add missing documentation for undocumented endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ You can find guides and tutorials in the `doc` directory.
 * [Users](doc/users.md)
 * [Groups](doc/groups.md)
 * [Tasks](doc/tasks.md)
+* [Trash](doc/trash.md)
 * [Collections](doc/collections.md)
 * [Devices](doc/devices.md)
 * [Retention Policies](doc/retention_policies.md)
@@ -197,6 +198,7 @@ You can find guides and tutorials in the `doc` directory.
 * [Webhooks](doc/webhooks.md)
 * [Web Links](doc/weblinks.md)
 * [Metadata Templates](doc/metadata_template.md)
+* [Recent Items](doc/recent_items.md)
 
 
 Javadocs are generated when `gradle javadoc` is run and can be found in

--- a/doc/collaborations.md
+++ b/doc/collaborations.md
@@ -10,6 +10,7 @@ define what permissions a user has for a folder.
 * [Get a Collaboration's Information](#get-a-collaborations-information)
 * [Get the Collaborations on a Folder](#get-the-collaborations-on-a-folder)
 * [Get Pending Collaborations](#get-pending-collaborations)
+* [Accept or Decline a Pending Collaboration](#accept-or-decline-a-pending-collaboration)
 
 Add a Collaboration
 -------------------
@@ -104,3 +105,18 @@ Collection<BoxCollaboration.Info> pendingCollaborations =
 ```
 
 [get-pending-collaborations]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxCollaboration.html#getPendingCollaborations-com.box.sdk.BoxAPIConnection-
+
+Accept or Decline a Pending Collaboration
+-----------------------------------------
+
+To accept or decline a pending collaboration, update the info of the pending collaboration object
+with the desired status.
+
+```java
+// Accept all pending collaborations
+Collection<BoxCollaboration.Info> pendingCollaborations = BoxCollaboration.getPendingCollaborations(api);
+for (BoxCollaboration.Info collabInfo : pendingCollaborations) {
+    collabInfo.setStatus(BoxCollaboration.Status.ACCEPTED);
+    collabInfo.getResource().updateInfo(collabInfo);
+}
+```

--- a/doc/files.md
+++ b/doc/files.md
@@ -9,6 +9,7 @@ file's contents, upload new versions, and perform other common file operations
 * [Update a File's Information](#update-a-files-information)
 * [Download a File](#download-a-file)
 * [Upload a File](#upload-a-file)
+* [Upload Preflight Check](#upload-preflight-check)
 * [Upload a large file in Chunks (using helper method)](#upload-a-new-large-file-in-chunks-helper-method)
 * [Upload a large file Version or existing file (using helper method)](#upload-a-large-file-version-of-existing-file-in-chunks-helper-method)
 * [Upload a large file in Chunks (using helper method)](#upload-a-new-large-file-in-chunks-without-helper-method)
@@ -139,6 +140,29 @@ stream.close();
 [upload]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxFolder.html#uploadFile-java.io.InputStream-java.lang.String-
 [upload2]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxFolder.html#uploadFile-java.io.InputStream-java.lang.String-long-com.box.sdk.ProgressListener-
 
+Upload Preflight Check
+----------------------
+
+You may want to check if a file can be successfully uploaded before beginning the file transfer, in order
+to the time and bandwidth of sending the file over the network if the upload would not have succeeded.
+Calling [`BoxFolder#canUpload(String, long)`][upload-preflight] on the folder you want to upload a new file
+to will verify that there is no name conflict and that the account has enough storage space for the file.
+
+```java
+String fileName = "My Doc.pdf";
+BoxFolder rootFolder = BoxFolder.getRootFolder(api);
+try {
+    folder.canUpload(fileName, 98734576);
+
+    // If the file upload would not have succeeded, it will not be attempted
+    folder.uploadFile(fileContents, fileName);
+} catch (BoxAPIException ex) (
+
+)
+```
+
+[upload-preflight]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxFolder.html#canUpload-java.lang.String-long-
+
 Upload a new large File in Chunks (helper method)
 --------------------------------------------------
 
@@ -264,6 +288,35 @@ This call will update the parts processed and other information in the session i
 ```java
 BoxFileUploadSession.Info updatedSessionInfo = session.getStatus();
 ```
+
+Move a File
+-----------
+
+To move a file from one folder into another, call [`move(BoxFolder)`][move] on the file to be moved
+with the destination folder.
+
+```java
+String fileID = "1234";
+String destinationFolderID = "5678";
+BoxFile file = new BoxFile(api, fileID);
+BoxFolder destinationFolder = new BoxFolder(destinationFolderID);
+file.move(destinationFolder)
+```
+
+To avoid name conflicts in the destination folder, you can optionally provide a new name for the file
+to [`move(BoxFolder, String)`][move-rename].  The file will be placed into the destination folder with
+the new name.
+
+```java
+String fileID = "1234";
+String destinationFolderID = "5678";
+BoxFile file = new BoxFile(api, fileID);
+BoxFolder destinationFolder = new BoxFolder(destinationFolderID);
+file.move(destinationFolder, "Vacation Photo (1).jpg");
+```
+
+[move]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxFile.html#move-com.box.sdk.BoxFolder-
+[move-rename]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxFile.html#move-com.box.sdk.BoxFolder-java.lang.String-
 
 Copy a File
 -----------

--- a/doc/groups.md
+++ b/doc/groups.md
@@ -42,6 +42,22 @@ BoxGroup.Info groupInfo = BoxGroup.createGroup(api, "My Group");
 
 [create-group]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxGroup.html#createGroup-com.box.sdk.BoxAPIConnection-java.lang.String-
 
+Get Information About a Group
+-----------------------------
+
+To look up the information about a group by the group's ID, instantiate the [`BoxGroup`][group-object]
+object with the group ID and then call [`getInfo()`][get-info] on the group.  You can optionally call
+[`getInfo(String... fields)`][get-info-fields] to specify the list of fields to retrieve for the group,
+which can result in reduced payload size.
+
+```java
+String groupID = "92875";
+BoxGroup.Info groupInfo = new BoxGroup(api, groupID).getInfo();
+```
+
+[group-object]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxGroup.html
+[get-info]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxGroup.html#getInfo--
+[get-info-fields]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxGroup.html#getInfo-java.lang.String...-
 
 Update a Group
 --------------

--- a/doc/recent_items.md
+++ b/doc/recent_items.md
@@ -1,0 +1,25 @@
+Recent Items
+============
+
+Recent Items returns information about files that have been accessed by a user not long ago. It keeps track of items
+that were accessed either in the last 90 days or the last 1000 items accessed (both conditions must be met).
+
+* [Get a User's Recent Items](#get-a-users-recent-items)
+
+
+Get a User's Recent Items
+-------------------------
+
+Get a list of all recent items the user has by calling
+[`BoxRecents.getRecentItems(BoxAPIConnection, int, String...)`][get-recents].
+This returns an ordered iterable of the [`BoxRecentItem`][recent-item] records,
+which describe which item the user interacted with, when they interacted with it,
+and what type of interaction it was.
+
+```java
+// Get the latest 100 items the user has interacted with
+Iterable<BoxRecentItem> recentItems = BoxRecents.getRecentItems(api, 100);
+```
+
+[get-recents]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRecents.html#getRecentItems-com.box.sdk.BoxAPIConnection-int-java.lang.String...-
+[recent-item]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxRecentItem.html

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -92,6 +92,23 @@ task.getAssignments();
 
 [get-assignments]: https://box.github.io/box-java-sdk/javadoc/com/box/sdk/BoxTask.html#getAssignments--
 
+Get Information About a Task Assignment
+---------------------------------------
+
+To look up information about a task assignment by its ID, instantiate the
+[`BoxTaskAssignment`][task-assignment-object] object with the ID, and call [`getInfo()`][get-assignment-info]
+on the assignment.  To retrieve only specific fields on the task assignment, call
+[`getInfo(String... fields)`][get-assignment-fields] with the fields to retrieve.
+
+```java
+String assignmentID = "4256974";
+BoxTaskAssignment.Info assignmentInfo = new BoxTaskAssignment(api, assignmentID).getInfo();
+```
+
+[task-assignment-object]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTaskAssignment.html
+[get-assignment-info]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTaskAssignment.html#getInfo--
+[get-assignment-fields]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTaskAssignment.html#getInfo-java.lang.String...-
+
 Add a Task Assignment
 ---------------------
 

--- a/doc/trash.md
+++ b/doc/trash.md
@@ -1,0 +1,147 @@
+Trash
+=====
+
+Under normal circumstances, when an item in Box is deleted, it is not actually erased immediately. Instead, it is
+moved to the Trash. The Trash allows you to recover files and folders that have been deleted. By default, items in
+the Trash will be purged after 30 days.
+
+* [Get Trashed Items](#get-trashed-items)
+* [Get Trashed File Information](#get-trashed-file-information)
+* [Get Trashed Folder Information](#get-trashed-folder-information)
+* [Permanently Delete File From Trash](#permanently-delete-file-from-trash)
+* [Permanently Delete Folder From Trash](#permanently-delete-folder-from-trash)
+* [Restore a File from the Trash](#restore-a-file-from-the-trash)
+* [Restore a Folder from the Trash](#restore-a-folder-from-the-trash)
+
+Get Trashed Items
+-----------------
+
+The [`BoxTrash`][trash-object] implements `Iterable<BoxItem.Info>`, so to get the collection of items currently in the trash,
+simply iterate over it.
+
+```java
+BoxTrash trash = new BoxTrash(api);
+for (BoxItem.Info itemInfo : trash) {
+    // Process the item
+}
+```
+
+[trash-object]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html
+
+Get Trashed File Information
+----------------------------
+
+Ordinarily, trying to call [`getInfo()`][file-get-info] on a file that is in the trash will return a 404 error.
+To get the information of a file in the trash, you must instead call
+[`BoxTrash#getFileInfo(String fileID)`][get-trashed-file] with the ID of the trashed file.  You can optionally
+pass a specific list of fields to retrieve to [`getFileInfo(String fileID, String... fields)`][get-trashed-file-fields],
+which will return only the specified fields to reduce payload size.
+
+```java
+String fileID = "9873459";
+BoxTrash trash = new BoxTrash(api);
+BoxFile.Info fileInfo = trash.getFileInfo(fileID);
+```
+
+[get-trashed-file]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html#getFileInfo-java.lang.String-
+[get-trashed-file-fields]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html#getFileInfo-java.lang.String-java.lang.String...-
+
+Get Trashed Folder Information
+------------------------------
+
+Ordinarily, trying to call [`getInfo()`][folder-get-info] on a folder that is in the trash will return a 404 error.
+To get the information of a folder in the trash, you must instead call
+[`BoxTrash#getFolderInfo(String fileID)`][get-trashed-folder] with the ID of the trashed folder.  You can optionally
+pass a specific list of fields to retrieve to
+[`getFileInfo(String folderID, String... fields)`][get-trashed-folder-fields], which will return only the specified
+fields to reduce payload size.
+
+```java
+String folderID = "2345343";
+BoxTrash trash = new BoxTrash(api);
+BoxFolder.Info folderInfo = trash.getFolderInfo(folderInfo);
+```
+
+[get-trashed-folder]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html#getFolderInfo-java.lang.String-
+[get-trashed-folder-fields]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html#getFolderInfo-java.lang.String-java.lang.String...-
+
+
+Permanently Delete File From Trash
+----------------------------------
+
+To delete a file from the trash, call [`BoxTrash#deleteFile(String fileID)`][delete-file] with the ID of the file to
+delete.
+
+> __Note:__ This will permanently delete the file, and cannot be undone.
+
+```java
+String fileID = "87398";
+BoxTrash trash = new BoxTrash(api);
+trash.deleteFile(fileID);
+```
+
+[delete-file]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html#deleteFile-java.lang.String-
+
+
+Permanently Delete Folder From Trash
+----------------------------------
+
+To delete a folder from the trash, call [`BoxTrash#deleteFolder(String fileID)`][delete-folder] with the ID of the
+folder to delete.
+
+> __Note:__ This will permanently delete the folder, and cannot be undone.
+
+```java
+String folder = "123456";
+BoxTrash trash = new BoxTrash(api);
+trash.deleteFolder(folderID);
+```
+
+[delete-folder]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html#deleteFolder-java.lang.String-
+
+Restore a File from the Trash
+-----------------------------
+
+To restore a file from the trash, effectively undeleting it, call [`BoxTrash#restoreFile(String fileID)`][restore-file]
+with the ID of the file.  To avoid scenarios where the parent folder that previously contained the file is no longer available,
+the user does not have permission to create items in that folder, or that folder has an item with the same name as the one
+being restored; you can pass a new parent folder ID and/or file name to
+[`BoxTrash#restoreFile(String fileID, String newName, String newParentID)`][restore-file-safe].  The new name
+and parent will only be used if a conflict is encountered while trying to restore the file to its original location.
+
+```java
+String fileID = "125367";
+String newName = "Presentation 2018 ORIGINAL.pptx";
+String newParentID = "98765";
+
+BoxTrash trash = new BoxTrash(api);
+// Avoid conflicts at the original location
+trash.restoreFile(fileID, newName, newParentID);
+```
+
+[restore-file]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html#restoreFile-java.lang.String-
+[restore-file-safe]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html#restoreFile-java.lang.String-java.lang.String-java.lang.String-
+
+Restore a Folder from the Trash
+-------------------------------
+
+To restore a folder from the trash, effectively undeleting it, call
+[`BoxTrash#restoreFolder(String folderID)`][restore-folder] with the ID of the folder.  To avoid scenarios where the
+parent folder that previously contained the folder to be restored is no longer available, the user
+does not have permission to create items in that folder, or that folder has an item with the same name as the one
+being restored; you can pass a new parent folder ID and/or folder name to
+[`BoxTrash#restoreFolder(String folderID, String newName, String newParentID)`][restore-folder-safe].  The new name
+and parent will only be used if a conflict is encountered while trying to restore the folder to its original location.
+
+```java
+String folderID = "125367";
+String newName = "My Documents ORIGINAL";
+String newParentID = "98765";
+
+BoxTrash trash = new BoxTrash(api);
+// Avoid conflicts at the original location
+trash.restoreFolder(folderID, newName, newParentID);
+```
+
+[restore-folder]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html#restoreFolder-java.lang.String-
+[restore-folder-safe]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxTrash.html#restoreFolder-java.lang.String-java.lang.String-java.lang.String-

--- a/src/test/java/com/box/sdk/BoxCollaborationTest.java
+++ b/src/test/java/com/box/sdk/BoxCollaborationTest.java
@@ -131,4 +131,18 @@ public class BoxCollaborationTest {
         assertEquals(2, numCollabs);
         uploadedFile.delete();
     }
+
+    @Test
+    @Category(IntegrationTest.class)
+    public void acceptPendingCollaboration() {
+
+        BoxAPIConnection api = new BoxAPIConnection("U08DU2wyWgqHmCmSLGnYtja4iffxRbLO");
+
+        Collection<BoxCollaboration.Info> pendingCollabs = BoxCollaboration.getPendingCollaborations(api);
+        for (BoxCollaboration.Info collabInfo : pendingCollabs) {
+            // Accept the pending collaboration
+            collabInfo.setStatus(BoxCollaboration.Status.ACCEPTED);
+            collabInfo.getResource().updateInfo(collabInfo);
+        }
+    }
 }


### PR DESCRIPTION
A review of our documentation identified 14 endpoints that are fully implemented but not yet documented.  Added documentation for these to help users find these endpoints and understand how to use them in the SDK.