### PR TITLE
Clarify required Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ public final class BoxDeveloperEditionAPIConnectionAsEnterpriseUser {
         accessTokenCache);
 ```
 
+Compatibility
+-------------
+
+The Box Java SDK is compatible with Java 7 and up.
+
 Building
 --------
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'eclipse'
 
-sourceCompatibility = 1.6
+sourceCompatibility = 1.7
 
 group = 'com.box'
 archivesBaseName = 'box-java-sdk'


### PR DESCRIPTION
Because of our dependency on jose4j, the SDK requires at least
Java 7 in order to run.  To clarify this, updating build.gradle
with the correct minimum version and adding a note to the README.

Fixes #482