### PR TITLE
ISSUE #541 Large File Upload Memory

### DIFF
--- a/src/main/java/com/box/sdk/LargeFileUpload.java
+++ b/src/main/java/com/box/sdk/LargeFileUpload.java
@@ -166,7 +166,7 @@ public final class LargeFileUpload {
         long processed = 0;
         int partPostion = 0;
         //Set the Max Queue Size to 1.5x the number of processors
-        double maxQueueSizeDouble = Math.ceil(this.executorService.getMaximumPoolSize()*1.5);
+        double maxQueueSizeDouble = Math.ceil(this.executorService.getMaximumPoolSize() * 1.5);
         int maxQueueSize = Double.valueOf(maxQueueSizeDouble).intValue();
         while (processed < fileSize) {
             //Waiting for any thread to finish before

--- a/src/main/java/com/box/sdk/LargeFileUpload.java
+++ b/src/main/java/com/box/sdk/LargeFileUpload.java
@@ -166,7 +166,8 @@ public final class LargeFileUpload {
         long processed = 0;
         int partPostion = 0;
         //Set the Max Queue Size to 1.5x the number of processors
-        int maxQueueSize = Double.valueOf(this.executorService.getMaximumPoolSize() * 1.5).intValue();
+        double maxQueueSizeDouble = Math.ceil(this.executorService.getMaximumPoolSize()*1.5);
+        int maxQueueSize = Double.valueOf(maxQueueSizeDouble).intValue();
         while (processed < fileSize) {
             //Waiting for any thread to finish before
             long timeoutForWaitingInMillis = TimeUnit.MILLISECONDS.convert(this.timeout, this.timeUnit);

--- a/src/main/java/com/box/sdk/LargeFileUpload.java
+++ b/src/main/java/com/box/sdk/LargeFileUpload.java
@@ -165,6 +165,8 @@ public final class LargeFileUpload {
         long offset = 0;
         long processed = 0;
         int partPostion = 0;
+        //Set the Max Queue Size to 1.5x the number of processors
+        int maxQueueSize = Double.valueOf(this.executorService.getMaximumPoolSize() * 1.5).intValue();
         while (processed < fileSize) {
             //Waiting for any thread to finish before
             long timeoutForWaitingInMillis = TimeUnit.MILLISECONDS.convert(this.timeout, this.timeUnit);
@@ -176,29 +178,32 @@ public final class LargeFileUpload {
                     throw new BoxAPIException("Upload parts timedout");
                 }
             }
-            long diff = fileSize - (long) processed;
-            //The size last part of the file can be lesser than the part size.
-            if (diff < (long) partSize) {
-                partSize = (int) diff;
-            }
-            parts.add(null);
-            byte[] bytes = new byte[partSize];
-            try {
-                int readStatus = stream.read(bytes);
-                if (readStatus == -1) {
-                    throw new BoxAPIException("Stream ended while upload was progressing");
+            if (this.executorService.getQueue().size() < maxQueueSize) {
+                long diff = fileSize - (long) processed;
+                //The size last part of the file can be lesser than the part size.
+                if (diff < (long) partSize) {
+                    partSize = (int) diff;
                 }
-            } catch (IOException ioe) {
-                throw new BoxAPIException("Reading data from stream failed.", ioe);
-            }
-            this.executorService.execute(
-                new LargeFileUploadTask(session.getResource(), bytes, offset, partSize, fileSize, parts, partPostion)
-            );
+                parts.add(null);
+                byte[] bytes = new byte[partSize];
+                try {
+                    int readStatus = stream.read(bytes);
+                    if (readStatus == -1) {
+                        throw new BoxAPIException("Stream ended while upload was progressing");
+                    }
+                } catch (IOException ioe) {
+                    throw new BoxAPIException("Reading data from stream failed.", ioe);
+                }
+                this.executorService.execute(
+                    new LargeFileUploadTask(session.getResource(), bytes, offset,
+                        partSize, fileSize, parts, partPostion)
+                );
 
-            //Increase the offset and proceesed bytes to calculate the Content-Range header.
-            processed += partSize;
-            offset += partSize;
-            partPostion++;
+                //Increase the offset and proceesed bytes to calculate the Content-Range header.
+                processed += partSize;
+                offset += partSize;
+                partPostion++;
+            }
         }
         this.executorService.shutdown();
         this.executorService.awaitTermination(this.timeout, this.timeUnit);


### PR DESCRIPTION
Issue 541 - Out of Memory exceptions due to back log of queued items in the ThreadPoolExecutor

Resolution:
Added Queue Size Handling For ThreadPoolExecutor in LargeFileUpload.uploadParts().  This consisted of a line to determine the Max Queue Size, which was set to 1.5 times the max number of worker threads.  Then adding a check to see if the queue is less than that Max size, before reading in the next set of bytes and adding another task to the queue.