### PR TITLE
Fix collaboration notify parameter

### DIFF
--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -1440,33 +1440,12 @@ public class BoxFile extends BoxItem {
 
     private BoxCollaboration.Info collaborate(JsonObject accessibleByField, BoxCollaboration.Role role,
                                               Boolean notify, Boolean canViewPath) {
-        BoxAPIConnection api = this.getAPI();
-        URL url = ADD_COLLABORATION_URL.build(api.getBaseURL());
 
         JsonObject itemField = new JsonObject();
         itemField.add("id", this.getID());
         itemField.add("type", "file");
 
-        JsonObject requestJSON = new JsonObject();
-        requestJSON.add("item", itemField);
-        requestJSON.add("accessible_by", accessibleByField);
-        requestJSON.add("role", role.toJSONString());
-        if (canViewPath != null) {
-            requestJSON.add("can_view_path", canViewPath.booleanValue());
-        }
-
-        BoxJSONRequest request = new BoxJSONRequest(api, url, "POST");
-        if (notify != null) {
-            request.addHeader("notify", notify.toString());
-        }
-
-        request.setBody(requestJSON.toString());
-        BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
-
-        BoxCollaboration newCollaboration = new BoxCollaboration(api, responseJSON.get("id").asString());
-        BoxCollaboration.Info info = newCollaboration.new Info(responseJSON);
-        return info;
+        return BoxCollaboration.create(this.getAPI(), accessibleByField, itemField, role, notify, canViewPath);
     }
 
     /**

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -935,6 +935,42 @@ public class BoxFolderTest {
     }
 
     @Test
+    @Category(UnitTest.class)
+    public void collaborateWithOptionalParamsSendsCorrectRequest() {
+
+        final String folderID = "983745";
+        final String collaboratorLogin = "boxer@example.com";
+        final BoxCollaboration.Role collaboratorRole = BoxCollaboration.Role.VIEWER;
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new JSONRequestInterceptor() {
+            @Override
+            public BoxJSONResponse onJSONRequest(BoxJSONRequest request, JsonObject body) {
+                Assert.assertEquals(
+                        "https://api.box.com/2.0/collaborations?notify=true",
+                        request.getUrl().toString());
+                Assert.assertEquals("POST", request.getMethod());
+
+                Assert.assertEquals(folderID, body.get("item").asObject().get("id").asString());
+                Assert.assertEquals("folder", body.get("item").asObject().get("type").asString());
+                Assert.assertEquals(collaboratorLogin, body.get("accessible_by").asObject().get("login").asString());
+                Assert.assertEquals("user", body.get("accessible_by").asObject().get("type").asString());
+                Assert.assertEquals(collaboratorRole.toJSONString(), body.get("role").asString());
+
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"type\":\"collaboration\",\"id\":\"98763245\"}";
+                    }
+                };
+            }
+        });
+
+        BoxFolder folder = new BoxFolder(api, folderID);
+        BoxCollaboration.Info collabInfo = folder.collaborate(collaboratorLogin, collaboratorRole, true, true);
+    }
+
+    @Test
     @Category(IntegrationTest.class)
     public void getCollaborationsHasCorrectCollaborations() {
         BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());


### PR DESCRIPTION
Fixed a bug where the `notify` parameter when creating a collab
was placed in a header instead of the query string.

Also did some opportunistic refactoring to consolidate collab
creation API call logic in one place in the BoxCollaboration
class to avoid duplicate code.

Fixes #544