### PR TITLE
Delay successive API calls by EventStream

### DIFF
--- a/src/main/java/com/box/sdk/EventStream.java
+++ b/src/main/java/com/box/sdk/EventStream.java
@@ -22,6 +22,7 @@ public class EventStream {
 
     private static final int LIMIT = 800;
     private static final int STREAM_POSITION_NOW = -1;
+    private static final int DEFAULT_POLLING_DELAY = 1000;
 
     /**
      * Events URL.
@@ -30,6 +31,7 @@ public class EventStream {
 
     private final BoxAPIConnection api;
     private final long startingPosition;
+    private final int pollingDelay;
     private final Collection<EventListener> listeners;
     private final Object listenerLock;
 
@@ -43,7 +45,7 @@ public class EventStream {
      * @param  api the API connection to use.
      */
     public EventStream(BoxAPIConnection api) {
-        this(api, STREAM_POSITION_NOW);
+        this(api, STREAM_POSITION_NOW, DEFAULT_POLLING_DELAY);
     }
 
     /**
@@ -52,10 +54,21 @@ public class EventStream {
      * @param startingPosition the starting position of the event stream.
      */
     public EventStream(BoxAPIConnection api, long startingPosition) {
+        this(api, startingPosition, DEFAULT_POLLING_DELAY);
+    }
+
+    /**
+     * Constructs an EventStream using an API connection and a starting initial position with custom polling delay.
+     * @param api the API connection to use.
+     * @param startingPosition the starting position of the event stream.
+     * @param pollingDelay the delay in milliseconds between successive calls to get more events.
+     */
+    public EventStream(BoxAPIConnection api, long startingPosition, int pollingDelay) {
         this.api = api;
         this.startingPosition = startingPosition;
         this.listeners = new ArrayList<EventListener>();
         this.listenerLock = new Object();
+        this.pollingDelay = pollingDelay;
     }
 
     /**
@@ -207,6 +220,16 @@ public class EventStream {
                     }
                     position = jsonObject.get("next_stream_position").asLong();
                     EventStream.this.notifyNextPosition(position);
+                    try {
+                        // Delay re-polling to avoid making too many API calls
+                        // Since duplicate events may appear in the stream, without any delay added
+                        // the stream can make 3-5 requests per second and not produce any new
+                        // events.  A short delay between calls balances latency for new events
+                        // and the risk of hitting rate limits.
+                        Thread.sleep(EventStream.this.pollingDelay);
+                    } catch (InterruptedException ex) {
+                        return;
+                    }
                 }
             }
         }

--- a/src/test/java/com/box/sdk/EventStreamTest.java
+++ b/src/test/java/com/box/sdk/EventStreamTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -207,5 +208,77 @@ public class EventStreamTest {
         }
 
         verify(eventListener).onEvent(any(BoxEvent.class));
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void delayBetweenCalls() throws InterruptedException {
+
+        final String realtimeServerURL = "/realtimeServer?channel=0";
+        final int delay = 2000;
+        final long[] times = new long[2];
+
+        stubFor(options(urlEqualTo("/events"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"entries\": [ { \"url\": \"http://localhost:53620" + realtimeServerURL + "\", "
+                                + "\"max_retries\": \"3\", \"retry_timeout\": 60000 } ] }")));
+
+        stubFor(get(urlMatching("/events\\?.*stream_position=now.*"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"next_stream_position\": 123 }")));
+
+        stubFor(get(urlMatching("/realtimeServer.*"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"message\": \"new_change\" }")));
+
+        stubFor(get(urlMatching("/events\\?.*stream_position=123"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"next_stream_position\": 456, \"entries\": [ { \"type\": \"event\", "
+                                + "\"event_id\": \"1\" } ] }")));
+
+        stubFor(get(urlMatching("/events\\?.*stream_position=456"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{ \"next_stream_position\": 789, \"entries\": [ { \"type\": \"event\", "
+                                + "\"event_id\": \"1\" } ] }")));
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setBaseURL("http://localhost:53620/");
+
+        final EventStream stream = new EventStream(api, -1, delay);
+        final EventListener eventListener = mock(EventListener.class);
+        stream.addListener(eventListener);
+
+        final Object requestLock = new Object();
+        this.wireMockRule.addMockServiceRequestListener(new RequestListener() {
+            @Override
+            public void requestReceived(Request request, Response response) {
+                boolean firstCall = request.getUrl().contains("stream_position=123");
+                boolean secondCall = request.getUrl().contains("stream_position=456");
+                boolean lastCall = request.getUrl().contains("stream_position=789");
+                if (firstCall) {
+                    times[0] = System.currentTimeMillis();
+                }
+                if (secondCall) {
+                    times[1] = System.currentTimeMillis();
+                }
+                if (lastCall) {
+                    synchronized (requestLock) {
+                        requestLock.notify();
+                    }
+                }
+            }
+        });
+
+        stream.start();
+        synchronized (requestLock) {
+            requestLock.wait();
+        }
+
+        Assert.assertTrue("Calls should be be 2s apart", times[1] - times[0] >= delay);
     }
 }


### PR DESCRIPTION
Inserting a delay between polling calls to get more events in order to control the number of API calls made by the Event Stream.  Because there may be duplicates in the stream, it is currently possible for the stream to make 3-5 calls per second even in cases when the user sees no new events — this is obviously undesirable.  The default is now to wait 1s between calls, and is user-configurable.