### PR TITLE
Adjust JWT expiration interval

### DIFF
--- a/src/main/java/com/box/sdk/BoxDeveloperEditionAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxDeveloperEditionAPIConnection.java
@@ -436,9 +436,9 @@ public class BoxDeveloperEditionAPIConnection extends BoxAPIConnection {
         claims.setIssuer(this.getClientID());
         claims.setAudience(JWT_AUDIENCE);
         if (now == null) {
-            claims.setExpirationTimeMinutesInTheFuture(1.0f);
+            claims.setExpirationTimeMinutesInTheFuture(0.5f);
         } else {
-            now.addSeconds(60L);
+            now.addSeconds(30L);
             claims.setExpirationTime(now);
         }
         claims.setSubject(this.entityID);

--- a/src/test/java/com/box/sdk/BoxDeveloperEditionAPIConnectionTest.java
+++ b/src/test/java/com/box/sdk/BoxDeveloperEditionAPIConnectionTest.java
@@ -117,7 +117,7 @@ public class BoxDeveloperEditionAPIConnectionTest {
                     String jti = claims.getJwtId();
                     long expTimestamp = claims.getExpirationTime().getValue();
 
-                    Assert.assertEquals("JWT should have the expected timestamp", 1511003940L, expTimestamp);
+                    Assert.assertEquals("JWT should have the expected timestamp", 1511003910L, expTimestamp);
                     Assert.assertNotEquals("JWT should have a new jti claim",
                             BoxDeveloperEditionAPIConnectionTest.this.jtiClaim, jti);
 


### PR DESCRIPTION
Setting the JWT expiration interval to the maximum allowed time of
60 seconds is not advisable, since the Box API server will actually
reject a JWT assertion if the exp claim is too far in the future.
Clock drift between the SDK and API of even a few seconds could
then cause the JWT to be rejected.  Setting the expiration
interval to 30 seconds instead should maximum the amount of clock
drift allowable before a JWT would get rejected, reducing the
chances of an error.