### PR TITLE
fixed BoxConfig constructor method where privateKeyPassword was not set

### DIFF
--- a/src/main/java/com/box/sdk/BoxConfig.java
+++ b/src/main/java/com/box/sdk/BoxConfig.java
@@ -62,7 +62,7 @@ public class BoxConfig {
         this.jwtEncryptionPreferences = new JWTEncryptionPreferences();
         this.jwtEncryptionPreferences.setPublicKeyID(publicKeyID);
         this.jwtEncryptionPreferences.setPrivateKey(privateKey);
-        this.jwtEncryptionPreferences.setPrivateKeyPassword(privateKey);
+        this.jwtEncryptionPreferences.setPrivateKeyPassword(privateKeyPassword);
         this.jwtEncryptionPreferences.setEncryptionAlgorithm(encryptionAlgorithm);
     }
 


### PR DESCRIPTION
In one of the contructor of BoxConfig class, privateKey was being set on place of privateKeyPassword due to typo.