### PR TITLE
Quick fix for NPE on request.toString() in interceptor

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -361,27 +361,30 @@ public class BoxAPIRequest {
         builder.append(this.url.toString());
         builder.append(lineSeparator);
 
-        for (Map.Entry<String, List<String>> entry : this.requestProperties.entrySet()) {
-            List<String> nonEmptyValues = new ArrayList<String>();
-            for (String value : entry.getValue()) {
-                if (value != null && value.trim().length() != 0) {
-                    nonEmptyValues.add(value);
+        if (this.requestProperties != null) {
+
+            for (Map.Entry<String, List<String>> entry : this.requestProperties.entrySet()) {
+                List<String> nonEmptyValues = new ArrayList<String>();
+                for (String value : entry.getValue()) {
+                    if (value != null && value.trim().length() != 0) {
+                        nonEmptyValues.add(value);
+                    }
                 }
-            }
 
-            if (nonEmptyValues.size() == 0) {
-                continue;
-            }
+                if (nonEmptyValues.size() == 0) {
+                    continue;
+                }
 
-            builder.append(entry.getKey());
-            builder.append(": ");
-            for (String value : nonEmptyValues) {
-                builder.append(value);
-                builder.append(", ");
-            }
+                builder.append(entry.getKey());
+                builder.append(": ");
+                for (String value : nonEmptyValues) {
+                    builder.append(value);
+                    builder.append(", ");
+                }
 
-            builder.delete(builder.length() - 2, builder.length());
-            builder.append(lineSeparator);
+                builder.delete(builder.length() - 2, builder.length());
+                builder.append(lineSeparator);
+            }
         }
 
         String bodyString = this.bodyToString();

--- a/src/test/java/com/box/sdk/BoxAPIConnectionTest.java
+++ b/src/test/java/com/box/sdk/BoxAPIConnectionTest.java
@@ -641,4 +641,26 @@ public class BoxAPIConnectionTest {
         BoxFile file = new BoxFile(api, "98765");
         file.getInfo();
     }
+
+    @Test
+    @Category(UnitTest.class)
+    public void requestToStringWorksInsideRequestInterceptor() {
+
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(new RequestInterceptor() {
+            @Override
+            public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                String reqString = request.toString();
+                Assert.assertTrue(reqString.length() > 0);
+                return new BoxJSONResponse() {
+                    @Override
+                    public String getJSON() {
+                        return "{\"type\":\"file\",\"id\":\"98765\"}";
+                    }
+                };
+            }
+        });
+
+        BoxFile.Info info = new BoxFile(api, "98765").getInfo();
+    }
 }


### PR DESCRIPTION
Small fix to prevent BoxAPIRequest#toString() from throwing a null
pointer exception inside of a request interceptor.  Ideally, the
request headers would always be available on the request object
instead of being partially stored on the connection, but in lieu
of that more involved fix, this should restore at least some
functionality in the meantime.

Fixes #133 (at least partially)