### PR TITLE
This part of document is outdated(compared to version 2.30.0), becaus…

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -298,10 +298,8 @@ while (processed < fileSize) {
         partSize = diff;
     }
 
-    //Generate a unique part ID
-    String partId = LargeFileUpload.generateHex();
     //Upload a part. It can be uploaded asynchorously
-    BoxFileUploadSessionPart part = session.uploadPart(partId, dis, offset, partSize, fileSize);
+    BoxFileUploadSessionPart part = session.uploadPart(dis, offset, (int)partSize, fileSize);
     parts.add(part);
 
     //Increase the offset and proceesed bytes to calculate the Content-Range header.


### PR DESCRIPTION
The document is outdated(compare to SDK version 2.30.1), for example, BoxFileUploadSession#uploadPart does not have  parameter "partId" and type of "partSize" is int instead of long.