### PR TITLE
Tag code samples for usage in developer docs

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -34,6 +34,7 @@ console](https://cloud.app.box.com/developers/services).
 
 The following example creates an API connection with a developer token:
 
+<!-- sample get_authorize -->
 ```java
 BoxAPIConnection api = new BoxAPIConnection("YOUR-DEVELOPER-TOKEN");
 ```
@@ -95,6 +96,7 @@ they will be redirected to your application's `redirect_uri` which will contain
 an auth code. This auth code can then be used along with your client ID and
 client secret to establish an API connection.
 
+<!-- sample post_token -->
 ```java
 BoxAPIConnection api = new BoxAPIConnection("YOUR-CLIENT-ID",
     "YOUR-CLIENT-SECRET", "YOUR-AUTH-CODE");
@@ -183,6 +185,7 @@ Revoke Token
 
 At any point if you wish to revoke your tokens you can do so by calling the following. 
 
+<!-- sample post_revoke -->
 ```java
 BoxAPIConnection api = new BoxAPIConnection("YOUR-ACCESS-TOKEN");
 api.revokeToken();

--- a/doc/collaboration_whitelists.md
+++ b/doc/collaboration_whitelists.md
@@ -27,6 +27,7 @@ A collaboration whitelist can be created for a domain with
 The `WhitelistDirection` parameter determines which way the whitelisting
 applies. You can set the value to inbound, outbound, or both.
 
+<!-- sample post_collaboration_whitelist_entries -->
 ```java
 BoxCollaborationWhitelist.create(api, "test.com", BoxCollaborationWhitelist.WhitelistDirection.BOTH);
 ```
@@ -39,6 +40,7 @@ Get a Collaboration Whitelist's Information for a Domain
 A specific collaboration whitelist for a domain can be retrieved with
 [`getInfo()`][getWhitelistInfo]
 
+<!-- sample get_collaboration_whitelist_entries_id -->
 ```java
 BoxCollaborationWhitelist domainWhitelist = new BoxCollaborationWhitelist(api, "id");
 domainWhitelist.getInfo();
@@ -52,6 +54,7 @@ Get all Collaboration Whitelist's Information for Domain
 All domain collaboration whitelists associated with an enterprise can be
 retrieved with [`getAll(BoxAPIConnection api)`][getAllWhitelists1]
 
+<!-- sample get_collaboration_whitelist_entries -->
 ```java
 BoxCollaborationWhitelist.getAll(api);
 ```
@@ -71,6 +74,7 @@ Remove a Collaboration Whitelist for a Domain
 
 To remove a collaboration whitelist you can call [`delete()`][deleteWhitelist]
 
+<!-- sample delete_collaboration_whitelist_entries_id -->
 ```java
 BoxCollaborationWhitelist domainToBeDeleted = new BoxCollaborationWhitelist(api, "whitelist-id");
 domainToBeDeleted.delete();
@@ -84,6 +88,7 @@ Add a Collaboration Whitelist for a User
 A collaboration whitelist can be created for a user with
 [`create(BoxAPIConnection api, String userID)`][createExempt]
 
+<!-- sample post_collaboration_whitelist_exempt_targets -->
 ```java
 String userID = "12345";
 BoxCollaborationWhitelistExemptTarget.create(api, userID);
@@ -97,6 +102,7 @@ Get a Collaboration Whitelist's Information for a User
 To retrieve information regarding a specific user collaboration whitelist use
 [`getInfo()`][getInfoExempt]
 
+<!-- sample get_collaboration_whitelist_exempt_targets_id -->
 ```java
 BoxCollaborationWhitelistExemptTarget userWhitelist = new BoxCollaborationWhitelistExemptTarget(api, "whitelistID");
 userWhitelist.getInfo();
@@ -110,6 +116,7 @@ Get all Collaboration Whitelist's Information for a User
 To retrieve information regarding all user whitelists associated with an enterprise use
 [`getAll(BoxAPIConnection api)`][getAllExempt1]
 
+<!-- sample get_collaboration_whitelist_exempt_targets -->
 ```java
 BoxCollaborationWhitelistExemptTarget.getAll(api);
 ```
@@ -131,6 +138,7 @@ Remove a Collaboration Whitelist for a User
 To remove a user collaboration whitelist entry from an enterprise use
 [`delete()`][deleteExempt]
 
+<!-- sample delete_collaboration_whitelist_exempt_targets_id -->
 ```java
 BoxCollaborationWhitelistExemptTarget userWhitelist = new BoxCollaborationWhitelistExemptTarget(api, "whitelist_id") 
 userWhitelist.delete();

--- a/doc/collaborations.md
+++ b/doc/collaborations.md
@@ -27,6 +27,7 @@ A collaboration can be added for an existing user or group with
 `role` parameter determines what permissions the collaborator will have on the
 folder.
 
+<!-- sample post_collaborations -->
 ```java
 BoxCollaborator user = new BoxUser(api, "user-id")
 BoxFolder folder = new BoxFolder(api, "folder-id");
@@ -52,6 +53,7 @@ A collaboration can be edited by creating a new
 [`BoxCollaboration.Info`][box-collaboration-info] object or updating an existing
 one, and then passing it to [`updateInfo(BoxCollaboration.Info fieldsToUpdate)`][update-info]
 
+<!-- sample put_collaborations_id -->
 ```java
 BoxCollaboration collaboration = new BoxCollaboration(api, "id");
 BoxCollaboration.Info info = collaboration.new Info();
@@ -67,6 +69,7 @@ Remove a Collaboration
 
 A collaboration can be removed by calling [`delete()`][delete].
 
+<!-- sample delete_collaborations_id -->
 ```java
 BoxCollaboration collaboration = new BoxCollaboration(api, "id");
 collaboration.delete();
@@ -80,6 +83,7 @@ Get a Collaboration's Information
 Calling [`getInfo()`][get-info] on a collaboration returns a snapshot of the
 collaboration's info.
 
+<!-- sample get_collaborations_id -->
 ```java
 BoxCollaboration collaboration = new BoxCollaboration(api, "id");
 BoxCollaboration.Info info = collaboration.getInfo();
@@ -102,6 +106,7 @@ Get the Collaborations on a Folder
 You can get all of the collaborations on a folder by calling
 [`getCollaborations()`][get-collaborations] on the folder.
 
+<!-- sample get_folders_id_collaborations -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id");
 Collection<BoxCollaboration.Info> collaborations = folder.getCollaborations();
@@ -116,6 +121,7 @@ You can get an iterator over all of the collaborations on a file by calling
 [`BoxFile#getAllFileCollaborations(String... fields)`][get-collaborations-file]
 on the file.
 
+<!-- sample get_files_id_collaborations -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 Iterable<BoxCollaboration.Info> collaborations = file.getAllFileCollaborations();
@@ -129,6 +135,7 @@ Get Pending Collaborations
 A collection of all the user's pending collaborations can be retrieved with
 [`getPendingCollaborations(BoxAPIConnection api)`][get-pending-collaborations].
 
+<!-- sample get_collaborations -->
 ```java
 Collection<BoxCollaboration.Info> pendingCollaborations =
     BoxCollaboration.getPendingCollaborations(api);
@@ -142,6 +149,7 @@ Accept or Decline a Pending Collaboration
 To accept or decline a pending collaboration, update the info of the pending collaboration object
 with the desired status.
 
+<!-- sample put_collaborations_id -->
 ```java
 // Accept all pending collaborations
 Collection<BoxCollaboration.Info> pendingCollaborations = BoxCollaboration.getPendingCollaborations(api);

--- a/doc/collections.md
+++ b/doc/collections.md
@@ -24,6 +24,7 @@ Existing collections can be retrieved by calling the
 [`getAllCollections(BoxAPIConnection)`][get-collections] method. Currently only
 "Favorites" collection is supported.
 
+<!-- sample get_collections -->
 ```java
 Iterable<BoxCollection.Info> collections = BoxCollection.getAllCollections(api);
 for (BoxCollection.Info collectionInfo : collections) {
@@ -41,6 +42,7 @@ you to iterate over the collection's contents. The iterator automatically
 handles paging and will make additional network calls to load more data from Box
 when necessary.
 
+<!-- sample get_collections_id_items -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id");
 for (BoxItem.Info itemInfo : folder) {

--- a/doc/comments.md
+++ b/doc/comments.md
@@ -23,6 +23,7 @@ Get a Comment's Information
 Calling [`getInfo()`][get-info] on a comment returns a snapshot of the comment's
 info.
 
+<!-- sample get_comments_id -->
 ```java
 BoxComment comment = new BoxComment(api, "id");
 BoxComment.Info info = comment.getInfo();
@@ -36,6 +37,7 @@ Get the Comments on a File
 You can get all of the comments on a file by calling the
 [`getComments()`][get-comments] method.
 
+<!-- sample get_files_id_comments -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 List<BoxComment.Info> comments = file.getComments();
@@ -49,6 +51,7 @@ Add a Comment to a File
 A comment can be added to a file with the [`addComment(String message)`][add-comment]
 method.
 
+<!-- sample post_comments -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 file.addComment("This file is pretty cool.");
@@ -85,6 +88,7 @@ Change a Comment's Message
 The message of a comment can be changed with the
 [`changeMessage(String message)`][change-message] method.
 
+<!-- sample put_comments_id -->
 ```java
 BoxComment comment = new BoxComment(api, "id");
 comment.changeMessage("An edited message.");
@@ -97,6 +101,7 @@ Delete a Comment
 
 A comment can be deleted with the [`delete()`][delete] method.
 
+<!-- sample delete_comments_id -->
 ```java
 BoxComment comment = new BoxComment(api, "id");
 comment.delete();

--- a/doc/devices.md
+++ b/doc/devices.md
@@ -23,6 +23,7 @@ enterprise with given ID. It is possible to specify maximum number of retrieved
 items per single response by passing the maxiumum number of records to retrieve to
 [`getEnterpriceDevicePins(BoxAPIConnection api, String enterpriseID, int limit, String... fields)`][get-enterprise-device-pins-with-limit]
 
+<!-- sample get_enterprises_id_device_pinners -->
 ```java
 Iterable<BoxDevicePin.Info> enterpriseDevicePins = BoxDevicePin.getEnterpriceDevicePins(api, id);
 for (BoxDevicePin.Info devicePin : enterpriseDevicePins) {
@@ -39,6 +40,7 @@ Get Device Pin
 Existing collections can be retrieved by calling the [`getInfo(String... fields)`][get-device-pin] method.
 Optional parameters can be used to retrieve specific fields of the Device Pin object.
 
+<!-- sample get_device_pinners_id -->
 ```java
 BoxDevicePin devicePin = new BoxDevicePin(api, id);
 BoxDevicePin.Info devicePinInfo = devicePin.getInfo();
@@ -51,6 +53,7 @@ Delete Device Pin
 
 A device pin can be deleted by calling the [`delete()`][delete] method.
 
+<!-- sample delete_device_pinners_id -->
 ```java
 BoxDevicePin devicePin = new BoxDevicePin(api, id);
 devicePin.delete();

--- a/doc/events.md
+++ b/doc/events.md
@@ -31,6 +31,7 @@ start from a known stream position, pass the stream position to the
 [`EventStream(BoxAPIConnection api, long streamPosition)`][event-stream-position]
 constructor.
 
+<!-- sample get_events -->
 ```java
 EventStream stream = new EventStream(api);
 stream.addListener(new EventListener() {

--- a/doc/files.md
+++ b/doc/files.md
@@ -48,6 +48,7 @@ Get a File's Information
 
 Calling [`getInfo()`][get-info] on a file returns a snapshot of the file's info.
 
+<!-- sample get_files_id -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 BoxFile.Info info = file.getInfo();
@@ -73,6 +74,7 @@ Updating a file's information is done by creating a new [`BoxFile.Info`][box-fil
 object or updating an existing one, and then calling
 [`updateInfo(BoxFile.Info fieldsToUpdate)`][update-info].
 
+<!-- sample put_files_id -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 BoxFile.Info info = file.new Info();
@@ -89,6 +91,7 @@ Download a File
 A file can be downloaded by calling [`download(OutputStream stream)`][download]
 and providing an `OutputStream` where the file's contents will be written.
 
+<!-- sample get_files_id_content -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 BoxFile.Info info = file.getInfo();
@@ -128,6 +131,7 @@ Files are uploaded to a folder by calling the
 [`uploadFile(InputStream fileContents, String fileName)`][upload] method
 on the [`BoxFolder`][box-folder] you want to upload the file into.
 
+<!-- sample post_files_content -->
 ```java
 BoxFolder rootFolder = BoxFolder.getRootFolder(api);
 FileInputStream stream = new FileInputStream("My File.txt");
@@ -176,6 +180,7 @@ the network if the upload would not have succeeded.  Calling the
 on the folder you want to upload a new file into will verify that there is no
 name conflict and that the account has enough storage space for the file.
 
+<!-- sample options_files_content -->
 ```java
 String fileName = "My Doc.pdf";
 BoxFolder rootFolder = BoxFolder.getRootFolder(api);
@@ -389,6 +394,7 @@ A file can be copied to a new folder and optionally be renamed with the
 [`copy(BoxFolder destination)`][copy] and
 [`copy(BoxFolder destination, String newName)`][copy2] methods.
 
+<!-- sample post_files_id_copy -->
 ```java
 // Copy a file into the user's root folder
 BoxFolder rootFolder = BoxFolder.getRootFolder(api);
@@ -404,6 +410,7 @@ Delete a File
 
 Calling the [`delete()`][delete] method will move the file to the user's trash.
 
+<!-- sample delete_files_id -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 file.delete();
@@ -417,6 +424,7 @@ Get Previous Versions of a File
 For users with premium accounts, versions of a file can be retrieved with the
 [`getVersions()`][get-versions] method.
 
+<!-- sample get_files_id_versions -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 List<BoxFileVersion> versions = file.getVersions();
@@ -434,6 +442,7 @@ New versions of a file can be uploaded with the
 [`uploadVersion(InputStream fileContents)`][upload-version]
 method.
 
+<!-- sample post_files_id_content -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 FileInputStream stream = new FileInputStream("My File.txt");
@@ -448,6 +457,7 @@ Download a Previous Version of a File
 For users with premium accounts, previous versions of a file can be downloaded
 by calling [`download(OutputStream output)`][download-version].
 
+<!-- sample get_files_id_content -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 List<BoxFileVersion> versions = file.getVersions();
@@ -466,6 +476,7 @@ Promote a Previous Version of a File
 A previous version of a file can be promoted with the [`promote()`][promote]
 method to become the current version of the file.
 
+<!-- sample post_files_id_versions_current -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 List<BoxFileVersion> versions = file.getVersions();
@@ -481,6 +492,7 @@ Delete a Previous Version of a File
 A version of a file can be deleted and moved to the trash by calling
 [`delete()`][delete-version].
 
+<!-- sample delete_files_id_versions_id -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 List<BoxFileVersion> versions = file.getVersions();
@@ -646,6 +658,7 @@ Metadata can be created on a file by calling
 Note: This method will only succeed if the provided metadata template is not currently applied to the file, otherwise
 it will fail with a Conflict error.
 
+<!-- sample post_files_id_metadata_id_id -->
 ```java
 // Add property "foo" with value "bar" to the default metadata properties
 BoxFile file = new BoxFile(api, "id");
@@ -654,6 +667,7 @@ file.createMetadata(new Metadata().add("/foo", "bar"));
 
 Update a files Metadata by calling [`updateMetadata(Metadata properties)`][update-metadata].
 
+<!-- sample put_files_id_metadata_id_id -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 file.updateMetadata(new Metadata().add("/foo", "bar"));
@@ -677,6 +691,7 @@ Retrieve a files Metadata by calling [`getMetadata()`][get-metadata],
 [`getMetadata(String templateKey, String templateScope)`][get-metadata-3].
 These methods return a [`Metadata`][metadata] object, which allows access to metadata values.
 
+<!-- sample get_files_id_metadata_id_id -->
 ```java
 // Get the default free-form metadata properties
 BoxFile file = new BoxFile(api, "id");
@@ -723,6 +738,7 @@ A files Metadata can be deleted by calling
 [`deleteMetadata(String templateKey)`][delete-metadata-2], or
 [`deleteMetadata(String templateKey, String templateScope)`][delete-metadata-3].
 
+<!-- sample delete_files_id_metadata_id_id -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 file.deleteMetadata("myMetadataTemplate");
@@ -738,6 +754,7 @@ Get All Metadata on File
 Calling the [`getAllMetadata()`][get-all-metadata] method on a file will return
 an iterable that will page through all of the metadata associated with the file.
 
+<!-- sample get_files_id_metadata -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 Iterable<Metadata> metadataList = file.getAllMetadata();

--- a/doc/folders.md
+++ b/doc/folders.md
@@ -58,6 +58,7 @@ Every `BoxFolder` implements [`Iterable<BoxItem>`][iterator] which allows you to
 iterate over the folder's contents. The iterator automatically handles paging
 and will make additional API calls to load more data when necessary.
 
+<!-- sample get_folders_id_items -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id");
 for (BoxItem.Info itemInfo : folder) {
@@ -106,6 +107,7 @@ Get a Folder's Information
 Calling [`getInfo()`][get-info] on a folder returns a snapshot of the folder's
 info.
 
+<!-- sample get_folders_id -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id");
 BoxFolder.Info info = folder.getInfo();
@@ -131,6 +133,7 @@ Updating a folder's information is done by creating a new `BoxFolder.Info`
 object or updating an existing one, and then calling
 [`updateInfo(BoxFolder.Info fieldsToUpdate)`][update-info].
 
+<!-- sample put_folders_id -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id");
 BoxFolder.Info info = folder.new Info();
@@ -146,6 +149,7 @@ Create a Folder
 Create a child folder by calling [`createFolder(String folderName)`][create-folder]
 on the parent folder.
 
+<!-- sample post_folders -->
 ```java
 BoxFolder parentFolder = new BoxFolder(api, "id");
 BoxFolder.Info childFolderInfo = parentFolder.createFolder("Child Folder Name");
@@ -159,6 +163,7 @@ Copy a Folder
 Call the [`copy(BoxFolder destination)`][copy] method to copy a folder to
 another folder.
 
+<!-- sample post_folders_id_copy -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id1");
 BoxFolder destination = new BoxFolder(api, "id2");
@@ -223,6 +228,7 @@ A folder can be deleted with the [`delete(boolean recursive)`][delete] method. P
 `true` to this method indicates that the folder and its contents should be
 recursively deleted.
 
+<!-- sample delete_folders_id -->
 ```java
 // Delete the folder and all its contents
 BoxFolder folder = new BoxFolder(api, "id");
@@ -292,6 +298,7 @@ Get All Collaborations for a Folder
 The [`getCollaborations()`][get-collaborations] method will return a collection
 of `BoxCollaboration.Info` objects for a folder.
 
+<!-- sample get_folders_id_collaborations -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id");
 Collection<BoxCollaboration.Info> collaborations = folder.getCollaborations();
@@ -320,6 +327,7 @@ Metadata can be created on a folder by calling
 Note: This method will only succeed if the provided metadata template is not currently applied to the folder, otherwise
 it will fail with a Conflict error.
 
+<!-- sample post_folders_id_metadata_id_id -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id");
 folder.createMetadata(new Metadata().add("/foo", "bar"));
@@ -343,7 +351,7 @@ Retrieve a folder's metadata by calling [`getMetadata()`][get-metadata],
 [`getMetadata(String templateKey, String templateScope)`][get-metadata-3].
 These methods return a [`Metadata`][metadata] object, which allows access to metadata values.
 
-
+<!-- sample get_folders_id_metadata_id_id -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id");
 Metadata metadata = folder.getMetadata();
@@ -371,6 +379,7 @@ Update Metadata
 
 Update a folder's metadata by calling [`updateMetadata(Metadata properties)`][update-metadata].
 
+<!-- sample put_folders_id_metadata_id_id -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id");
 folder.updateMetadata(new Metadata().add("/foo", "bar"));
@@ -386,6 +395,7 @@ A folder's metadata can be deleted by calling
 [`deleteMetadata(String templateKey)`][delete-metadata-2], or
 [`deleteMetadata(String templateKey, String templateScope)`][delete-metadata-3].
 
+<!-- sample delete_folders_id_metadata_id_id -->
 ```java
 BoxFolder folder = new BoxFolder(api, "id");
 folder.deleteMetadata("myMetadataTemplate");
@@ -400,6 +410,7 @@ Get All Metadata on Folder
 
 [`getAllMetadata()`][get-all-metadata] method will return an iterable that will page through all of the metadata associated with the folder.
 
+<!-- sample get_folders_id_metadata -->
 ```java
 BoxFolder file = new BoxFolder(api, "id");
 Iterable<Metadata> metadataList = folder.getAllMetadata();
@@ -502,6 +513,7 @@ Get a Cascade Policy's Information
 To retrieve information about a specific metadata cascade policy, call 
 [`getInfo()`][get-info]
 
+<!-- sample get_metadata_cascade_policies_id -->
 ```java
 String cascadePolicyID = "1234";
 BoxMetadataCascadePolicy metadataCascadePolicy = new BoxMetadataCascadePolicy(api, cascadePolicyID);
@@ -516,6 +528,7 @@ Get All Cascade Policies on Folder
 To get a list of all cascade policies on a folder, which show the metadata templates that are being applied to all 
 items in the folder, call [`getMetadataCascadePolicies()`][get-all] on that folder.
 
+<!-- sample get_metadata_cascade_policies -->
 ```java
 String folderID = "2222";
 BoxFolder folder = new BoxFolder(api, folderID);
@@ -548,6 +561,7 @@ Force Apply Cascade Policy on Folder
 To force apply a metadata template policy and apply metadata values to all existing items in an affected folder, call 
 [`forceApply(String conflictResolution)`][force-apply] with the conflict resolution method for dealing with items that already have a metadata value that conflicts with the folder. Specifying a resolution value of `none` will preserve the existing values on items, and specifying `overwrite` will overwrite values on items in the folder with the metadata value from the folder.
 
+<!-- sample post_metadata_cascade_policies_id_apply -->
 ```java
 String cascadePolicyID = "e4392a41-7de5-4232-bdf7-15e0d6bba067";
 BoxMetadataCascadePolicy policy = new BoxMetadataCascadePolicy(api, cascadePolicyID);
@@ -562,6 +576,7 @@ Delete Cascade Policy
 To remove a cascade policy and stop applying metadata from a folder to items in the folder,
 call [`delete()`][delete-cascade-policy].
 
+<!-- sample delete_metadata_cascade_policies_id -->
 ```java
 String cascadePolicyID = "e4392a41-7de5-4232-bdf7-15e0d6bba067";
 BoxMetadataCascadePolicy policyToDelete = new BoxMetadataCascadePolicy(api, cascadePolicyID);

--- a/doc/groups.md
+++ b/doc/groups.md
@@ -28,6 +28,7 @@ Get All Groups
 Calling the static [`getAllGroups(BoxAPIConnection api)`][get-all-groups] will
 return an iterable that will page through all of the user's groups.
 
+<!-- sample get_groups -->
 ```java
 Iterable<BoxGroup.Info> groups = BoxGroup.getAllGroups(api);
 for (BoxGroup.Info groupInfo : groups) {
@@ -43,6 +44,7 @@ Create a Group
 The static [`createGroup(BoxAPIConnection api, String name)`][create-group] method will
 let you create a new group with a specified name.
 
+<!-- sample post_groups -->
 ```java
 BoxGroup.Info groupInfo = BoxGroup.createGroup(api, "My Group");
 ```
@@ -57,6 +59,7 @@ object with the group ID and then call [`getInfo()`][get-info] on the group.  Yo
 [`getInfo(String... fields)`][get-info-fields] to specify the list of fields to retrieve for the group,
 which can result in reduced payload size.
 
+<!-- sample get_groups_id -->
 ```java
 String groupID = "92875";
 BoxGroup.Info groupInfo = new BoxGroup(api, groupID).getInfo();
@@ -71,6 +74,7 @@ Update a Group
 
 To update a group, call [`updateInfo(BoxGroup.Info fieldsToUpdate)`][update-group] method.
 
+<!-- sample put_groups_id -->
 ```java
 BoxGroup group = new BoxGroup(api, id);
 BoxGroup.Info groupInfo = group.getInfo();
@@ -86,6 +90,7 @@ Delete a Group
 
 A group can be deleted by calling the [`delete()`][delete] method.
 
+<!-- sample delete_groups_id -->
 ```java
 BoxGroup group = new BoxGroup(api, "id");
 group.delete();
@@ -98,6 +103,7 @@ Get a Groups collaborations
 
 A groups collaborations can be retrieved by calling the [`getCollaborations()`][get-collaborations] method.
 
+<!-- sample get_groups_id_collaborations -->
 ```java
 BoxGroup group = new BoxGroup(api, "id");
 group.getCollaborations();
@@ -112,6 +118,7 @@ Membership for the group can be created by calling the
 [`addMembership(BoxUser user)`][add-membership] and
 [`addMembership(BoxUser user, BoxGroupMembership.Role role)`][add-membership2] methods.
 
+<!-- sample post_group_memberships -->
 ```java
 BoxGroup group = new BoxGroup(api, "groupID");
 BoxUser user = new BoxUser(api, "userID");
@@ -126,6 +133,7 @@ Get Membership
 
 A groups membership can be retrieved by calling the [`BoxGroupMembership.getInfo()`][get-membership] method.
 
+<!-- sample get_group_memberships_id -->
 ```java
 BoxGroupMembership membership = new BoxGroupMembership(api, id);
 BoxGroupMembership.Info groupMembershipInfo = membership.getInfo();
@@ -139,6 +147,7 @@ Update Membership
 A groups membership can be updated by calling the
 [`BoxGroupMembership.updateInfo(BoxGroupMembership.Info fieldsToUpdate)`][update-membership] method.
 
+<!-- sample put_group_memberships_id -->
 ```java
 BoxGroupMembership membership = new BoxGroupMembership(api, id);
 BoxGroupMembership.Info info = membership.new Info();
@@ -153,6 +162,7 @@ Delete Membership
 
 A group can be deleted by calling the [`BoxGroupMembership.delete()`][delete-membership] method.
 
+<!-- sample delete_group_memberships_id -->
 ```java
 BoxGroupMembership membership = new BoxGroupMembership(api, id);
 membership.delete();
@@ -166,6 +176,7 @@ Get Memberships for Group
 Calling the [`getAllMemberships(String... fields)`][get-memberships-for-group] will return an iterable that will page through all of the group's memberships.
 Optional parameters can be used to retrieve specific fields of the Group Membership object.
 
+<!-- sample get_groups_id_memberships -->
 ```java
 BoxGroup group = new BoxGroup(api, id);
 Iterable<BoxGroupMembership.Info> memberships = group.getAllMemberships();
@@ -182,6 +193,7 @@ Get Memberships for User
 Calling the [`BoxUser.getAllMemberships(String... fields)`][get-memberships-for-user] will return an iterable that will page through all of the user's memberships.
 Optional parameters can be used to retrieve specific fields of the Group Membership object.
 
+<!-- sample get_users_id_memberships -->
 ```java
 BoxUser user = new BoxUser(api, id);
 Iterable<BoxGroupMembership.Info> memberships = user.getAllMemberships();

--- a/doc/legal_holds.md
+++ b/doc/legal_holds.md
@@ -29,6 +29,7 @@ Calling [`getInfo(String...)`][get-info] will return a BoxLegalHoldPolicy.Info o
 containing information about the legal hold policy. If necessary to retrieve
 limited set of fields, it is possible to specify them using param.
 
+<!-- sample get_legal_hold_policies_id -->
 ```java
 BoxLegalHoldPolicy policy = new BoxLegalHoldPolicy(api, id);
 BoxLegalHoldPolicy.Info policyInfo = policy.getInfo();
@@ -45,6 +46,7 @@ It is possible to specify name of legal hold policy, maximum number of items per
 response and fields to retrieve by calling the static
 [`getAll(BoxAPIConnection, String, int, String...)`][get-list-of-legal-hold-policies-with-fields] method.
 
+<!-- sample get_legal_hold_policies -->
 ```java
 Iterable<BoxLegalHoldPolicy.Info> policies = BoxLegalHoldPolicy.getAll(api);
 for (BoxLegalHoldPolicy.Info policyInfo : policies) {
@@ -61,6 +63,7 @@ Create New Legal Hold Policy
 The static [`create(BoxAPIConnection api, String name, String description, Date startDate, Date endDate)`][create-new-legal-hold-policy-with-dates]
 method will let you create a new legal hold policy with a specified name, description, start and end dates.
 
+<!-- sample post_legal_hold_policies -->
 ```java
 BoxLegalHoldPolicy.Info policyInfo = BoxLegalHoldPolicy.create(api, name, description, startedAt, endedAt);
 ```
@@ -81,6 +84,7 @@ Update Existing Legal Hold Policy
 Updating a legal hold policy's information is done by calling
 [`updateInfo(BoxLegalHoldPolicy.Info fieldsToUpdate)`][update-info].
 
+<!-- sample put_legal_hold_policies_id -->
 ```java
 BoxLegalHoldPolicy policy = new BoxLegalHoldPolicy(api, id);
 BoxLegalHoldPolicy.Info policyInfo = policy.new Info();
@@ -95,6 +99,7 @@ Delete Legal Hold Policy
 
 A legal hold policy can be deleted by calling the [`delete()`][delete] method.
 
+<!-- sample delete_legal_hold_policies_id -->
 ```java
 BoxLegalHoldPolicy policy = new BoxLegalHoldPolicy(api, id);
 policy.delete();
@@ -108,6 +113,7 @@ Get Assignment
 Calling [`getInfo(String... fields)`][get-assignment] will return a BoxLegalHoldAssignment.Info 
 object containing information about the legal hold policy assignment.
 
+<!-- sample get_legal_hold_policy_assignments_id -->
 ```java
 BoxLegalHoldAssignment assignment = new BoxLegalHoldAssignment(api, id);
 BoxLegalHoldAssignment.Info info = assignment.getInfo("assigned_by");
@@ -124,6 +130,7 @@ It is possible to specify filters for type and id, maximum number of items per s
 response and fields to retrieve by calling
 [`getAssignments(String type, String id, int limit, String... fields)`][get-list-of-assignments-with-params].
 
+<!-- sample get_legal_hold_policy_assignment -->
 ```java
 BoxLegalHoldPolicy policy = new BoxLegalHoldPolicy(api, id);
 Iterable<BoxLegalHoldAssignment.Info> assignments = policy.getAssignments(BoxResource.getResourceType(BoxFolder.class), null, 50, "assigned_at");
@@ -141,6 +148,7 @@ Create New Assignment
 To create new legal hold policy assignment call [`assignTo(BoxResource target)`][create-assignment] method. 
 Currently only BoxFile, BoxFileVersion, BoxFolder and BoxUser objects are supported as a parameter.
 
+<!-- sample post_legal_hold_policy_assignments -->
 ```java
 BoxLegalHoldPolicy policy = new BoxLegalHoldPolicy(api, policyID);
 BoxFolder folder = new BoxFolder(api, folderID);
@@ -155,6 +163,7 @@ Delete Assignment
 A legal hold policy assignment can be deleted by calling the [`delete()`][delete-assignment] method 
 of BoxLegalHoldAssignment object.
 
+<!-- sample delete_legal_hold_policy_assignments_id -->
 ```java
 BoxLegalHoldAssignment assignment = new BoxLegalHoldAssignment(api, id);
 assignment.delete();
@@ -168,6 +177,7 @@ Get File Version Legal Hold
 Calling [`getInfo(String... fields)`][get-file-version-legal-hold] will return 
 a BoxFileVersionLegalHold.Info object containing information about the file version legal hold policy.
 
+<!-- sample get_file_version_legal_holds_id -->
 ```java
 BoxFileVersionLegalHold hold = new BoxFileVersionLegalHold(api, id);
 hold.getInfo("file");
@@ -182,6 +192,7 @@ legal hold policy, call [`getFileVersionHolds(String... fields)`][get-lest-of-fi
 It is possible to specify maximum number of items per single response by calling
 [`getFileVersionHolds(int limit, String... fields)`][get-lest-of-file-version-legal-holds-with-limit].
 
+<!-- sample get_file_version_legal_holds -->
 ```java
 BoxLegalHoldPolicy policy = new BoxLegalHoldPolicy(api, id);
 Iterable<BoxFileVersionLegalHold.Info> fileVersionHolds = policy.getFileVersionHolds();

--- a/doc/metadata_template.md
+++ b/doc/metadata_template.md
@@ -25,6 +25,7 @@ method will create a metadata template schema.
 
 You can create custom metadata fields that will be associated with the metadata template.
 
+<!-- sample post_metadata_templates_schema -->
 ```java
 MetadataTemplate.Field metadataField = new MetadataTemplate.Field();
 metadataField.setType("string");
@@ -52,6 +53,7 @@ To update an existing metadata template, call the
 [`updateMetadataTemplate(BoxAPIConnection api, String scope, String template, List<FieldOperation> fieldOperations)`][update-metadata-template]
 method with the scope and key of the template, and the list of field operations to perform:
 
+<!-- sample put_metadata_templates_id_id_schema -->
 ```java
 List<MetadataTemplate.FieldOperation> updates = new ArrayList<MetadataTemplate.FieldOperation>();
 
@@ -79,6 +81,7 @@ method will return information about default metadata schema.  Also,
 [`getMetadataTemplate(BoxAPIConnection api, String templateKey, String templateScope, String... fields)`][get-metadata-template-3]
 can be used to set metadata template name, metadata scope and fields to retrieve.
 
+<!-- sample get_metadata_templates_id_id_schema -->
 ```java
 MetadataTemplate template = MetadataTemplate.getMetadataTemplate(api, "templateName");
 ```
@@ -92,6 +95,7 @@ MetadataTemplate template = MetadataTemplate.getMetadataTemplate(api, "templateN
 The static [`MetadataTemplate.getMetadataTemplateByID(BoxAPIConnection api, String templateID)`][get-template-by-id]
 method will return a specific metadata template.
 
+<!-- sample get_metadata_templates_id -->
 ```java
 MetadataTemplate template = MetadataTemplate.getMetadataTemplateByID(api, "37c0204b-3fe1-4a32-b9da-f28e88f4c4c6");
 ```
@@ -108,6 +112,7 @@ Also, [`getEnterpriseMetadataTemplates(String templateScope, BoxAPIConnection ap
 [`getEnterpriseMetadataTemplates(String templateScope, int limit, BoxAPIConnection api, String... fields)`][get-enterprise-metadata-3]
 can be used to set metadata scope, limit of items per single response.
 
+<!-- sample get_metadata_templates_enterprise -->
 ```java
 Iterable<MetadataTemplate> templates = MetadataTemplate.getEnterpriseMetadataTemplates(api);
 for (MetadataTemplate templateInfo : templates) {
@@ -125,6 +130,7 @@ Delete a Metadata Template
 The [`deleteMetadataTemplate(BoxAPIConnection api, String scope, String template)`][delete-metadata-template]
 method will remove a metadata template schema from an enterprise.
 
+<!-- sample delete_metadata_templates_id_id_schema -->
 ```java
 MetadataTemplate.deleteMetadataTemplate(api, "enterprise", "templateName");
 ```

--- a/doc/recent_items.md
+++ b/doc/recent_items.md
@@ -23,6 +23,7 @@ which describe which item the user interacted with, when they interacted with it
 and what type of interaction it was.  Any `fields` specified relate to the items
 themselves (e.g. the recent files and folders).
 
+<!-- sample get_recent_items -->
 ```java
 // Get the latest 100 items the user has interacted with
 Iterable<BoxRecentItem> recentItems = BoxRecents.getRecentItems(api, 100);

--- a/doc/retention_policies.md
+++ b/doc/retention_policies.md
@@ -26,6 +26,7 @@ Create Retention Policy
 The static [`createIndefinitePolicy(BoxAPIConnection api, String name)`][create-indefinite-retention-policy]
 method will let you create a new indefinite retention policy with a specified name.
 
+<!-- sample post_retention_policies -->
 ```java
 BoxRetentionPolicy.createIndefinitePolicy(api, name);
 ```
@@ -68,6 +69,7 @@ Calling [`getInfo(String... fields)`][get-info] will return a
 about the retention policy. If necessary to retrieve limited set of fields, it
 is possible to specify them using the `fields` parameter.
 
+<!-- sample get_retention_policies_id -->
 ```java
 // Get the policy name and status for a given retention policy
 BoxRetentionPolicy policy = new BoxRetentionPolicy(api, id);
@@ -83,6 +85,7 @@ Update Retention Policy
 Updating a retention policy's information is done by calling
 [`updateInfo(BoxRetentionPolicy.Info fieldsToUpdate)`][update-info].
 
+<!-- sample put_retention_policies_id -->
 ```java
 BoxRetentionPolicy policy = new BoxRetentionPolicy(api, id);
 BoxRetentionPolicy.Info policyInfo = policy.new Info();
@@ -103,6 +106,7 @@ response and fields to retrieve by calling the static
 [`getAll(String name, String type, String userID, int limit, BoxAPIConnection api, String... fields)`][get-retention-policies-with-fields]
 method.
 
+<!-- sample get_retention_policies -->
 ```java
 Iterable<BoxRetentionPolicy.Info> policies = BoxRetentionPolicy.getAll(api);
 for (BoxRetentionPolicy.Info policyInfo : policies) {
@@ -125,6 +129,7 @@ If it is necessary to retrieve only assignments of certain type, you can call
 [`getFolderAssignments(int limit, String... fields)`][get-folder-assignments] or
 [`getEnterpriseAssignments(int limit, String... fields)`][get-enterprise-assignments].
 
+<!-- sample get_retention_policies_id_assignments -->
 ```java
 BoxRetentionPolicy policy = new BoxRetentionPolicy(api, id);
 Iterable<BoxRetentionPolicyAssignment.Info> allAssignments = policy.getAllAssignments("assigned_by");
@@ -153,6 +158,7 @@ to a specific folder, [`assignToEnterprise()`][create-assignment-to-enterprise] 
 entire enterprise, or [`assignToMetadataTemplate(String templateID, MetadataFieldFilter... filterFields)`][assign-to-metadata]
 to assign the policy to items with a specific metadata template.
 
+<!-- sample post_retention_policy_assignments -->
 ```java
 // Assign the policy to the entire enterprise
 BoxRetentionPolicy policy = new BoxRetentionPolicy(api, policyID);
@@ -177,6 +183,7 @@ Calling [`getInfo(String... fields)`][get-assignment] will return a
 [`BoxRetentionPolicyAssignment.Info`][policy-assignment-info] object containing
 information about the retention policy assignment.
 
+<!-- sample get_retention_policy_assignments_id -->
 ```java
 BoxRetentionPolicyAssignment assignment = new BoxRetentionPolicyAssignment(api, id);
 BoxRetentionPolicyAssignment.Info assignmentInfo = assignment.getInfo("assigned_to");
@@ -192,6 +199,7 @@ Calling [`getInfo(String... fields)`][get-file-version-retention] will return a
 [`BoxFileVersionRetention.Info`][version-retention-info] object containing
 information about the file version retention policy.
 
+<!-- sample get_file_version_retentions_id -->
 ```java
 BoxFileVersionRetention policy = new BoxFileVersionRetention(api, id);
 BoxFileVersionRetention.Info policyInfo = policy.getInfo();
@@ -209,6 +217,7 @@ method. It is possible to add filters to query passing a
 [`BoxFileVersionRetention.QueryFilter`][query-filter] object as a parameter to
 [`getRetentions(BoxAPIConnection api, BoxFileVersionRetention.QueryFilter filter, String... fields)`][get-all-file-version-retentions-with-filter].
 
+<!-- sample get_file_version_retentions -->
 ```java
 BoxFileVersionRetention.QueryFilter filter = new BoxFileVersionRetention.QueryFilter()
                 .addFileID("0")

--- a/doc/search.md
+++ b/doc/search.md
@@ -22,6 +22,7 @@ A search can be performed in your Box instance with specified starting position 
 
 You can use the `limit` and `offset` parameters to page through the search results.
 
+<!-- sample get_search -->
 ```java
 // Find the first 10 files matching "taxes"
 long offsetValue = 0;

--- a/doc/shared-items.md
+++ b/doc/shared-items.md
@@ -21,6 +21,7 @@ If the shared link is password-protected, call
 [`BoxItem.getSharedItem(BoxAPIConnection api, String sharedLink, String password)`][get-shared-item-password]
 with the shared link and password.
 
+<!-- sample get_shared_items -->
 ```java
 String sharedLink = "https://app.box.com/s/abcdefghijklmnopqrstuvwxyz123456";
 String password = "foo";

--- a/doc/storage_policy.md
+++ b/doc/storage_policy.md
@@ -21,6 +21,7 @@ Calling [`getInfo(String fields ...)`][get-info] will return BoxStoragePolicy.In
 containing information about the storage policy. If necessary to retrieve 
 limited set of fields. It is possible to specify them using param.
 
+<!-- sample get_storage_policies_id -->
 ```java
 BoxStoragePolicy storagePolicy = new BoxStoragePolicy(api, id);
 BoxStoragePolicy.Info storagePolicyInfo = storagePolicy.getInfo();
@@ -36,6 +37,7 @@ will return an iterable that will page through all of the storage policies.
 It is possible to specify maximum number of items per response and fields to retrieve by 
 calling the static [`getAll(BoxAPIConnection api, int limit, String fields ...)`][get-list-of-storage-policies-with-fields] method. 
 
+<!-- sample get_storage_policies -->
 ```java
 Iterable<BoxStoragePolicy.Info> storagePolicies = BoxStoragePolicy.getAll(api);
 for (BoxStoragePolicy.Info storagePolicyInfo : storagePolicies) {
@@ -51,6 +53,7 @@ Create New Assignment
 
 To create new storage policy assignment call [`create(BoxAPIConnection api, String policyID, String userID)`][create] method. 
 
+<!-- sample post_storage_policy_assignments -->
 ```java
 BoxStoragePolicyAssignment.Info assignmentInfo = BoxStoragePolicyAssignment.create(api, policyID, userID);
 ```
@@ -63,6 +66,7 @@ Update Existing Assignment
 Updating a storage policy assignment information is done by calling
 [`updateInfo(BoxStoragePolicyAssignment.Info updatedInfo)`][update-info].
 
+<!-- sample put_storage_policy_assignments_id -->
 ```java
 BoxStoragePolicyAssignment storagePolicyAssignment = new BoxStoragePolicyAssignment(api, "ASSIGNMENT_ID");
 BoxStoragePolicyAssignment.Info assignmentInfo = storagePolicyAssignment.new Info();
@@ -78,6 +82,7 @@ Get Assignment
 Calling [`getInfo(String fields ...)`][get-assignment] will return a BoxStoragePolicyAssignment.Info object containing information
 about the storage policy assignment. 
 
+<!-- sample get_storage_policy_assignments_id -->
 ```java
 BoxStoragePolicyAssignment storagePolicyAssignment = new BoxStoragePolicyAssignment(api, id);
 BoxStoragePolicyAssignment.Info assignmentInfo = storagePolicyAssignment.getInfo();
@@ -91,6 +96,7 @@ Get Assignment for Target
 Calling [`getAssignmentForTarget(BoxAPIConnection api, String resolvedForType, String resolvedForID)`][get-assignment-for-target] will return a BoxStorageAssignment.Info
 object containing information about the storage policy assignment. 
 
+<!-- sample get_storage_policy_assignments -->
 ```java
 BoxStoragePolicyAssignment.Info assignmentInfo = BoxStoragePolicyAssignment.getAssignmentForTarget(api, "user", "1234")
 ```
@@ -103,6 +109,7 @@ Assign Storage Policy
 Calling [`assign(BoxAPIConnection api, String storagePolicyID, String userID)`][assign] will check if this user already has storage policy assigned to them. If not then a new
 this user will be assigned the specified storage policy. 
 
+<!-- sample post_storage_policy_assignments -->
 ```java
 BoxStoragePolicyAssignment.Info assignmentInfo = BoxStoragePolicyAssignment.assign(api, "1234", "5678");
 ```
@@ -114,6 +121,7 @@ Delete Assignment
 
 Calling [`delete()`][delete] will remove the storage policy assignment from the user. 
 
+<!-- sample delete_storage_policy_assignments_id -->
 ```java
 BoxStoragePolicyAssignment assignment = new BoxStoragePolicyAssignment(api, "dXNlcl8xMjM0");
 assignment.delete();

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -26,6 +26,7 @@ Get a Task's Information
 Calling [`getInfo()`][get-info] on a task returns a snapshot of the task's
 info.
 
+<!-- sample get_tasks_id -->
 ```java
 BoxTask task = new BoxTask(api, "id");
 BoxTask.Info info = task.getInfo();
@@ -39,6 +40,7 @@ Get the Tasks on a File
 You can get all of the tasks on a file by calling the
 [`getTasks()`][get-tasks] method.
 
+<!-- sample get_files_id_tasks -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 List<BoxTask.Info> tasks = file.getTasks();
@@ -52,6 +54,7 @@ Add a Task to a File
 A task can be added to a file with the
 [`addTask(String taskType, String message, Date dueDate)`][add-task] method.
 
+<!-- sample post_tasks -->
 ```java
 BoxFile file = new BoxFile(api, "id");
 Date dueAt = new Date();
@@ -66,6 +69,7 @@ Update a Task's Information
 The message of a task can be changed with the
 [`updateInfo(BoxTask.Info fieldsToUpdate)`][update-info] method.
 
+<!-- sample put_tasks_id -->
 ```java
 BoxTask task = new BoxTask(api, "id");
 BoxTask.Info info = task.new Info();
@@ -80,6 +84,7 @@ Delete a Task
 
 A task can be deleted with the [`delete()`][delete] method.
 
+<!-- sample delete_tasks_id -->
 ```java
 BoxTask task = new BoxTask(api, "id");
 task.delete();
@@ -92,6 +97,7 @@ Get a Task's Assignments
 
 Retreive a tasks assignments with the [`getAssignments()`][get-assignments] method.
 
+<!-- sample get_tasks_id_assignments -->
 ```java
 BoxTask task = new BoxTask(api, "id");
 task.getAssignments();
@@ -107,6 +113,7 @@ To look up information about a task assignment by its ID, instantiate the
 on the assignment.  To retrieve only specific fields on the task assignment, call
 [`getInfo(String... fields)`][get-assignment-fields] with the fields to retrieve.
 
+<!-- sample get_task_assignments_id -->
 ```java
 String assignmentID = "4256974";
 BoxTaskAssignment.Info assignmentInfo = new BoxTaskAssignment(api, assignmentID).getInfo();
@@ -122,6 +129,7 @@ Add a Task Assignment
 An assignment can be added to a task with the
 [`addAssignment(BoxUser assignee)`][add-assignment] method.
 
+<!-- sample post_task_assignments -->
 ```java
 BoxUser user = new BoxUser(api, "user-id")
 BoxTask task = new BoxTask(api, "id");
@@ -137,6 +145,7 @@ An assignment can be deleted from a task with the
 [`delete()`][delete-assignment] method on a [`BoxTaskAssignment`][task-assignment-object]
 instance.
 
+<!-- sample delete_task_assignments_id -->
 ```java
 BoxTaskAssignment taskAssignment = new BoxTaskAssignment(api, "id");
 taskAssignment.delete();
@@ -150,6 +159,7 @@ Update a Task Assignment
 A task assignment can be updated with the
 [`updateInfo(BoxTask.Info fieldsToUpdate)`][update-assignment] method.
 
+<!-- sample put_task_assignments_id -->
 ```java
 String assignmentID = "12345";
 BoxTaskAssignment taskAssignment = new BoxTaskAssignment(api, assignmentID);

--- a/doc/terms_of_service.md
+++ b/doc/terms_of_service.md
@@ -28,6 +28,7 @@ terms of service.
 You can create a custom terms of service by calling
 [`create(BoxAPIConnection api, BoxTermsOfService.TermsOfServiceStatus status, BoxTermsOfService.TermsOfServiceType type, String text)`][createTermsOfService].
 
+<!-- sample post_terms_of_services -->
 ```java
 BoxTermsOfService.Info newTOS = BoxTermsOfService.create(
     api,
@@ -45,6 +46,7 @@ Edit a Terms of Service
 You can update a terms of service status and text after you have created them by calling
 [`updateInfo(BoxTermsOfService.Info fieldsToUpdate)`][update-terms-of-service]
 
+<!-- sample put_terms_of_services_id -->
 ```java
 BoxTermsOfService termsOfService = new BoxTermsOfService(api, "tos-id");
 BoxTermsOfService.Info termsOfServiceInfo = termsOfService.new Info();
@@ -61,6 +63,7 @@ Get a Terms of Service
 You can retrieve a terms of service by providing the ID and calling
 [`getInfo()`][getTermsOfServiceInfo].
 
+<!-- sample get_terms_of_services_id -->
 ```java
 BoxTermsOfService termsOfService = new BoxTermsOfService(api, "tos-id");
 BoxTermsOfService.Info tosInfo = termsOfService.getInfo();
@@ -75,6 +78,7 @@ You can also retrieve all terms of service in your enterprise by calling
 [`getAllTermsOfServices(BoxAPIConnection api)`][get-all-terms-of-services1].
 This will return an iterable that will page through all of the enterprises terms of services.
 
+<!-- sample get_terms_of_services -->
 ```java
 List<BoxTermsOfService.Info> termsOfServices = BoxTermsOfService.getAllTermsOfServices(api);
 for(BoxTermsOfService.Info termsOfServiceInfo : termsOfServices){
@@ -95,6 +99,7 @@ Accept or Decline a Terms of Service for New User
 For new users you can accept or decline a terms of service by calling
 [`create(BoxAPIConnection api, String tosID, Boolean accepted, String userID)`][create-user-status]
 
+<!-- sample post_terms_of_service_user_statuses -->
 ```java
 BoxTermsOfService.Info newUserStatus = BoxTermsOfServiceUserStatus.create(api, "tos-id", true, "user-id");
 ```
@@ -110,6 +115,7 @@ Accept or Decline a Terms of Service for Existing User
 For an existing user you can accept or decline a terms of service by calling
 [`updateInfo(BoxTermsOfService.Info fieldsToUpdate)`][update-user-status].
 
+<!-- sample put_terms_of_service_user_statuses_id -->
 ```java
 BoxTermsOfServiceUserStatus tosUserStatus = new BoxTermsOfServiceUserStatus(api, "tos-user-status-id");
 BoxTermOfServiceUserStatus.Info tosUserStatusInfo = tosUserStatus.new Info();
@@ -125,6 +131,7 @@ Get User Status on a Terms of Service
 You can retrieve the terms of service status for a user by calling
 [`getInfo(BoxAPIConnection api, String tosID, String userID)`][get-user-status1]
 
+<!-- sample get_terms_of_service_user_statuses_id -->
 ```java
 List<BoxTermsOfServiceUserStatus.Info> tosUserStatusInfo = BoxTermsOfServiceUserStatus.getInfo(api, "tos-id", "user-id");
 for(BoxTermsOfServiceUserStatus.Info info : toUserStatusInfo){

--- a/doc/trash.md
+++ b/doc/trash.md
@@ -25,6 +25,7 @@ Get Trashed Items
 The [`BoxTrash`][trash-object] implements `Iterable<BoxItem.Info>`, so to get
 the collection of items currently in the trash, simply iterate over it.
 
+<!-- sample get_trash -->
 ```java
 BoxTrash trash = new BoxTrash(api);
 for (BoxItem.Info itemInfo : trash) {
@@ -44,6 +45,7 @@ trash, you must instead call
 pass a specific list of fields to retrieve to [`getFileInfo(String fileID, String... fields)`][get-trashed-file-fields],
 which will return only the specified fields to reduce payload size.
 
+<!-- sample get_files_id_trash -->
 ```java
 String fileID = "9873459";
 BoxTrash trash = new BoxTrash(api);
@@ -63,6 +65,7 @@ pass a specific list of fields to retrieve to
 [`getFileInfo(String folderID, String... fields)`][get-trashed-folder-fields], which will return only the specified
 fields to reduce payload size.
 
+<!-- sample get_folder_id_trash -->
 ```java
 String folderID = "2345343";
 BoxTrash trash = new BoxTrash(api);
@@ -81,6 +84,7 @@ delete.
 
 > __Note:__ This will permanently delete the file, and cannot be undone.
 
+<!-- sample delete_files_id_trash -->
 ```java
 String fileID = "87398";
 BoxTrash trash = new BoxTrash(api);
@@ -98,6 +102,7 @@ folder to delete.
 
 > __Note:__ This will permanently delete the folder, and cannot be undone.
 
+<!-- sample delete_folders_id_trash -->
 ```java
 String folder = "123456";
 BoxTrash trash = new BoxTrash(api);
@@ -116,6 +121,7 @@ being restored; you can pass a new parent folder ID and/or file name to
 [`BoxTrash#restoreFile(String fileID, String newName, String newParentID)`][restore-file-safe].  The new name
 and parent will only be used if a conflict is encountered while trying to restore the file to its original location.
 
+<!-- sample post_files_id -->
 ```java
 String fileID = "125367";
 String newName = "Presentation 2018 ORIGINAL.pptx";
@@ -140,6 +146,7 @@ being restored; you can pass a new parent folder ID and/or folder name to
 [`BoxTrash#restoreFolder(String folderID, String newName, String newParentID)`][restore-folder-safe].  The new name
 and parent will only be used if a conflict is encountered while trying to restore the folder to its original location.
 
+<!-- sample post_folders_id -->
 ```java
 String folderID = "125367";
 String newName = "My Documents ORIGINAL";

--- a/doc/users.md
+++ b/doc/users.md
@@ -29,6 +29,7 @@ To get the current user, call the static
 [`getCurrentUser(BoxAPIConnection api)`][get-current-user] method.
 Then use [`getInfo(String... fields)`][get-info] to get information about the user.
 
+<!-- sample get_users_me -->
 ```java
 BoxUser user = BoxUser.getCurrentUser(api);
 BoxUser.Info info = user.getInfo();
@@ -42,6 +43,7 @@ Get User Information
 
 To get information about a user, call the [`getInfo()`][get-info] method on the user object.
 
+<!-- sample get_users_id -->
 ```java
 String userID = "33333";
 BoxUser user = new BoxUser(api, userID);
@@ -53,6 +55,7 @@ Get Avatar for a User
 
 To retrieve the avatar for a user, call the [`getAvatar()`][get-avatar] method on the user object.
 
+<!-- sample get_users_id_avatar -->
 ```java
 String userID = "33333";
 BoxUser user = new BoxUser(api, userID);
@@ -70,6 +73,7 @@ To pass additional optional parameters, use the
 [`createEnterpriseUser(BoxAPIConnection api, String loginEmail, String userName, CreateUserParams options)`][create-enterprise-user-2]
 method.
 
+<!-- sample post_users -->
 ```java
 BoxUser.Info createdUserInfo = BoxUser.createEnterpriseUser(api, "user@example.com", "A User");
 ```
@@ -104,6 +108,7 @@ Update User
 
 To update a user call the [`updateInfo(BoxUser.Info fieldsToUpdate)`][update-info] method.
 
+<!-- sample put_users_id -->
 ```java
 BoxUser user = new BoxUser(api, "0");
 BoxUser.Info info = user.new Info();
@@ -122,6 +127,7 @@ The `notifyUser` determines whether the user should receive an email about the d
 and the `force` parameter will cause the user to be deleted even if they still have files
 in their account.
 
+<!-- sample delete_users_id -->
 ```java
 BoxUser user = new BoxUser(api, "0");
 user.delete(false, false);
@@ -135,6 +141,7 @@ Invite User
 To invite an existing user to join an Enterprise call the
 [`inviteUser(String enterpriseID, String userEmail)`][invite] method.
 
+<!-- sample post_invites -->
 ```java
 BoxUser user = new BoxUser(api, "0");
 user.invite("Enterprise ID", "Invited User Login");
@@ -147,6 +154,7 @@ Get Email Aliases
 
 To get a user's email aliases call the [`getEmailAliases()`][get-email-aliases] method.
 
+<!-- sample get_users_id_email_aliases -->
 ```java
 BoxUser user = new BoxUser(api, "0");
 Collection<EmailAlias> emailAliases = user.getEmailAliases();
@@ -160,6 +168,7 @@ Add Email Alias
 To add an email alias for a user, call the
 [`addEmailAlias(String emailAddress)`][add-email-alias] method.
 
+<!-- sample post_users_id_email_aliases -->
 ```java
 BoxUser user = new BoxUser(api, "0");
 user.addEmailAlias("user+alias@example.com");
@@ -182,6 +191,7 @@ Delete Email Alias
 To delete a users email alias call the
 [`deleteEmailAlias(String emailAliasID)`][delete-email-alias] method.
 
+<!-- sample delete_users_id_email_aliases_id -->
 ```java
 BoxUser user = new BoxUser(api, "0");
 user.deleteEmailAlias("123");
@@ -197,6 +207,7 @@ To get an enterprises users call the
 [`getAllEnterpriseUsers(BoxAPIConnection api, String filterTerm, String... fields)`][get-all-enterprise-users-2], or
 [`getAllEnterpriseOrExternalUsers(BoxAPIConnection api, String filterTerm, String... fields)`][get-all-enterprise-users-3] method.
 
+<!-- sample get_users -->
 ```java
 Iterable<BoxUser.Info> users = BoxUser.getAllEnterpriseUsers(api);
 ```
@@ -225,6 +236,7 @@ Move User's Folder
 To move all of a user's content to another user, call the
 [`transferContent(String destinationUserID)`][transfer-folder-to-new-user] method.
 
+<!-- sample put_users_id_folders_id -->
 ```java
 String sourceUserID = "11111";
 String destinationUserID = "22222";

--- a/doc/watermarking.md
+++ b/doc/watermarking.md
@@ -21,6 +21,7 @@ Get Watermark on File
 
 Calling [`getWatermark(String... fields)`][get-watermark-on-file] will return a BoxWatermark object containing information about the watermark associated for this file. If the file does not have a watermark applied on it, a 404 Not Found will be returned.
 
+<!-- sample get_files_id_watermark -->
 ```java
 BoxFile file = new BoxFile(api, id);
 BoxWatermark watermark = file.getWatermark();
@@ -34,6 +35,7 @@ Apply Watermark on File
 To apply watermark on file, call [`applyWatermark()`][apply-watermark-on-file] method. While the endpoint accepts a JSON body describing the watermark to apply, custom watermarks are not supported yet.
 The method will return a BoxWatermark object containing information about the watermark applied on this file.
 
+<!-- sample put_files_id_watermark -->
 ```java
 BoxFile file = new BoxFile(api, id);
 file.applyWatermark();
@@ -47,6 +49,7 @@ Remove Watermark on File
 A watermark can be removed by calling the [`removeWatermark()`][remove-watermark-on-file] method.
 If the file did not have a watermark applied on it, a 404 Not Found will be returned by API.
 
+<!-- sample delete_files_id_watermark -->
 ```java
 BoxFile file = new BoxFile(api, id);
 file.removeWatermark();
@@ -59,6 +62,7 @@ Get Watermark on Folder
 
 Calling [`getWatermark(String... fields)`][get-watermark-on-folder] will return a BoxWatermark object containing information about the watermark associated for this folder. If the folder does not have a watermark applied on it, a 404 Not Found will be returned.
 
+<!-- sample get_folders_id_watermark -->
 ```java
 BoxFolder folder = new BoxFolder(api, id);
 BoxWatermark watermark = folder.getWatermark();
@@ -72,6 +76,7 @@ Apply Watermark on Folder
 To apply watermark on folder, call [`applyWatermark()`][apply-watermark-on-folder] method.
 The method will return a BoxWatermark object containing information about the watermark applied on this folder.
 
+<!-- sample put_folders_id_watermark -->
 ```java
 BoxFolder folder = new BoxFolder(api, id);
 fodler.applyWatermark();
@@ -85,6 +90,7 @@ Remove Watermark on Folder
 A watermark can be removed by calling the [`removeWatermark()`][remove-watermark-on-folder] method.
 If the folder did not have a watermark applied on it, a 404 Not Found will be returned by API.
 
+<!-- sample delete_folders_id_watermark -->
 ```java
 BoxFolder folder = new BoxFolder(api, id);
 folder.removeWatermark();

--- a/doc/webhooks.md
+++ b/doc/webhooks.md
@@ -21,6 +21,7 @@ Get a Webhook
 
 A webhook infocan be retrieved by calling the [`getInfo(String... fields)`][get-info] method.
 
+<!-- sample get_webhooks_id -->
 ```java
 BoxWebHook webhook = new BoxWebHook(api, id);
 BoxWebHook.Info info = webhook.getInfo();
@@ -35,6 +36,7 @@ Calling the static [`all(BoxAPIConnection api, String... fields)`][all] will
 return an iterable that will page through all defined webhooks for the
 requesting application and user.
 
+<!-- sample get_webhooks -->
 ```java
 Iterable<BoxWebHook.Info> webhooks = BoxWebHook.all(api);
 for (BoxWebHook.Info webhookInfo: webhooks) {
@@ -50,6 +52,7 @@ Create a Webhook
 The static [`create(BoxResource targetItem, URL callbackURL, BoxWebHook.Trigger... triggerEvents)`][create-webhook]
 method will let you create a new webhook for a specified target object.
 
+<!-- sample post_webhooks -->
 ```java
 // Listen for file upload events in the specified folder
 BoxFolder folder = new BoxFolder(api, id);
@@ -63,6 +66,7 @@ Delete a Webhook
 
 A webhook can be deleted by calling the [`delete()`][delete] method.
 
+<!-- sample delete_webhooks -->
 ```java
 BoxWebHook webhook = new BoxWebHook(api, id);
 webhook.delete();
@@ -75,6 +79,7 @@ Update a Webhook
 
 A webhook can be updated by calling the [`update(BoxWebHook.Info fieldsToUpdate)`][update] method.
 
+<!-- sample put_webhooks_id -->
 ```java
 BoxWebHook webhook = new BoxWebHook(api, id);
 BoxWebHook.Info info = webhook.getInfo();

--- a/doc/weblinks.md
+++ b/doc/weblinks.md
@@ -21,6 +21,7 @@ Create Web Link
 
 Calling [`BoxFolder.createWebLink(String name, URL url, String description)`][create-web-link] will let you create a new web link with a specified name and description.
 
+<!-- sample post_web_links -->
 ```java
 BoxFolder folder = new BoxFolder(api, id);
 URL url = new URL("https://www.example.com");
@@ -46,6 +47,7 @@ Get Web Link
 A web link info can be retrieved by calling the [`getInfo(String... fields)`][get-web-link] method.
 Optional parameters can be used to retrieve specific fields of the Device Pin object.
 
+<!-- sample get_web_links_id -->
 ```java
 BoxWebLink webLink = new BoxWebLink(api, id);
 BoxWebLink.Info webLinkInfo = webLink.getInfo();
@@ -59,6 +61,7 @@ Update Web Link
 A web link can be updated by calling the
 [`updateInfo(BoxWebLink.Info fieldsToUpdate)`][update-web-link] method.
 
+<!-- sample put_web_links_id -->
 ```java
 BoxWebLink webLink = new BoxWebLink(api, id);
 BoxWebLink.Info webLinkInfo = webLink.new Info();
@@ -73,6 +76,7 @@ Delete Web Link
 
 A web link can be deleted by calling the [`delete()`][delete] method.
 
+<!-- sample delete_web_links_id -->
 ```java
 BoxWebLink webLink = new BoxWebLink(api, id);
 webLink.delete();


### PR DESCRIPTION
I've tagged the majority of code samples to an endpoint for usage in the new developer documentation.

