### PR TITLE
Improving authentication docs for BoxConfig.readFrom()

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -84,27 +84,26 @@ BoxConfig boxConfig = new BoxConfig("YOUR-CLIENT-ID", "YOUR-CLIENT-SECRET", "ENT
 BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(boxConfig);
 ```
 
-The Java SDK also has a convenient helper function `BoxConfig.readFrom()` to assist in constructing an BoxAPIConnection.
+The Java SDK also has a convenient helper function `BoxConfig.readFrom()` to assist in constructing an API connection.
 The `readFrom()` method takes in a stream constructed by the JSON config downloaded from the Developer Console seen 
-[here](https://developer.box.com/docs/setting-up-a-jwt-app#section-use-an-application-config-file).
+[here](https://developer.box.com/docs/setting-up-a-jwt-app#section-use-an-application-config-file). Once a `BoxConfig`
+object has been created you can use that to create an API connection.
 
 ```java
 Reader reader = new FileReader("src/example/config/config.json");
 BoxConfig boxConfig = BoxConfig.readFrom(reader);
 
-BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(BoxConfig boxConfig);
+BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(boxConfig);
 ```
 
-It is also possible to get an API connection for an app user by doing somethin like this
+It is also possible to get an API connection for an app user by doing somethin like this:
 
 ```java
 Reader reader = new FileReader("src/example/config/config.json");
 BoxConfig boxConfig = BoxConfig.readFrom(reader);
 
-BoxDeveloperEditionAPIConnection api = new BoxDeveloperEditionAPIConnection.getAppUserConnection(String userId,
-	BoxConfig boxConfig)
+BoxDeveloperEditionAPIConnection api = new BoxDeveloperEditionAPIConnection.getAppUserConnection('USER_ID', boxConfig)
 ```
-
 
 ### Standard 3-Legged Oauth 2.0
 

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -64,7 +64,7 @@ BoxConfig boxConfig = BoxConfig.readFrom(reader);
 BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(boxConfig);
 ```
 
-It is also possible to get an API connection for an app user by doing somethin like this:
+It is also possible to get an API connection for an app user by doing something like this:
 
 ```java
 Reader reader = new FileReader("src/example/config/config.json");

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -52,6 +52,29 @@ account to provision and manage users, or as an individual app user to make call
 [API documentation](https://github.com/box/box-node-sdk/blob/master/docs/authentication.md#app-user-authentication)
 for detailed instruction on how to use app auth. 
 
+The Java SDK also has a convenient helper function `BoxConfig.readFrom()` to assist in constructing an API connection.
+The `readFrom()` method takes in a stream constructed by the JSON config downloaded from the Developer Console seen 
+[here](https://developer.box.com/docs/setting-up-a-jwt-app#section-use-an-application-config-file). Once a `BoxConfig`
+object has been created you can use that to create an API connection.
+
+```java
+Reader reader = new FileReader("src/example/config/config.json");
+BoxConfig boxConfig = BoxConfig.readFrom(reader);
+
+BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(boxConfig);
+```
+
+It is also possible to get an API connection for an app user by doing somethin like this:
+
+```java
+Reader reader = new FileReader("src/example/config/config.json");
+BoxConfig boxConfig = BoxConfig.readFrom(reader);
+
+BoxDeveloperEditionAPIConnection api = new BoxDeveloperEditionAPIConnection.getAppUserConnection('USER_ID', boxConfig)
+```
+
+However, if you would like to do a manual set up then that is also possible with the below options.
+
 App User example: 
 ```java
 JWTEncryptionPreferences jwtPreferences = new JWTEncryptionPreferences();
@@ -82,27 +105,6 @@ jwtPreferences.setEncryptionAlgorithm(EncryptionAlgorithm.RSA_SHA_256);
 BoxConfig boxConfig = new BoxConfig("YOUR-CLIENT-ID", "YOUR-CLIENT-SECRET", "ENTERPRISE-ID", jwtPreferences);
 
 BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(boxConfig);
-```
-
-The Java SDK also has a convenient helper function `BoxConfig.readFrom()` to assist in constructing an API connection.
-The `readFrom()` method takes in a stream constructed by the JSON config downloaded from the Developer Console seen 
-[here](https://developer.box.com/docs/setting-up-a-jwt-app#section-use-an-application-config-file). Once a `BoxConfig`
-object has been created you can use that to create an API connection.
-
-```java
-Reader reader = new FileReader("src/example/config/config.json");
-BoxConfig boxConfig = BoxConfig.readFrom(reader);
-
-BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(boxConfig);
-```
-
-It is also possible to get an API connection for an app user by doing somethin like this:
-
-```java
-Reader reader = new FileReader("src/example/config/config.json");
-BoxConfig boxConfig = BoxConfig.readFrom(reader);
-
-BoxDeveloperEditionAPIConnection api = new BoxDeveloperEditionAPIConnection.getAppUserConnection('USER_ID', boxConfig)
 ```
 
 ### Standard 3-Legged Oauth 2.0

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -82,8 +82,29 @@ jwtPreferences.setEncryptionAlgorithm(EncryptionAlgorithm.RSA_SHA_256);
 BoxConfig boxConfig = new BoxConfig("YOUR-CLIENT-ID", "YOUR-CLIENT-SECRET", "ENTERPRISE-ID", jwtPreferences);
 
 BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(boxConfig);
-
 ```
+
+The Java SDK also has a convenient helper function `BoxConfig.readFrom()` to assist in constructing an BoxAPIConnection.
+The `readFrom()` method takes in a stream constructed by the JSON config downloaded from the Developer Console seen 
+[here](https://developer.box.com/docs/setting-up-a-jwt-app#section-use-an-application-config-file).
+
+```java
+Reader reader = new FileReader("src/example/config/config.json");
+BoxConfig boxConfig = BoxConfig.readFrom(reader);
+
+BoxDeveloperEditionAPIConnection api = BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(BoxConfig boxConfig);
+```
+
+It is also possible to get an API connection for an app user by doing somethin like this
+
+```java
+Reader reader = new FileReader("src/example/config/config.json");
+BoxConfig boxConfig = BoxConfig.readFrom(reader);
+
+BoxDeveloperEditionAPIConnection api = new BoxDeveloperEditionAPIConnection.getAppUserConnection(String userId,
+	BoxConfig boxConfig)
+```
+
 
 ### Standard 3-Legged Oauth 2.0
 


### PR DESCRIPTION
BoxConfig.readFrom() is a convenience function that helps the users create an BoxConfig object. However, this method is not currently documented, just used in examples.