### PR TITLE
Added ubuntu trusty routing over ubuntu xenial to fix issue installing oraclejdk8 with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
 
+dist: trusty
+
 # Test against multiple JDKs to verify compatibility
 jdk:
   # Re-enable when TravisCI supports Gradle >= 4.3


### PR DESCRIPTION
Travis CI is migrating from Ubuntu Trusty to Ubuntu Xenial - however, Xenial does not have support for oracle jdk 8, thus two/three of our builds are failing on the install stage. To fix this issue we need to add the target Trusty to our yaml file in order to stop our installs from defaulting to Xenial.

More context here:

1. https://travis-ci.community/t/install-of-oracle-jdk8-is-failing/4365
2. https://travis-ci.community/t/error-installing-oraclejdk8-expected-feature-release-number-in-range-of-9-to-14-but-got-8/3766/3