### PR TITLE
Add replace functionality for multi select metadata as well as documentation.

### DIFF
--- a/doc/files.md
+++ b/doc/files.md
@@ -741,7 +741,30 @@ BoxFile file = new BoxFile(api, "id");
 file.updateMetadata(new Metadata().add("/foo", "bar"));
 ```
 
+Also, it is possible to add multi-select fields for your file metadata by calling
+[`updateMetadata(Metadata properties)`][update-metadata] with a list of values.
+
+```java
+BoxFile file = new BoxFile(api, "id");
+List<String> valueList = new ArrayList<String>();
+valueList.add("bar");
+valueList.add("qux");
+file.updateMetadata(new Metadata().add("/foo", valueList));
+```
+
+If you wanted to replace all selected fields for a specified key you can use the
+[`replace(String key, List<String> values)`][replace-metadata].
+
+```java
+BoxFile file = new BoxFile(api, "id");
+List<String> valueList = new ArrayList<String>();
+valueList.add("bar");
+valueList.add("qux");
+file.updateMetadata(new Metadata().replace("/foo", valueList));
+```
+
 [update-metadata]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxFile.html#updateMetadata-com.box.sdk.Metadata-
+[replace-metadata]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/Metadata.html#replace-java.lang.String-java.util.List-
 
 Delete Metadata
 ---------------

--- a/doc/folders.md
+++ b/doc/folders.md
@@ -398,7 +398,30 @@ BoxFolder folder = new BoxFolder(api, "id");
 folder.updateMetadata(new Metadata().add("/foo", "bar"));
 ```
 
+Also, it is possible to add multi-select fields for your folder metadata by calling
+[`updateMetadata(Metadata properties)`][update-metadata] with a list of values.
+
+```java
+BoxFolder folder = new BoxFolder(api, "id");
+List<String> valueList = new ArrayList<String>();
+valueList.add("bar");
+valueList.add("qux");
+folder.updateMetadata(new Metadata().add("/foo", valueList));
+```
+
+If you wanted to replace all selected fields for a specified key you can use the
+[`replace(String key, List<String> values)`][replace-metadata].
+
+```java
+BoxFolder folder = new BoxFolder(api, "id");
+List<String> valueList = new ArrayList<String>();
+valueList.add("bar");
+valueList.add("qux");
+folder.updateMetadata(new Metadata().replace("/foo", valueList));
+```
+
 [update-metadata]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/BoxFolder.html#updateMetadata-com.box.sdk.Metadata-
+[replace-metadata]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/Metadata.html#replace-java.lang.String-java.util.List-
 
 Delete Metadata
 ---------------

--- a/src/main/java/com/box/sdk/Metadata.java
+++ b/src/main/java/com/box/sdk/Metadata.java
@@ -226,6 +226,22 @@ public class Metadata {
     }
 
     /**
+     * Replaces an existing metadata value of array type.
+     * @param path the path that designates the key. Must be prefixed with a "/".
+     * @param values the collection of values.
+     * @return the metadata object.
+     */
+    public Metadata replace(String path, List<String> values) {
+        JsonArray arr = new JsonArray();
+        for (String value : values) {
+            arr.add(value);
+        }
+        this.values.add(this.pathToProperty(path), arr);
+        this.addOp("replace", path, arr);
+        return this;
+    }
+
+    /**
      * Removes an existing metadata value.
      * @param path the path that designates the key. Must be prefixed with a "/".
      * @return this metadata object.

--- a/src/test/java/com/box/sdk/MetadataTest.java
+++ b/src/test/java/com/box/sdk/MetadataTest.java
@@ -56,6 +56,21 @@ public class MetadataTest {
 
     @Test
     @Category(UnitTest.class)
+    public void testReplaceWithMultiSelect() {
+        List<String> valueList = new ArrayList<String>();
+        valueList.add("bar");
+        valueList.add("qux");
+        Metadata m = new Metadata().replace("/foo", valueList);
+        JsonArray operations = JsonArray.readFrom(m.getPatch());
+        Assert.assertEquals(1, operations.size());
+        JsonObject op = operations.get(0).asObject();
+        Assert.assertEquals("replace", op.get("op").asString());
+        Assert.assertEquals("/foo", op.get("path").asString());
+        Assert.assertEquals("[\"bar\",\"qux\"]", op.get("value").toString());
+    }
+
+    @Test
+    @Category(UnitTest.class)
     public void testTest() {
         Metadata m = new Metadata().test("/foo", "bar");
         JsonArray operations = JsonArray.readFrom(m.getPatch());


### PR DESCRIPTION
Multiselect was missing the functionality to perform a `replace` on it. Added the ability to replace as well as documentation for adding and replacing.