### PR TITLE
Added enum for complete field on BoxTasks Actions enum

### DIFF
--- a/src/main/java/com/box/sdk/BoxTask.java
+++ b/src/main/java/com/box/sdk/BoxTask.java
@@ -408,7 +408,12 @@ public class BoxTask extends BoxResource {
         /**
          * The task must be reviewed.
          */
-        REVIEW ("review");
+        REVIEW ("review"),
+
+        /**
+         * The task must be completed.
+         */
+        COMPLETE ("complete");
 
         private final String jsonValue;
 
@@ -419,6 +424,8 @@ public class BoxTask extends BoxResource {
         static Action fromJSONString(String jsonValue) {
             if (jsonValue.equals("review")) {
                 return REVIEW;
+            } else if (jsonValue.equals("complete")) {
+                return COMPLETE;
             } else {
                 throw new IllegalArgumentException("The provided JSON value isn't a valid Action.");
             }

--- a/src/test/Fixtures/BoxTask/CreateATaskWithActionComplete200.json
+++ b/src/test/Fixtures/BoxTask/CreateATaskWithActionComplete200.json
@@ -1,0 +1,33 @@
+{
+    "type": "task",
+    "id": "12345",
+    "item": {
+        "type": "file",
+        "id": "1111",
+        "file_version": {
+            "type": "file_version",
+            "id": "304867920258",
+            "sha1": "7ea91497ad7351d80f3a8439ae3d89dcc2675d27"
+        },
+        "sequence_id": "2",
+        "etag": "2",
+        "sha1": "7ea91497ad7351d80f3a8439ae3d89dcc2675d27",
+        "name": "Sample.pdf"
+    },
+    "due_at": null,
+    "action": "complete",
+    "message": "New Message",
+    "completion_rule": "all_assignees",
+    "task_assignment_collection": {
+        "total_count": 0,
+        "entries": []
+    },
+    "is_completed": false,
+    "created_by": {
+        "type": "user",
+        "id": "2222",
+        "name": "Test User",
+        "login": "test@user.com"
+    },
+    "created_at": "2018-04-26T17:02:45-07:00"
+}


### PR DESCRIPTION
Previously, BoxTask was missing the "complete" enum option for allowable actions.