### PR TITLE
Return metadata for each item returned by a metadata query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next Release
+- Return metadata for each item returned by a metadata query
+
 ## 2.44.1 [2020-02-13]
 - Fix formatting bug for Java Logger
 - Improve date / time parsing for responses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Next Release
-- Return metadata for each item returned by a metadata query
+- Add metadata to each item returned by a metadata query
 
 ## 2.44.1 [2020-02-13]
 - Fix formatting bug for Java Logger

--- a/doc/metadata_template.md
+++ b/doc/metadata_template.md
@@ -14,6 +14,7 @@ Metadata that belongs to a file is grouped by templates. Templates allow the met
   - [Get by ID](#get-by-id)
 - [Get Enterprise Metadata Templates](#get-enterprise-metadata-templates)
 - [Delete a Metadata Template](#delete-a-metadata-template)
+- [Execute Metadata Query](#execute-metadata-query)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -147,3 +148,21 @@ MetadataTemplate.deleteMetadataTemplate(api, "enterprise", "templateName");
 ```
 
 [delete-metadata-template]: http://opensource.box.com/box-java-sdk/javadoc/com/box/sdk/MetadataTemplate.html#deleteMetadataTemplate-com.box.sdk.BoxAPIConnection-java.lang.String-java.lang.String-
+
+Execute Metadata Query
+--------------------------
+
+The `executeMetadataQuery(BoxAPIConnection api, String scope, String template)` queries files, folders and weblinks based on their metadata.
+
+```java
+String from = "enterprise_341532.test";
+String query = "testfield = :arg";
+String ancestorFolderId = "0";
+JsonObject queryParameters = new JsonObject().add("arg", "test");
+
+BoxResourceIterable<BoxMetadataQueryItem> results = MetadataTemplate.executeMetadataQuery(api, from, query, queryParameters, ancestorFolderId);
+for (BoxMetadataQueryItem r: results) {
+  String customFieldValue = r.getMetadata().get("enterprise_341532").get(0).get("/customField");
+  System.out.println(customFieldValue);
+}
+```

--- a/src/main/java/com/box/sdk/BoxMetadataQueryItem.java
+++ b/src/main/java/com/box/sdk/BoxMetadataQueryItem.java
@@ -15,26 +15,27 @@ import java.util.Iterator;
  * handling for errors related to the Box REST API, you should capture this exception explicitly.*
  */
 public class BoxMetadataQueryItem extends BoxJSONObject {
-    private BoxItem.Info item;
-    private HashMap<String, ArrayList<Metadata>> metadata;
-    private BoxAPIConnection api;
+	private BoxItem.Info item;
+	private HashMap<String, ArrayList<Metadata>> metadata;
+	private BoxAPIConnection api;
 
-    /**
-     * Construct a BoxMetadataQueryItem.
-     * @param jsonObject the parsed JSON object.
-     * @param api the API connection to be used to fetch interacted item
-     */
-    public BoxMetadataQueryItem(JsonObject jsonObject, BoxAPIConnection api) {
-        super(jsonObject);
-        this.api = api;
-    }
+	/**
+	 * Construct a BoxMetadataQueryItem.
+	 *
+	 * @param jsonObject the parsed JSON object.
+	 * @param api        the API connection to be used to fetch interacted item
+	 */
+	public BoxMetadataQueryItem(JsonObject jsonObject, BoxAPIConnection api) {
+		super(jsonObject);
+		this.api = api;
+	}
 
-    @Override
-    protected void parseJSONMember(JsonObject.Member member) {
-        super.parseJSONMember(member);
+	@Override
+	protected void parseJSONMember(JsonObject.Member member) {
+		super.parseJSONMember(member);
 
-        String memberName = member.getName();
-        JsonValue value = member.getValue();
+		String memberName = member.getName();
+		JsonValue value = member.getValue();
 		if (memberName.equals("item")) {
 			String id = value.asObject().get("id").asString();
 			String type = value.asObject().get("type").asString();
@@ -44,10 +45,10 @@ public class BoxMetadataQueryItem extends BoxJSONObject {
 				this.item = folder.new Info(value.asObject());
 			} else if (type.equals("file")) {
 				BoxFile file = new BoxFile(this.api, id);
-				this.item  = file.new Info(value.asObject());
+				this.item = file.new Info(value.asObject());
 			} else if (type.equals("web_link")) {
 				BoxWebLink link = new BoxWebLink(this.api, id);
-				this.item  = link.new Info(value.asObject());
+				this.item = link.new Info(value.asObject());
 			} else {
 				assert false : "Unsupported item type: " + type;
 				throw new BoxAPIException("Unsupported item type: " + type);
@@ -55,11 +56,11 @@ public class BoxMetadataQueryItem extends BoxJSONObject {
 		} else if (memberName.equals("metadata")) {
 			this.metadata = new HashMap<String, ArrayList<Metadata>>();
 			JsonObject metadataObject = value.asObject();
-			for (JsonObject.Member enterprise: metadataObject){
+			for (JsonObject.Member enterprise : metadataObject) {
 				String enterpriseName = enterprise.getName();
 				JsonObject templates = enterprise.getValue().asObject();
 				ArrayList<Metadata> enterpriseMetadataArray = new ArrayList<Metadata>();
-				for (JsonObject.Member template: templates){
+				for (JsonObject.Member template : templates) {
 					String templateName = template.getName();
 					JsonObject templateValue = template.getValue().asObject();
 					Metadata metadataOfTemplate = new Metadata(templateValue);
@@ -70,22 +71,24 @@ public class BoxMetadataQueryItem extends BoxJSONObject {
 				this.metadata.put(enterpriseName, enterpriseMetadataArray);
 			}
 		}
-    }
+	}
 
-    /**
-     * Get the item which was interacted with.
-     * @return box item
-     */
-    public BoxItem.Info getItem() {
-        return this.item;
-    }
+	/**
+	 * Get the item which was interacted with.
+	 *
+	 * @return box item
+	 */
+	public BoxItem.Info getItem() {
+		return this.item;
+	}
 
-    /**
-     * Get the metadata on the item.
-     * @return HashMap of metadata
-     */
-    public HashMap<String, ArrayList<Metadata>> getMetadata() {
-        return this.metadata;
-    }
+	/**
+	 * Get the metadata on the item.
+	 *
+	 * @return HashMap of metadata
+	 */
+	public HashMap<String, ArrayList<Metadata>> getMetadata() {
+		return this.metadata;
+	}
 
 }

--- a/src/main/java/com/box/sdk/BoxMetadataQueryItem.java
+++ b/src/main/java/com/box/sdk/BoxMetadataQueryItem.java
@@ -1,11 +1,10 @@
 package com.box.sdk;
 
-import com.eclipsesource.json.JsonObject;
-import com.eclipsesource.json.JsonValue;
-
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
+
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
 
 /**
  * Represents an individual item returned by a metadata query item.
@@ -15,80 +14,80 @@ import java.util.Iterator;
  * handling for errors related to the Box REST API, you should capture this exception explicitly.*
  */
 public class BoxMetadataQueryItem extends BoxJSONObject {
-	private BoxItem.Info item;
-	private HashMap<String, ArrayList<Metadata>> metadata;
-	private BoxAPIConnection api;
+    private BoxItem.Info item;
+    private HashMap<String, ArrayList<Metadata>> metadata;
+    private BoxAPIConnection api;
 
-	/**
-	 * Construct a BoxMetadataQueryItem.
-	 *
-	 * @param jsonObject the parsed JSON object.
-	 * @param api        the API connection to be used to fetch interacted item
-	 */
-	public BoxMetadataQueryItem(JsonObject jsonObject, BoxAPIConnection api) {
-		super(jsonObject);
-		this.api = api;
-	}
+    /**
+     * Construct a BoxMetadataQueryItem.
+     *
+     * @param jsonObject the parsed JSON object.
+     * @param api        the API connection to be used to fetch interacted item
+     */
+    public BoxMetadataQueryItem(JsonObject jsonObject, BoxAPIConnection api) {
+        super(jsonObject);
+        this.api = api;
+    }
 
-	@Override
-	protected void parseJSONMember(JsonObject.Member member) {
-		super.parseJSONMember(member);
+    @Override
+    protected void parseJSONMember(JsonObject.Member member) {
+        super.parseJSONMember(member);
 
-		String memberName = member.getName();
-		JsonValue value = member.getValue();
-		if (memberName.equals("item")) {
-			String id = value.asObject().get("id").asString();
-			String type = value.asObject().get("type").asString();
-			this.item = new BoxFile(this.api, id).new Info(value.asObject());
-			if (type.equals("folder")) {
-				BoxFolder folder = new BoxFolder(this.api, id);
-				this.item = folder.new Info(value.asObject());
-			} else if (type.equals("file")) {
-				BoxFile file = new BoxFile(this.api, id);
-				this.item = file.new Info(value.asObject());
-			} else if (type.equals("web_link")) {
-				BoxWebLink link = new BoxWebLink(this.api, id);
-				this.item = link.new Info(value.asObject());
-			} else {
-				assert false : "Unsupported item type: " + type;
-				throw new BoxAPIException("Unsupported item type: " + type);
-			}
-		} else if (memberName.equals("metadata")) {
-			this.metadata = new HashMap<String, ArrayList<Metadata>>();
-			JsonObject metadataObject = value.asObject();
-			for (JsonObject.Member enterprise : metadataObject) {
-				String enterpriseName = enterprise.getName();
-				JsonObject templates = enterprise.getValue().asObject();
-				ArrayList<Metadata> enterpriseMetadataArray = new ArrayList<Metadata>();
-				for (JsonObject.Member template : templates) {
-					String templateName = template.getName();
-					JsonObject templateValue = template.getValue().asObject();
-					Metadata metadataOfTemplate = new Metadata(templateValue);
-					metadataOfTemplate.add("/$scope", enterpriseName);
-					metadataOfTemplate.add("/$template", templateName);
-					enterpriseMetadataArray.add(metadataOfTemplate);
-				}
-				this.metadata.put(enterpriseName, enterpriseMetadataArray);
-			}
-		}
-	}
+        String memberName = member.getName();
+        JsonValue value = member.getValue();
+        if (memberName.equals("item")) {
+            String id = value.asObject().get("id").asString();
+            String type = value.asObject().get("type").asString();
+            this.item = new BoxFile(this.api, id).new Info(value.asObject());
+            if (type.equals("folder")) {
+                BoxFolder folder = new BoxFolder(this.api, id);
+                this.item = folder.new Info(value.asObject());
+            } else if (type.equals("file")) {
+                BoxFile file = new BoxFile(this.api, id);
+                this.item = file.new Info(value.asObject());
+            } else if (type.equals("web_link")) {
+                BoxWebLink link = new BoxWebLink(this.api, id);
+                this.item = link.new Info(value.asObject());
+            } else {
+                assert false : "Unsupported item type: " + type;
+                throw new BoxAPIException("Unsupported item type: " + type);
+            }
+        } else if (memberName.equals("metadata")) {
+            this.metadata = new HashMap<String, ArrayList<Metadata>>();
+            JsonObject metadataObject = value.asObject();
+            for (JsonObject.Member enterprise : metadataObject) {
+                String enterpriseName = enterprise.getName();
+                JsonObject templates = enterprise.getValue().asObject();
+                ArrayList<Metadata> enterpriseMetadataArray = new ArrayList<Metadata>();
+                for (JsonObject.Member template : templates) {
+                    String templateName = template.getName();
+                    JsonObject templateValue = template.getValue().asObject();
+                    Metadata metadataOfTemplate = new Metadata(templateValue);
+                    metadataOfTemplate.add("/$scope", enterpriseName);
+                    metadataOfTemplate.add("/$template", templateName);
+                    enterpriseMetadataArray.add(metadataOfTemplate);
+                }
+                this.metadata.put(enterpriseName, enterpriseMetadataArray);
+            }
+        }
+    }
 
-	/**
-	 * Get the item which was interacted with.
-	 *
-	 * @return box item
-	 */
-	public BoxItem.Info getItem() {
-		return this.item;
-	}
+    /**
+     * Get the item which was interacted with.
+     *
+     * @return box item
+     */
+    public BoxItem.Info getItem() {
+        return this.item;
+    }
 
-	/**
-	 * Get the metadata on the item.
-	 *
-	 * @return HashMap of metadata
-	 */
-	public HashMap<String, ArrayList<Metadata>> getMetadata() {
-		return this.metadata;
-	}
+    /**
+     * Get the metadata on the item.
+     *
+     * @return HashMap of metadata
+     */
+    public HashMap<String, ArrayList<Metadata>> getMetadata() {
+        return this.metadata;
+    }
 
 }

--- a/src/main/java/com/box/sdk/BoxMetadataQueryItem.java
+++ b/src/main/java/com/box/sdk/BoxMetadataQueryItem.java
@@ -1,0 +1,72 @@
+package com.box.sdk;
+
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+
+/**
+ * Represents an individual item returned by a metadata query item.
+ *
+ * <p>Unless otherwise noted, the methods in this class can throw an unchecked {@link BoxAPIException} (unchecked
+ * meaning that the compiler won't force you to handle it) if an error occurs. If you wish to implement custom error
+ * handling for errors related to the Box REST API, you should capture this exception explicitly.*
+ */
+public class BoxMetadataQueryItem extends BoxJSONObject {
+    private BoxItem.Info item;
+    private JsonObject metadata;
+    private BoxAPIConnection api;
+
+    /**
+     * Construct a BoxMetadataQueryItem.
+     * @param jsonObject the parsed JSON object.
+     * @param api the API connection to be used to fetch interacted item
+     */
+    public BoxMetadataQueryItem(JsonObject jsonObject, BoxAPIConnection api) {
+        super(jsonObject);
+        this.api = api;
+    }
+
+    @Override
+    protected void parseJSONMember(JsonObject.Member member) {
+        super.parseJSONMember(member);
+
+        String memberName = member.getName();
+        JsonValue value = member.getValue();
+		if (memberName.equals("item")) {
+			String id = value.asObject().get("id").asString();
+			String type = value.asObject().get("type").asString();
+			this.item = new BoxFile(this.api, id).new Info(value.asObject());
+			if (type.equals("folder")) {
+				BoxFolder folder = new BoxFolder(this.api, id);
+				this.item = folder.new Info(value.asObject());
+			} else if (type.equals("file")) {
+				BoxFile file = new BoxFile(this.api, id);
+				this.item  = file.new Info(value.asObject());
+			} else if (type.equals("web_link")) {
+				BoxWebLink link = new BoxWebLink(this.api, id);
+				this.item  = link.new Info(value.asObject());
+			} else {
+				assert false : "Unsupported item type: " + type;
+				throw new BoxAPIException("Unsupported item type: " + type);
+			}
+		} else if (memberName.equals("metadata")) {
+			this.metadata = value.asObject();
+		}
+    }
+
+    /**
+     * Get the item which was interacted with.
+     * @return box item
+     */
+    public BoxItem.Info getItem() {
+        return this.item;
+    }
+
+    /**
+     * Get the metadata on the item.
+     * @return JsonObject of metadata
+     */
+    public JsonObject getMetadata() {
+        return this.metadata;
+    }
+
+}

--- a/src/main/java/com/box/sdk/BoxMetadataQueryItem.java
+++ b/src/main/java/com/box/sdk/BoxMetadataQueryItem.java
@@ -11,7 +11,7 @@ import com.eclipsesource.json.JsonValue;
  *
  * <p>Unless otherwise noted, the methods in this class can throw an unchecked {@link BoxAPIException} (unchecked
  * meaning that the compiler won't force you to handle it) if an error occurs. If you wish to implement custom error
- * handling for errors related to the Box REST API, you should capture this exception explicitly.*
+ * handling for errors related to the Box REST API, you should capture this exception explicitly.
  */
 public class BoxMetadataQueryItem extends BoxJSONObject {
     private BoxItem.Info item;

--- a/src/main/java/com/box/sdk/MetadataTemplate.java
+++ b/src/main/java/com/box/sdk/MetadataTemplate.java
@@ -326,9 +326,9 @@ public class MetadataTemplate extends BoxJSONObject {
      * @param orderBy Optional: the field_key(s) to order on and the corresponding direction(s)
      * @param limit Optional: max results to return for a single request (0-100 inclusive)
      * @param marker Optional: the marker to use for requesting the next page
-     * @return An iterable of BoxItem.Info search results
+     * @return An iterable of BoxMetadataQueryItem search results
      */
-    public static BoxResourceIterable<BoxItem.Info> executeMetadataQuery(final BoxAPIConnection api,
+    public static BoxResourceIterable<BoxMetadataQueryItem> executeMetadataQuery(final BoxAPIConnection api,
                                             String from, String query, JsonObject queryParameters,
                                             String ancestorFolderId, String indexName,
                                             JsonArray orderBy, int limit, String marker) {
@@ -355,36 +355,11 @@ public class MetadataTemplate extends BoxJSONObject {
         }
 
         URL url = METADATA_QUERIES_URL_TEMPLATE.build(api.getBaseURL());
-        return new BoxResourceIterable<BoxItem.Info>(api, url, limit, jsonObject, marker) {
+        return new BoxResourceIterable<BoxMetadataQueryItem>(api, url, limit, jsonObject, marker) {
 
             @Override
-            protected BoxItem.Info factory(JsonObject jsonObject) {
-                if (jsonObject != null) {
-                    JsonObject itemObj = (JsonObject) jsonObject.get("item");
-
-                    if (itemObj != null) {
-
-                        String type = itemObj.get("type").asString();
-                        String id = itemObj.get("id").asString();
-
-                        BoxItem.Info nextItemInfo;
-                        if (type.equals("folder")) {
-                            BoxFolder folder = new BoxFolder(api, id);
-                            nextItemInfo = folder.new Info(itemObj);
-                        } else if (type.equals("file")) {
-                            BoxFile file = new BoxFile(api, id);
-                            nextItemInfo = file.new Info(itemObj);
-                        } else if (type.equals("web_link")) {
-                            BoxWebLink link = new BoxWebLink(api, id);
-                            nextItemInfo = link.new Info(itemObj);
-                        } else {
-                            assert false : "Unsupported item type: " + type;
-                            throw new BoxAPIException("Unsupported item type: " + type);
-                        }
-                        return nextItemInfo;
-                    }
-                }
-                return null;
+            protected BoxMetadataQueryItem factory(JsonObject jsonObject) {
+                return new BoxMetadataQueryItem(jsonObject, api);
             }
         };
     }

--- a/src/main/java/com/box/sdk/MetadataTemplate.java
+++ b/src/main/java/com/box/sdk/MetadataTemplate.java
@@ -317,21 +317,69 @@ public class MetadataTemplate extends BoxJSONObject {
     /**
      * Executes a metadata query.
      *
-     * @param api the API connection to be used
-     * @param from Required: the template used in the query. Must be in the form scope.templateKey
-     * @param query Optional: the logical expression of the query
-     * @param queryParameters Optional: Required if query present. the arguments for the query
-     * @param ancestorFolderId Optional: the folder_id to which to restrain the query
-     * @param indexName Optional: the name of the Index to use
-     * @param orderBy Optional: the field_key(s) to order on and the corresponding direction(s)
-     * @param limit Optional: max results to return for a single request (0-100 inclusive)
-     * @param marker Optional: the marker to use for requesting the next page
+     * @param api The API connection to be used
+     * @param from The template used in the query. Must be in the form scope.templateKey
+     * @param ancestorFolderId The folder_id to which to restrain the query
      * @return An iterable of BoxMetadataQueryItem search results
      */
     public static BoxResourceIterable<BoxMetadataQueryItem> executeMetadataQuery(final BoxAPIConnection api,
-                                            String from, String query, JsonObject queryParameters,
-                                            String ancestorFolderId, String indexName,
-                                            JsonArray orderBy, int limit, String marker) {
+                                                            String from, String ancestorFolderId) {
+        return executeMetadataQuery(api, from, null, null, ancestorFolderId, null, null, 100, null);
+    }
+
+    /**
+      * Executes a metadata query.
+      *
+      * @param api The API connection to be used
+      * @param from The template used in the query. Must be in the form scope.templateKey
+      * @param query The logical expression of the query
+      * @param queryParameters Required if query present. The arguments for the query
+      * @param ancestorFolderId The folder_id to which to restrain the query
+      * @return An iterable of BoxMetadataQueryItem search results
+      */
+    public static BoxResourceIterable<BoxMetadataQueryItem> executeMetadataQuery(final BoxAPIConnection api,
+                                                            String from, String query, JsonObject queryParameters,
+                                                            String ancestorFolderId) {
+        return executeMetadataQuery(api, from, query, queryParameters, ancestorFolderId, null, null, 100, null);
+    }
+
+    /**
+      * Executes a metadata query.
+      *
+      * @param api The API connection to be used
+      * @param from The template used in the query. Must be in the form scope.templateKey
+      * @param query The logical expression of the query
+      * @param queryParameters Required if query present. The arguments for the query
+      * @param ancestorFolderId The folder_id to which to restrain the query
+      * @param indexName The name of the Index to use
+      * @param orderBy The field_key(s) to order on and the corresponding direction(s)
+      * @return An iterable of BoxMetadataQueryItem search results
+      */
+    public static BoxResourceIterable<BoxMetadataQueryItem> executeMetadataQuery(final BoxAPIConnection api,
+                                                            String from, String query, JsonObject queryParameters,
+                                                            String ancestorFolderId, String indexName,
+                                                            JsonArray orderBy) {
+        return executeMetadataQuery(api, from, query, queryParameters, ancestorFolderId, indexName, orderBy, 100, null);
+    }
+
+    /**
+     * Executes a metadata query.
+     *
+     * @param api The API connection to be used
+     * @param from The template used in the query. Must be in the form scope.templateKey
+     * @param query The logical expression of the query
+     * @param queryParameters Required if query present. The arguments for the query
+     * @param ancestorFolderId The folder_id to which to restrain the query
+     * @param indexName The name of the Index to use
+     * @param orderBy The field_key(s) to order on and the corresponding direction(s)
+     * @param limit Max results to return for a single request (0-100 inclusive)
+     * @param marker The marker to use for requesting the next page
+     * @return An iterable of BoxMetadataQueryItem search results
+     */
+    public static BoxResourceIterable<BoxMetadataQueryItem> executeMetadataQuery(final BoxAPIConnection api,
+                                                            String from, String query, JsonObject queryParameters,
+                                                            String ancestorFolderId, String indexName,
+                                                            JsonArray orderBy, int limit, String marker) {
 
         JsonObject jsonObject = new JsonObject().add("from", from);
         if (query != null) {

--- a/src/test/Fixtures/BoxMetadataTemplate/MetadataQuery1stResponse200.json
+++ b/src/test/Fixtures/BoxMetadataTemplate/MetadataQuery1stResponse200.json
@@ -164,6 +164,29 @@
                         "$parent": "file_123451",
                         "$typeScope": "enterprise_67890",
                         "$typeVersion": 2
+                    },
+                    "randomTemplate": {
+                        "customField": "custom",
+                        "$id": "32fdsa1432hf33jkf3",
+                        "$version": 1,
+                        "$type": "randomTemplate-asdfghjkf234hjjhfks7890",
+                        "$parent": "file_12343251",
+                        "$typeScope": "enterprise_67890",
+                        "$typeVersion": 2
+                    }
+                },
+                "enterprise_123456": {
+                    "someTemplate": {
+                        "$parent": "file_161753469109",
+                        "$version": 0,
+                        "customerName": "Phoenix Corp",
+                        "$type": "someTemplate-3d5fcaca-f496-4bb6-9046-d25c37bc5594",
+                        "$typeVersion": 0,
+                        "$id": "ba52e2cc-371d-4659-8d53-50f1ac642e35",
+                        "amount": 100,
+                        "claimDate": "2016-04-10T00:00:00Z",
+                        "region": "West",
+                        "$typeScope": "enterprise_123456"
                     }
                 }
             }

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -35,13 +35,11 @@ import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
-import net.minidev.json.JSONObject;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import com.eclipsesource.json.JsonObject;
 
 /**
  * {@link BoxFile} related unit tests.

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -1757,20 +1757,28 @@ public class BoxFileTest {
         assertEquals("file", currBoxItem.getItem().getType());
         assertEquals("123450", currBoxItem.getItem().getID());
         assertEquals("1.jpg", currBoxItem.getItem().getName());
-        JsonObject metadata = currBoxItem.getMetadata();
-        Assert.assertEquals("Werk Flow 0", metadata.getJsonObject("enterprise_67890").getJsonObject("relayWorkflowInformation").getString("workflowName"));
+        HashMap<String, ArrayList<Metadata>> metadata = currBoxItem.getMetadata();
+        Assert.assertEquals("relayWorkflowInformation", metadata.get("enterprise_67890").get(0).getTemplateName());
+        Assert.assertEquals("enterprise_67890", metadata.get("enterprise_67890").get(0).getScope());
+        Assert.assertEquals("Werk Flow 0", metadata.get("enterprise_67890").get(0).get("/workflowName"));
 
         // Second item on the first page of results
         currBoxItem = results.iterator().next();
         assertEquals("file", currBoxItem.getItem().getType());
         assertEquals("123451", currBoxItem.getItem().getID());
         assertEquals("2.jpg", currBoxItem.getItem().getName());
+        metadata = currBoxItem.getMetadata();
+        Assert.assertEquals("relayWorkflowInformation", metadata.get("enterprise_67890").get(0).getTemplateName());
+        Assert.assertEquals("randomTemplate", metadata.get("enterprise_67890").get(1).getTemplateName());
+        Assert.assertEquals("someTemplate", metadata.get("enterprise_123456").get(0).getTemplateName());
 
         // First item on the second page of results (this next call makes the second request to get the second page)
         currBoxItem = results.iterator().next();
         assertEquals("file", currBoxItem.getItem().getType());
         assertEquals("123452", currBoxItem.getItem().getID());
         assertEquals("3.jpg", currBoxItem.getItem().getName());
+        metadata = currBoxItem.getMetadata();
+        Assert.assertEquals("relayWorkflowInformation", metadata.get("enterprise_67890").get(0).getTemplateName());
     }
 
     @Test


### PR DESCRIPTION
`MetadataTemplate.executeMetadataQuery()` would returned `BoxItem` that did not include the metadata for each item. Now, instead of returning a `BoxItem`, the method returns a `BoxMetadataQueryItem`. This will contain an item and its associated metadata.