### PR TITLE
Add preflight check before chunked uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 - Fix bug with premature disconnect when renaming files and weblinks
 - Add metadata to each item returned by a metadata query
+- Add preflight check before chunked uploads
 
 ## 2.44.1 [2020-02-13]
 - Fix formatting bug for Java Logger

--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -1088,6 +1088,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
     public BoxFile.Info uploadLargeFile(InputStream inputStream, String fileName, long fileSize)
             throws InterruptedException, IOException {
         URL url = UPLOAD_SESSION_URL_TEMPLATE.build(this.getAPI().getBaseUploadURL());
+        this.canUpload(fileName, fileSize);
         return new LargeFileUpload().
                 upload(this.getAPI(), this.getID(), inputStream, url, fileName, fileSize);
     }
@@ -1107,6 +1108,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
             Map<String, String> fileAttributes)
             throws InterruptedException, IOException {
         URL url = UPLOAD_SESSION_URL_TEMPLATE.build(this.getAPI().getBaseUploadURL());
+        this.canUpload(fileName, fileSize);
         return new LargeFileUpload().
                 upload(this.getAPI(), this.getID(), inputStream, url, fileName, fileSize, fileAttributes);
     }
@@ -1128,6 +1130,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
                                         int nParallelConnections, long timeOut, TimeUnit unit)
             throws InterruptedException, IOException {
         URL url = UPLOAD_SESSION_URL_TEMPLATE.build(this.getAPI().getBaseUploadURL());
+        this.canUpload(fileName, fileSize);
         return new LargeFileUpload(nParallelConnections, timeOut, unit).
                 upload(this.getAPI(), this.getID(), inputStream, url, fileName, fileSize);
     }
@@ -1151,6 +1154,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
                                         Map<String, String> fileAttributes)
             throws InterruptedException, IOException {
         URL url = UPLOAD_SESSION_URL_TEMPLATE.build(this.getAPI().getBaseUploadURL());
+        this.canUpload(fileName, fileSize);
         return new LargeFileUpload(nParallelConnections, timeOut, unit).
                 upload(this.getAPI(), this.getID(), inputStream, url, fileName, fileSize, fileAttributes);
     }

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -37,6 +37,7 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -1894,6 +1895,8 @@ public class BoxFileTest {
     @Test
     @Category(UnitTest.class)
     public void testChunkedUploadWithCorrectPartSize() throws IOException, InterruptedException {
+        String javaVersion = System.getProperty("java.version");
+        Assume.assumeFalse("Test is not run for JDK 7", javaVersion.contains("1.7"));
         String sessionResult = "";
         String uploadResult = "";
         String commitResult = "";

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -1897,6 +1897,7 @@ public class BoxFileTest {
         String sessionResult = "";
         String uploadResult = "";
         String commitResult = "";
+        final String preflightURL = "/files/content";
         final String sessionURL = "/files/upload_sessions";
         final String uploadURL = "/files/upload_sessions/D5E3F8ADA11A38F0A66AD0B64AACA658";
         final String commitURL = "/files/upload_sessions/D5E3F8ADA11A38F0A66AD0B64AACA658/commit";
@@ -1905,6 +1906,14 @@ public class BoxFileTest {
         sessionResult = TestConfig.getFixture("BoxFile/CreateUploadSession201");
         uploadResult = TestConfig.getFixture("BoxFile/UploadPartOne200");
         commitResult = TestConfig.getFixture("BoxFile/CommitUpload201");
+
+        JsonObject idObject = new JsonObject()
+                .add("id", "12345");
+
+        JsonObject preflightObject = new JsonObject()
+                .add("name", "testfile.txt")
+                .add("size", 5)
+                .add("parent", idObject);
 
         JsonObject sessionObject = new JsonObject()
                 .add("folder_id", "12345")
@@ -1921,6 +1930,12 @@ public class BoxFileTest {
 
         JsonObject commitObject = new JsonObject()
                 .add("parts", parts);
+
+        WIRE_MOCK_CLASS_RULE.stubFor(WireMock.options(WireMock.urlPathEqualTo(preflightURL))
+                .withRequestBody(WireMock.equalToJson(preflightObject.toString()))
+                .willReturn(WireMock.aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(200)));
 
         WIRE_MOCK_CLASS_RULE.stubFor(WireMock.post(WireMock.urlPathEqualTo(sessionURL))
                 .withRequestBody(WireMock.equalToJson(sessionObject.toString()))

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -616,6 +616,8 @@ public class BoxFolderTest {
     @Test
     @Category(UnitTest.class)
     public void testChunkedUploadThrows409() throws IOException, InterruptedException {
+        String javaVersion = System.getProperty("java.version");
+        Assume.assumeFalse("Test is not run for JDK 7", javaVersion.contains("1.7"));
         final String preflightURL = "/files/content";
         BoxFileTest.FakeStream stream = new BoxFileTest.FakeStream("aaaaa");
 
@@ -649,6 +651,8 @@ public class BoxFolderTest {
     @Test
     @Category(UnitTest.class)
     public void testChunkedUploadWithCorrectPartSizeAndAttributes() throws IOException, InterruptedException {
+        String javaVersion = System.getProperty("java.version");
+        Assume.assumeFalse("Test is not run for JDK 7", javaVersion.contains("1.7"));
         String sessionResult = "";
         String uploadResult = "";
         String commitResult = "";
@@ -737,6 +741,8 @@ public class BoxFolderTest {
     @Test
     @Category(UnitTest.class)
     public void testChunkedParallelUploadWithCorrectPartSizeAndAttributes() throws IOException, InterruptedException {
+        String javaVersion = System.getProperty("java.version");
+        Assume.assumeFalse("Test is not run for JDK 7", javaVersion.contains("1.7"));
         String sessionResult = "";
         String uploadResult = "";
         String commitResult = "";
@@ -918,6 +924,8 @@ public class BoxFolderTest {
     @Test
     @Category(UnitTest.class)
     public void testRetryingChunkedUploadWith500Error() throws IOException, InterruptedException {
+        String javaVersion = System.getProperty("java.version");
+        Assume.assumeFalse("Test is not run for JDK 7", javaVersion.contains("1.7"));
         String responseBody500 = TestConfig.getFixture("BoxException/BoxResponseException500");
         String sessionResult = "";
         String uploadResult = "";

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -827,6 +827,7 @@ public class BoxFolderTest {
     @Category(UnitTest.class)
     public void testChunkedUploadWith500Error() throws IOException, InterruptedException {
         String javaVersion = System.getProperty("java.version");
+        System.out.println(javaVersion);
         Assume.assumeTrue("Test is not run for JDK 7", javaVersion.contains("1.7"));
         String responseBody500 = TestConfig.getFixture("BoxException/BoxResponseException500");
         String sessionResult = "";

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -827,7 +827,7 @@ public class BoxFolderTest {
     @Category(UnitTest.class)
     public void testChunkedUploadWith500Error() throws IOException, InterruptedException {
         String javaVersion = System.getProperty("java.version");
-        Assume.assumeTrue("Test is not run for JDK 7", false);
+        Assume.assumeFalse("Test is not run for JDK 7", javaVersion.contains("1.7"));
         String responseBody500 = TestConfig.getFixture("BoxException/BoxResponseException500");
         String sessionResult = "";
         String partsResult = "";

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -827,7 +827,6 @@ public class BoxFolderTest {
     @Category(UnitTest.class)
     public void testChunkedUploadWith500Error() throws IOException, InterruptedException {
         String javaVersion = System.getProperty("java.version");
-        System.out.println(javaVersion);
         Assume.assumeTrue("Test is not run for JDK 7", javaVersion.contains("1.7"));
         String responseBody500 = TestConfig.getFixture("BoxException/BoxResponseException500");
         String sessionResult = "";

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -827,7 +827,7 @@ public class BoxFolderTest {
     @Category(UnitTest.class)
     public void testChunkedUploadWith500Error() throws IOException, InterruptedException {
         String javaVersion = System.getProperty("java.version");
-        Assume.assumeTrue("Test is not run for JDK 7", javaVersion.contains("1.7"));
+        Assume.assumeTrue("Test is not run for JDK 7", true);
         String responseBody500 = TestConfig.getFixture("BoxException/BoxResponseException500");
         String sessionResult = "";
         String partsResult = "";

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -614,10 +614,44 @@ public class BoxFolderTest {
 
     @Test
     @Category(UnitTest.class)
+    public void testChunkedUploadThrows409() throws IOException, InterruptedException {
+        final String preflightURL = "/files/content";
+        BoxFileTest.FakeStream stream = new BoxFileTest.FakeStream("aaaaa");
+
+        String getResult = TestConfig.getFixture("BoxException/BoxResponseException409");
+
+        JsonObject idObject = new JsonObject()
+                .add("id", "12345");
+
+        JsonObject preflightObject = new JsonObject()
+                .add("name", "testfile.txt")
+                .add("size", 5)
+                .add("parent", idObject);
+
+        WIRE_MOCK_CLASS_RULE.stubFor(WireMock.options(WireMock.urlPathEqualTo(preflightURL))
+                .withRequestBody(WireMock.equalToJson(preflightObject.toString()))
+                .willReturn(WireMock.aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(getResult)
+                        .withStatus(409)));
+
+        try {
+            BoxFolder folder = new BoxFolder(this.api, "12345");
+            BoxFile.Info uploadedFile = folder.uploadLargeFile(stream, "testfile.txt", 5);
+            //If the chunked upload does not fail, this line will be executed.
+            Assert.assertFalse("Preflight check for chunked upload did not fail with 409.", true);
+        } catch (BoxAPIException apiEx) {
+            Assert.assertEquals(apiEx.getResponseCode(), 409);
+        }
+    }
+
+    @Test
+    @Category(UnitTest.class)
     public void testChunkedUploadWithCorrectPartSizeAndAttributes() throws IOException, InterruptedException {
         String sessionResult = "";
         String uploadResult = "";
         String commitResult = "";
+        final String preflightURL = "/files/content";
         final String sessionURL = "/files/upload_sessions";
         final String uploadURL = "/files/upload_sessions/D5E3F8ADA11A38F0A66AD0B64AACA658";
         final String commitURL = "/files/upload_sessions/D5E3F8ADA11A38F0A66AD0B64AACA658/commit";
@@ -626,6 +660,14 @@ public class BoxFolderTest {
         sessionResult = TestConfig.getFixture("BoxFile/CreateUploadSession201");
         uploadResult = TestConfig.getFixture("BoxFile/UploadPartOne200");
         commitResult = TestConfig.getFixture("BoxFile/CommitUploadWithAttributes201");
+
+        JsonObject idObject = new JsonObject()
+                .add("id", "12345");
+
+        JsonObject preflightObject = new JsonObject()
+                .add("name", "testfile.txt")
+                .add("size", 5)
+                .add("parent", idObject);
 
         JsonObject sessionObject = new JsonObject()
                 .add("folder_id", "12345")
@@ -651,6 +693,12 @@ public class BoxFolderTest {
         JsonObject commitObject = new JsonObject()
                 .add("parts", parts)
                 .add("attributes", fileAttributesJson);
+
+        WIRE_MOCK_CLASS_RULE.stubFor(WireMock.options(WireMock.urlPathEqualTo(preflightURL))
+                    .withRequestBody(WireMock.equalToJson(preflightObject.toString()))
+                    .willReturn(WireMock.aResponse()
+                            .withHeader("Content-Type", "application/json")
+                            .withStatus(200)));
 
         WIRE_MOCK_CLASS_RULE.stubFor(WireMock.post(WireMock.urlPathEqualTo(sessionURL))
                 .withRequestBody(WireMock.equalToJson(sessionObject.toString()))
@@ -691,6 +739,7 @@ public class BoxFolderTest {
         String sessionResult = "";
         String uploadResult = "";
         String commitResult = "";
+        final String preflightURL = "/files/content";
         final String sessionURL = "/files/upload_sessions";
         final String uploadURL = "/files/upload_sessions/D5E3F8ADA11A38F0A66AD0B64AACA658";
         final String commitURL = "/files/upload_sessions/D5E3F8ADA11A38F0A66AD0B64AACA658/commit";
@@ -699,6 +748,14 @@ public class BoxFolderTest {
         sessionResult = TestConfig.getFixture("BoxFile/CreateUploadSession201");
         uploadResult = TestConfig.getFixture("BoxFile/UploadPartOne200");
         commitResult = TestConfig.getFixture("BoxFile/CommitUploadWithAttributes201");
+
+        JsonObject idObject = new JsonObject()
+                .add("id", "12345");
+
+        JsonObject preflightObject = new JsonObject()
+                .add("name", "testfile.txt")
+                .add("size", 5)
+                .add("parent", idObject);
 
         JsonObject sessionObject = new JsonObject()
                 .add("folder_id", "12345")
@@ -724,6 +781,12 @@ public class BoxFolderTest {
         JsonObject commitObject = new JsonObject()
                 .add("parts", parts)
                 .add("attributes", fileAttributesJson);
+
+        WIRE_MOCK_CLASS_RULE.stubFor(WireMock.options(WireMock.urlPathEqualTo(preflightURL))
+                .withRequestBody(WireMock.equalToJson(preflightObject.toString()))
+                .willReturn(WireMock.aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(200)));
 
         WIRE_MOCK_CLASS_RULE.stubFor(WireMock.post(WireMock.urlPathEqualTo(sessionURL))
                 .withRequestBody(WireMock.equalToJson(sessionObject.toString()))

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -827,7 +827,7 @@ public class BoxFolderTest {
     @Category(UnitTest.class)
     public void testChunkedUploadWith500Error() throws IOException, InterruptedException {
         String javaVersion = System.getProperty("java.version");
-        Assume.assumeTrue("Test is not run for JDK 7", true);
+        Assume.assumeTrue("Test is not run for JDK 7", false);
         String responseBody500 = TestConfig.getFixture("BoxException/BoxResponseException500");
         String sessionResult = "";
         String partsResult = "";

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -827,7 +827,7 @@ public class BoxFolderTest {
     @Category(UnitTest.class)
     public void testChunkedUploadWith500Error() throws IOException, InterruptedException {
         String javaVersion = System.getProperty("java.version");
-        Assume.assumeTrue("Test is not run for JDK 7", javaVersion.contains("1.8"));
+        Assume.assumeTrue("Test is not run for JDK 7", javaVersion.contains("1.7"));
         String responseBody500 = TestConfig.getFixture("BoxException/BoxResponseException500");
         String sessionResult = "";
         String partsResult = "";

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.*;
 
 import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -825,10 +826,13 @@ public class BoxFolderTest {
     @Test
     @Category(UnitTest.class)
     public void testChunkedUploadWith500Error() throws IOException, InterruptedException {
+        String javaVersion = System.getProperty("java.version");
+        Assume.assumeTrue("Test is not run for JDK 7", javaVersion.contains("1.8"));
         String responseBody500 = TestConfig.getFixture("BoxException/BoxResponseException500");
         String sessionResult = "";
         String partsResult = "";
         String commitResult = "";
+        final String preflightURL = "/files/content";
         final String sessionURL = "/files/upload_sessions";
         final String uploadURL = "/files/upload_sessions/D5E3F8ADA11A38F0A66AD0B64AACA658";
         final String listPartsURL = "/files/upload_sessions/D5E3F8ADA11A38F0A66AD0B64AACA658/parts";
@@ -839,6 +843,14 @@ public class BoxFolderTest {
         sessionResult = TestConfig.getFixture("BoxFile/CreateUploadSession201");
         partsResult = TestConfig.getFixture("BoxFile/ListUploadedPart200");
         commitResult = TestConfig.getFixture("BoxFile/CommitUpload201");
+
+        JsonObject idObject = new JsonObject()
+                .add("id", "12345");
+
+        JsonObject preflightObject = new JsonObject()
+                .add("name", "testfile.txt")
+                .add("size", 5)
+                .add("parent", idObject);
 
         JsonObject sessionObject = new JsonObject()
                 .add("folder_id", "12345")
@@ -855,6 +867,12 @@ public class BoxFolderTest {
 
         JsonObject commitObject = new JsonObject()
                 .add("parts", parts);
+
+        WIRE_MOCK_CLASS_RULE.stubFor(WireMock.options(WireMock.urlPathEqualTo(preflightURL))
+                .withRequestBody(WireMock.equalToJson(preflightObject.toString()))
+                .willReturn(WireMock.aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(200)));
 
         WIRE_MOCK_CLASS_RULE.stubFor(WireMock.post(WireMock.urlPathEqualTo(sessionURL))
                 .withRequestBody(WireMock.equalToJson(sessionObject.toString()))
@@ -906,6 +924,7 @@ public class BoxFolderTest {
         String wrongPartsResult = "";
         String partsResult = "";
         String commitResult = "";
+        final String preflightURL = "/files/content";
         final String sessionURL = "/files/upload_sessions";
         final String uploadURL = "/files/upload_sessions/D5E3F8ADA11A38F0A66AD0B64AACA658";
         final String listPartsURL = "/files/upload_sessions/D5E3F8ADA11A38F0A66AD0B64AACA658/parts";
@@ -918,6 +937,14 @@ public class BoxFolderTest {
         wrongPartsResult = TestConfig.getFixture("BoxFile/ListUploadedParts200");
         partsResult = TestConfig.getFixture("BoxFile/ListUploadedPart200");
         commitResult = TestConfig.getFixture("BoxFile/CommitUpload201");
+
+        JsonObject idObject = new JsonObject()
+                .add("id", "12345");
+
+        JsonObject preflightObject = new JsonObject()
+                .add("name", "testfile.txt")
+                .add("size", 5)
+                .add("parent", idObject);
 
         JsonObject sessionObject = new JsonObject()
                 .add("folder_id", "12345")
@@ -934,6 +961,12 @@ public class BoxFolderTest {
 
         JsonObject commitObject = new JsonObject()
                 .add("parts", parts);
+
+        WIRE_MOCK_CLASS_RULE.stubFor(WireMock.options(WireMock.urlPathEqualTo(preflightURL))
+                .withRequestBody(WireMock.equalToJson(preflightObject.toString()))
+                .willReturn(WireMock.aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withStatus(200)));
 
         WIRE_MOCK_CLASS_RULE.stubFor(WireMock.post(WireMock.urlPathEqualTo(sessionURL))
                 .withRequestBody(WireMock.equalToJson(sessionObject.toString()))


### PR DESCRIPTION
When large files are uploaded to the chunked upload endpoint using the `Folder.uploadLargeFile()` method, they can fail because of 409 conflict errors. To avoid these errors, we do a preflight check before uploading. The preflight check will determine whether the file is already uploaded rather than uploading the file, then finding that out. This will reduce network traffic.