### PR TITLE
Fix path parameter sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 - Add support for the uploader display name field for Files and File Versions ([#791](https://github.com/box/box-java-sdk/pull/791))
+- Fix path parameter sanitization ([#797](https://github.com/box/box-java-sdk/pull/797))
 
 ## 2.46.0 [2020-04-09]
 - Fix retry logic ([#787](https://github.com/box/box-java-sdk/pull/787))

--- a/src/main/java/com/box/sdk/URLTemplate.java
+++ b/src/main/java/com/box/sdk/URLTemplate.java
@@ -31,7 +31,7 @@ public class URLTemplate {
             String valueString = String.valueOf(value);
             Boolean test = NUMERIC.matcher(valueString).matches();
             if (!NUMERIC.matcher(valueString).matches()) {
-                assert false : "An invalid path parameter passed in. It must be numeric.";
+                throw new BoxAPIException("An invalid path parameter passed in. It must be numeric.");
             }
         }
         String urlString = String.format(base + this.template, values);
@@ -40,7 +40,7 @@ public class URLTemplate {
         try {
             url = new URL(urlString);
         } catch (MalformedURLException e) {
-            assert false : "A valid URL could not be constructed from the provided parameters.";
+            throw new BoxAPIException("An invalid path parameter passed in. It must be numeric.");
         }
 
         return url;
@@ -57,7 +57,7 @@ public class URLTemplate {
             String valueString = String.valueOf(value);
             Boolean test = ALPHA_NUMERIC.matcher(valueString).matches();
             if (!ALPHA_NUMERIC.matcher(valueString).matches()) {
-                assert false : "An invalid path parameter passed in. It must be alphanumeric.";
+                throw new BoxAPIException("An invalid path parameter passed in. It must be alphanumeric.");
             }
         }
         String urlString = String.format(base + this.template, values);
@@ -66,7 +66,7 @@ public class URLTemplate {
         try {
             url = new URL(urlString);
         } catch (MalformedURLException e) {
-            assert false : "A valid URL could not be constructed from the provided parameters.";
+            throw new BoxAPIException("A valid URL could not be constructed from the provided parameters.");
         }
 
         return url;
@@ -83,7 +83,7 @@ public class URLTemplate {
         for (Object value: values) {
             String valueString = String.valueOf(value);
             if (!NUMERIC.matcher(valueString).matches()) {
-                assert false : "An invalid path param passed in. It must be numeric.";
+                throw new BoxAPIException("An invalid path param passed in. It must be numeric.");
             }
         }
         String urlString = String.format(base + this.template, values) + queryString;
@@ -91,7 +91,7 @@ public class URLTemplate {
         try {
             url = new URL(urlString);
         } catch (MalformedURLException e) {
-            assert false : "A valid URL could not be constructed from the provided parameters.";
+            throw new BoxAPIException("A valid URL could not be constructed from the provided parameters.");
         }
 
         return url;
@@ -108,7 +108,7 @@ public class URLTemplate {
         for (Object value: values) {
             String valueString = String.valueOf(value);
             if (!ALPHA_NUMERIC.matcher(valueString).matches()) {
-                assert false : "An invalid path param passed in. It must be alphanumeric.";
+                throw new BoxAPIException("An invalid path param passed in. It must be alphanumeric.");
             }
         }
         String urlString = String.format(base + this.template, values) + queryString;
@@ -116,7 +116,7 @@ public class URLTemplate {
         try {
             url = new URL(urlString);
         } catch (MalformedURLException e) {
-            assert false : "A valid URL could not be constructed from the provided parameters.";
+            throw new BoxAPIException("A valid URL could not be constructed from the provided parameters.");
         }
 
         return url;

--- a/src/test/java/com/box/sdk/BoxURLTemplateTest.java
+++ b/src/test/java/com/box/sdk/BoxURLTemplateTest.java
@@ -34,12 +34,12 @@ public class BoxURLTemplateTest {
     public void testBuildFails() {
         URLTemplate template = new URLTemplate("test/%s");
         try {
-            URL url = template.build(BASE_URL, "1fdsa45");
-        } catch (AssertionError e) {
+            URL url = template.build(BASE_URL, "123dfest");
+        } catch (BoxAPIException e) {
             Assert.assertEquals("An invalid path parameter passed in. It must be numeric.", e.getMessage());
             return;
         }
-        Assert.fail("Never threw an AssertionError");
+        Assert.fail("Never threw a BoxAPIException");
     }
 
     /**
@@ -64,10 +64,10 @@ public class BoxURLTemplateTest {
         URLTemplate template = new URLTemplate("test/%s");
         try {
             URL url = template.buildAlpha(BASE_URL, "1234.45/43/5");
-        } catch (AssertionError e) {
+        } catch (BoxAPIException e) {
             Assert.assertEquals("An invalid path parameter passed in. It must be alphanumeric.", e.getMessage());
             return;
         }
-        Assert.fail("Never threw an AssertionError");
+        Assert.fail("Never threw a BoxAPIException");
     }
 }


### PR DESCRIPTION
The SDK did not break execution and throw an exception to the user and when the sanitization check for parameters failed. This is now fixed.