### PR TITLE
Fix issue for `getIsExternallyOwned()` for Files and Folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next Release
+- Fix issue for `getIsExternallyOwned()` for Files and Folders ([#808](https://github.com/box/box-java-sdk/pull/808))
+
 ## 2.47.0 [2020-04-23]
 - Add support for the uploader display name field for Files and File Versions ([#791](https://github.com/box/box-java-sdk/pull/791))
 - Fix path parameter sanitization ([#797](https://github.com/box/box-java-sdk/pull/797))

--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -1745,7 +1745,7 @@ public class BoxFile extends BoxItem {
          * Returns the field for indicating whether a file is owned by a user outside the enterprise.
          * @return indicator for whether or not the file is owned by a user outside the enterprise.
          */
-        public boolean getIsExternallyOwned() {
+        public Boolean getIsExternallyOwned() {
             return this.isExternallyOwned;
         }
 

--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -1579,7 +1579,7 @@ public class BoxFile extends BoxItem {
         private URL previewLink;
         private BoxLock lock;
         private boolean isWatermarked;
-        private Boolean isExternallyOwned;
+        private boolean isExternallyOwned;
         private JsonObject metadata;
         private Map<String, Map<String, Metadata>> metadataMap;
         private List<Representation> representations;
@@ -1745,7 +1745,7 @@ public class BoxFile extends BoxItem {
          * Returns the field for indicating whether a file is owned by a user outside the enterprise.
          * @return indicator for whether or not the file is owned by a user outside the enterprise.
          */
-        public Boolean getIsExternallyOwned() {
+        public boolean getIsExternallyOwned() {
             return this.isExternallyOwned;
         }
 

--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -1211,7 +1211,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         private boolean canNonOwnersInvite;
         private boolean isWatermarked;
         private boolean isCollaborationRestrictedToEnterprise;
-        private Boolean isExternallyOwned;
+        private boolean isExternallyOwned;
         private Map<String, Map<String, Metadata>> metadataMap;
         private List<String> allowedSharedLinkAccessLevels;
         private List<String> allowedInviteeRoles;
@@ -1392,9 +1392,9 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         /**
          * Get the field is_externally_owned determining whether this folder is owned by a user outside of the
          * enterprise.
-         * @return a Boolean indicating whether this folder is owned by a user outside the enterprise.
+         * @return a boolean indicating whether this folder is owned by a user outside the enterprise.
          */
-        public Boolean getIsExternallyOwned() {
+        public boolean getIsExternallyOwned() {
             return this.isExternallyOwned;
         }
 

--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -1392,9 +1392,9 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         /**
          * Get the field is_externally_owned determining whether this folder is owned by a user outside of the
          * enterprise.
-         * @return a boolean indicating whether this folder is owned by a user outside the enterprise.
+         * @return a Boolean indicating whether this folder is owned by a user outside the enterprise.
          */
-        public boolean getIsExternallyOwned() {
+        public Boolean getIsExternallyOwned() {
             return this.isExternallyOwned;
         }
 


### PR DESCRIPTION
Calling `getIsExternallyOwned()` on `File.Info` object or `Folder.info` would cause an exception when the value is null. This is because the return type for the method was a boolean, but the value being returned was a Boolean. So when the Boolean has value null, the value could not be cast to a primitive and would throw an exception. This issue was brought up in #805. 

This is fixed by changing the type of the value being returned from a Boolean to a boolean.