### PR TITLE
Add ability to set the filename when uploading a new version of a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Next Release
 - Add support for setting Tracking Codes ([#766](https://github.com/box/box-java-sdk/pull/766))
 - Fix issue for `getIsExternallyOwned()` for Files and Folders ([#808](https://github.com/box/box-java-sdk/pull/808))
+- Add ability to set the filename when uploading a new version of a file ([#810](https://github.com/box/box-java-sdk/pull/810))
 
 ## 2.47.0 [2020-04-23]
 - Add support for the uploader display name field for Files and File Versions ([#791](https://github.com/box/box-java-sdk/pull/791))

--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -846,6 +846,20 @@ public class BoxFile extends BoxItem {
     }
 
     /**
+     * Uploads a new version of this file, replacing the current version. Note that only users with premium accounts
+     * will be able to view and recover previous versions of the file.
+     *
+     * @param fileContent     a stream containing the new file contents.
+     * @param fileContentSHA1 a string containing the SHA1 hash of the new file contents.
+     * @param modified        the date that the new version was modified.
+     * @param name            the new name for the file
+     * @return the uploaded file version.
+     */
+    public BoxFile.Info uploadNewVersion(InputStream fileContent, String fileContentSHA1, Date modified, String name) {
+        return this.uploadNewVersion(fileContent, fileContentSHA1, modified, 0, null, name);
+    }
+
+    /**
      * Uploads a new version of this file, replacing the current version, while reporting the progress to a
      * ProgressListener. Note that only users with premium accounts will be able to view and recover previous versions
      * of the file.

--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -856,7 +856,7 @@ public class BoxFile extends BoxItem {
      * @return the uploaded file version.
      */
     public BoxFile.Info uploadNewVersion(InputStream fileContent, String fileContentSHA1, Date modified, String name) {
-        return this.uploadNewVersion(fileContent, fileContentSHA1, modified, 0, null, name);
+        return this.uploadNewVersion(fileContent, fileContentSHA1, modified, name, 0, null);
     }
 
     /**
@@ -889,7 +889,7 @@ public class BoxFile extends BoxItem {
      */
     public BoxFile.Info uploadNewVersion(InputStream fileContent, String fileContentSHA1, Date modified, long fileSize,
                               ProgressListener listener) {
-        return this.uploadNewVersion(fileContent, fileContentSHA1, modified, fileSize, listener, null);
+        return this.uploadNewVersion(fileContent, fileContentSHA1, modified, null, fileSize, listener);
     }
 
     /**
@@ -900,13 +900,13 @@ public class BoxFile extends BoxItem {
      * @param fileContent     a stream containing the new file contents.
      * @param fileContentSHA1 the SHA1 hash of the file contents. will be sent along in the Content-MD5 header
      * @param modified        the date that the new version was modified.
+     * @param name            the new name for the file
      * @param fileSize        the size of the file used for determining the progress of the upload.
      * @param listener        a listener for monitoring the upload's progress.
-     * @param name            the new name for the file
      * @return the uploaded file version.
      */
-    public BoxFile.Info uploadNewVersion(InputStream fileContent, String fileContentSHA1, Date modified, long fileSize,
-                              ProgressListener listener, String name) {
+    public BoxFile.Info uploadNewVersion(InputStream fileContent, String fileContentSHA1, Date modified, String name,
+                                         long fileSize, ProgressListener listener) {
         URL uploadURL = CONTENT_URL_TEMPLATE.build(this.getAPI().getBaseUploadURL(), this.getID());
         BoxMultipartRequest request = new BoxMultipartRequest(getAPI(), uploadURL);
 

--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -921,7 +921,6 @@ public class BoxFile extends BoxItem {
         }
 
         JsonObject attributesJSON = new JsonObject();
-
         if (modified != null) {
             attributesJSON.add("content_modified_at", BoxDateFormat.format(modified));
         }

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -394,6 +394,24 @@ public class BoxFileTest {
 
     @Test
     @Category(IntegrationTest.class)
+    public void uploadNewVersionSucceeds() {
+        BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
+        BoxFolder rootFolder = BoxFolder.getRootFolder(api);
+        String fileName = "Multi-version File.txt";
+        String updatedFileName = "[uploadNewVersionSucceeds] Multi-version File.txt";
+        Date contentModifiedAt = new Date(10000);
+        byte[] versionBytes = "Version 1".getBytes(StandardCharsets.UTF_8);
+
+        InputStream uploadStream = new ByteArrayInputStream(versionBytes);
+        BoxFile uploadedFile = rootFolder.uploadFile(uploadStream, fileName).getResource();
+        BoxFile.Info newVersion = uploadedFile.uploadNewVersion(uploadStream, null, contentModifiedAt,0, null, updatedFileName);
+        uploadedFile.delete();
+        Assert.assertEquals(updatedFileName, newVersion.getName());
+        Assert.assertEquals(contentModifiedAt, newVersion.getContentModifiedAt());
+    }
+
+    @Test
+    @Category(IntegrationTest.class)
     public void deleteVersionSucceeds() {
         BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
         BoxFolder rootFolder = BoxFolder.getRootFolder(api);

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -405,7 +405,7 @@ public class BoxFileTest {
         InputStream uploadStream = new ByteArrayInputStream(versionBytes);
         BoxFile uploadedFile = rootFolder.uploadFile(uploadStream, fileName).getResource();
         BoxFile.Info newVersion = uploadedFile.uploadNewVersion(uploadStream, null, contentModifiedAt,
-                                                            0, null, updatedFileName);
+                                                                updatedFileName, 0, null);
         uploadedFile.delete();
         Assert.assertEquals(updatedFileName, newVersion.getName());
         Assert.assertEquals(contentModifiedAt, newVersion.getContentModifiedAt());

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -404,7 +404,8 @@ public class BoxFileTest {
 
         InputStream uploadStream = new ByteArrayInputStream(versionBytes);
         BoxFile uploadedFile = rootFolder.uploadFile(uploadStream, fileName).getResource();
-        BoxFile.Info newVersion = uploadedFile.uploadNewVersion(uploadStream, null, contentModifiedAt,0, null, updatedFileName);
+        BoxFile.Info newVersion = uploadedFile.uploadNewVersion(uploadStream, null, contentModifiedAt,
+                                                            0, null, updatedFileName);
         uploadedFile.delete();
         Assert.assertEquals(updatedFileName, newVersion.getName());
         Assert.assertEquals(contentModifiedAt, newVersion.getContentModifiedAt());


### PR DESCRIPTION
- Added the ability to set the filename when uploading a new version of a file.
- Fixed a bug with updating the `content_modified_at` field when upload a new version