### PR TITLE
Fix bug with setting the unshared at date for a shared link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next Release
+- Fix bug with setting the unshared at date for a shared link ([#819](https://github.com/box/box-java-sdk/pull/819))
+
 ## 2.48.0 [2020-06-23] 
 - Add ability to get groups by name with fields option ([#789](https://github.com/box/box-java-sdk/pull/789))
 - Add shared link downscoping ([#785](https://github.com/box/box-java-sdk/pull/785))

--- a/src/main/java/com/box/sdk/BoxSharedLink.java
+++ b/src/main/java/com/box/sdk/BoxSharedLink.java
@@ -103,7 +103,7 @@ public class BoxSharedLink extends BoxJSONObject {
      */
     public void setUnsharedDate(Date unsharedDate) {
         this.unsharedAt = unsharedDate;
-        this.addPendingChange("unshared_at", unsharedDate.toString());
+        this.addPendingChange("unshared_at", BoxDateFormat.format(unsharedDate.toString()));
     }
 
     /**

--- a/src/main/java/com/box/sdk/BoxSharedLink.java
+++ b/src/main/java/com/box/sdk/BoxSharedLink.java
@@ -103,7 +103,7 @@ public class BoxSharedLink extends BoxJSONObject {
      */
     public void setUnsharedDate(Date unsharedDate) {
         this.unsharedAt = unsharedDate;
-        this.addPendingChange("unshared_at", BoxDateFormat.format(unsharedDate.toString()));
+        this.addPendingChange("unshared_at", BoxDateFormat.format(unsharedDate));
     }
 
     /**


### PR DESCRIPTION
unshareAt field was not working, when you set it and try to create a sharelink or update one. The reason is simple, was using default java Date toString to convert to box date what is not correct. It needs to use BoxDateFormat instead. 