### PR TITLE
Add GitHub action that notifies Box developer changelog

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,28 @@
+# A GitHub action that notifies the developer
+# changelog repository of any new releases.
+
+name: Notify changelog
+
+on:
+  # Only trigger for a full release,
+  # ignoring pre-releases and drafts
+  release:
+    types:
+      - released
+
+jobs:
+  notify:
+    # This job can run on the latest Ubuntu
+    # and it should not take more than 3 minutes
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      # There's really only 1 step, and i
+      - name: Notify changelog of new release
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+          repository: box/box-developer-changelog
+          event-type: new-release-note
+          client-payload: '{"ref": "${{ github.ref }}", "repository": "${{github.repository}}", "labels": "sdks,java", "repo_display_name": "Box Java SDK"}'


### PR DESCRIPTION
Hey SDK team, it's time for some exciting new stuff! As you know, I've been working on a new unified developer changelog for on developer.box.com, and as part of this I've set up a workflow that will automatically import new GitHub Releases for this project into our [developer changelog repository](https://github.com/box/box-developer-changelog).

This pull request adds a new GitHub action workflow that will notify the changelog repository of any new GitHub releases when they happen. More details on how this automation works can be found in this section of the related repository: https://github.com/box/box-developer-changelog#automatic-contributions

## Things we need to do now

1. Merge this pull request
2. Enable 3rd party GitHub actions in the [GitHub actions tab](https://github.com/box/box-java-sdk/settings/actions) for this repository. This will allow us to use the `peter-evans/repository-dispatch@v1` action to send notifications across repositories.
3. Add a `DISPATCH_ACCESS_TOKEN` secret to the [GitHub secrets](https://github.com/box/box-java-sdk/settings/actions) for this repository. This allows us to act as @box-devrel when notifying across repositories. Please talk to me in Slack for this token.

## How to make a new release?

Just keep making new releases as you always have, but maybe check out the documents below for some guidelines as to how to best write your markdown and best structure release notes.

Every time you make a new release:

* This new workflow will trigger another workflow in the changelog GitHub repository
* That second workflow will import the details for that release and create a new markdown file
* A new Pull Request is then created in the changelog repo with that new file
* If all linters and spell checks pass, the markdown file is automatically merged into our developer documentation.
* If not, someone on the developer relations team will be notified of the new pull request and will make some manual changes to the entry.

An example of how this would work can be seen in [this test release](https://github.com/box/box-developer-changelog/pull/30) that was automatically merged.

## Useful things to read next

As per multiple requests, we've put together some guidelines on how to write a great Release Note. For this reason, we've put together a few templates, as well as a markdown style guide.

- A [`standard` markdown template](https://github.com/box/box-developer-changelog/blob/main/templates/standard.md) for release notes. This uses the format that we use within the changelog, but can be easily used for writing GitHub releases as well. Just make sure to drop the FrontMatter.
- A [`short` markdown template](https://github.com/box/box-developer-changelog/blob/main/templates/short.md) for when you rather have a short release note and point to a separate piece of documentation.
- A [markdown style guide](https://github.com/box/box-developer-changelog/blob/main/docs/markdown.md) that shows you how to write markdown that will pass our internal spell checkers and other linting.