### PR TITLE
Add support for more fields in `BoxCollaborator.Info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Changelog
 
 ## Next Release
--
+- Add support for more fields in `BoxCollaborator.Info` ([#843](https://github.com/box/box-java-sdk/pull/843))
 
 ## 2.50.1 [2020-08-20]
-- Fix bug that occurred when downscoping a token for a Box folder (#832)
+- Fix bug that occurred when downscoping a token for a Box folder ([#832](https://github.com/box/box-java-sdk/pull/832))
 
 ## 2.50.0 [2020-07-21]
 - API request creation errors are now retried with the same automatic retry logic as 429 and 5XX response errors ([#828](https://github.com/box/box-java-sdk/pull/828))

--- a/src/main/java/com/box/sdk/BoxCollaborator.java
+++ b/src/main/java/com/box/sdk/BoxCollaborator.java
@@ -20,6 +20,35 @@ public abstract class BoxCollaborator extends BoxResource {
     }
 
     /**
+     * Enumerates the possible types of groups.
+     */
+    public enum GroupType {
+        /**
+         * A users group.
+         */
+        ALL_USERS_GROUP ("all_users_group"),
+
+        /**
+         * A managed group.
+         */
+        MANAGED_GROUP ("managed_group");
+
+        private final String jsonValue;
+
+        private GroupType(String jsonValue) {
+            this.jsonValue = jsonValue;
+        }
+
+        static GroupType fromJSONValue(String jsonValue) {
+            return GroupType.valueOf(jsonValue.toUpperCase());
+        }
+
+        String toJSONValue() {
+            return this.jsonValue;
+        }
+    }
+
+    /**
      * Contains information about a BoxCollaborator.
      */
     public abstract class Info extends BoxResource.Info {
@@ -28,7 +57,7 @@ public abstract class BoxCollaborator extends BoxResource {
         private Date createdAt;
         private Date modifiedAt;
         private String login;
-        private String groupType;
+        private GroupType groupType;
 
         /**
          * Constructs an empty Info object.
@@ -106,7 +135,7 @@ public abstract class BoxCollaborator extends BoxResource {
          * Gets the group type for the collaborator if the collaborator is a group.
          * @return the group type of the collaboraor.
          */
-        public String getGroupType() {
+        public GroupType getGroupType() {
             return this.groupType;
         }
 
@@ -129,7 +158,7 @@ public abstract class BoxCollaborator extends BoxResource {
                 } else if (name.equals("login")) {
                     this.login = value.asString();
                 } else if (name.equals("group_type")) {
-                    this.groupType = value.asString();
+                    this.groupType = GroupType.fromJSONValue(value.asString());
                 }
             } catch (Exception e) {
                 throw new BoxDeserializationException(name, value.toString(), e);

--- a/src/main/java/com/box/sdk/BoxCollaborator.java
+++ b/src/main/java/com/box/sdk/BoxCollaborator.java
@@ -20,6 +20,35 @@ public abstract class BoxCollaborator extends BoxResource {
     }
 
     /**
+     * Enumerates the possible types of collaborations.
+     */
+    public enum CollaboratorType {
+        /**
+         * A user.
+         */
+        USER ("user"),
+
+        /**
+         * A group.
+         */
+        GROUP ("group");
+
+        private final String jsonValue;
+
+        private CollaboratorType(String jsonValue) {
+            this.jsonValue = jsonValue;
+        }
+
+        static CollaboratorType fromJSONValue(String jsonValue) {
+            return CollaboratorType.valueOf(jsonValue.toUpperCase());
+        }
+
+        String toJSONValue() {
+            return this.jsonValue;
+        }
+    }
+
+    /**
      * Enumerates the possible types of groups.
      */
     public enum GroupType {
@@ -52,7 +81,7 @@ public abstract class BoxCollaborator extends BoxResource {
      * Contains information about a BoxCollaborator.
      */
     public abstract class Info extends BoxResource.Info {
-        private String type;
+        private CollaboratorType type;
         private String name;
         private Date createdAt;
         private Date modifiedAt;
@@ -86,7 +115,7 @@ public abstract class BoxCollaborator extends BoxResource {
          * Gets the type of the collaborator.
          * @return the type of the collaborator.
          */
-        public String getType() {
+        public CollaboratorType getType() {
             return this.type;
         }
 
@@ -148,7 +177,7 @@ public abstract class BoxCollaborator extends BoxResource {
             try {
 
                 if (name.equals("type")) {
-                    this.type = value.asString();
+                    this.type = CollaboratorType.fromJSONValue(value.asString());
                 } else if (name.equals("name")) {
                     this.name = value.asString();
                 } else if (name.equals("created_at")) {

--- a/src/main/java/com/box/sdk/BoxCollaborator.java
+++ b/src/main/java/com/box/sdk/BoxCollaborator.java
@@ -23,10 +23,12 @@ public abstract class BoxCollaborator extends BoxResource {
      * Contains information about a BoxCollaborator.
      */
     public abstract class Info extends BoxResource.Info {
+        private String type;
         private String name;
         private Date createdAt;
         private Date modifiedAt;
         private String login;
+        private String groupType;
 
         /**
          * Constructs an empty Info object.
@@ -49,6 +51,14 @@ public abstract class BoxCollaborator extends BoxResource {
          */
         Info(JsonObject jsonObject) {
             super(jsonObject);
+        }
+
+        /**
+         * Gets the type of the collaborator.
+         * @return the type of the collaborator.
+         */
+        public String getType() {
+            return this.type;
         }
 
         /**
@@ -85,11 +95,19 @@ public abstract class BoxCollaborator extends BoxResource {
         }
 
         /**
-         * Gets the login for the collaborator.
+         * Gets the login for the collaborator if the collaborator is a user.
          * @return the login of the collaboraor.
          */
         public String getLogin() {
             return this.login;
+        }
+
+        /**
+         * Gets the group type for the collaborator if the collaborator is a group.
+         * @return the group type of the collaboraor.
+         */
+        public String getGroupType() {
+            return this.groupType;
         }
 
         @Override
@@ -100,7 +118,9 @@ public abstract class BoxCollaborator extends BoxResource {
 
             try {
 
-                if (name.equals("name")) {
+                if (name.equals("type")) {
+                    this.type = value.asString();
+                } else if (name.equals("name")) {
                     this.name = value.asString();
                 } else if (name.equals("created_at")) {
                     this.createdAt = BoxDateFormat.parse(value.asString());
@@ -108,6 +128,8 @@ public abstract class BoxCollaborator extends BoxResource {
                     this.modifiedAt = BoxDateFormat.parse(value.asString());
                 } else if (name.equals("login")) {
                     this.login = value.asString();
+                } else if (name.equals("group_type")) {
+                    this.groupType = value.asString();
                 }
             } catch (Exception e) {
                 throw new BoxDeserializationException(name, value.toString(), e);

--- a/src/test/Fixtures/BoxFolder/GetAllFolderCollaborations200.json
+++ b/src/test/Fixtures/BoxFolder/GetAllFolderCollaborations200.json
@@ -29,6 +29,35 @@
                 "etag": "1",
                 "name": "Test Folder"
             }
-        }
+        },
+        {
+             "type": "collaboration",
+             "id": "124783",
+             "created_by": {
+                 "type": "user",
+                 "id": "1111",
+                 "name": "Test User",
+                 "login": "test@user.com"
+             },
+             "created_at": "2016-09-19T11:16:59-07:00",
+             "modified_at": "2016-09-19T14:30:59-07:00",
+             "expires_at": null,
+             "status": "accepted",
+             "accessible_by": {
+                 "type": "group",
+                 "id": "2322",
+                 "name": "Owners Group",
+                 "group_type": "managed_group"
+             },
+             "role": "viewer",
+             "acknowledged_at": "2016-09-19T11:16:59-07:00",
+             "item": {
+                 "type": "folder",
+                 "id": "4444",
+                 "sequence_id": "1",
+                 "etag": "1",
+                 "name": "Test Folder 2"
+             }
+         }
     ]
 }

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -1366,13 +1366,12 @@ public class BoxFolderTest {
     @Category(UnitTest.class)
     public void testGetAllFolderCollaborationsSucceeds() throws IOException {
         String result = "";
-        final String collaborationType = "user";
         final String folderID = "3333";
         final String folderCollaborationURL = "/folders/" + folderID + "/collaborations";
         final String collaborationID = "12345";
         final String accessiblyByLogin = "Test User";
         final BoxCollaboration.Role collaborationRole = BoxCollaboration.Role.VIEWER;
-        final String collaborationType2 = "group";
+        final String collaborationType = "group";
         final String collaborationGroupType = "managed_group";
 
         result = TestConfig.getFixture("BoxFolder/GetAllFolderCollaborations200");
@@ -1384,16 +1383,17 @@ public class BoxFolderTest {
 
         BoxFolder folder = new BoxFolder(this.api, folderID);
         Collection<BoxCollaboration.Info> collaborations = folder.getCollaborations();
-        BoxCollaboration.Info collaborationInfo = collaborations.iterator().next();
-        BoxCollaboration.Info collaborationInfo2 = collaborations.iterator().next();
+        Iterator<BoxCollaboration.Info> iterator = collaborations.iterator();
+        BoxCollaboration.Info collaborationInfo = iterator.next();
+        BoxCollaboration.Info collaborationInfo2 = iterator.next();
 
-        Assert.assertEquals(collaborationType, collaborationInfo.getType());
         Assert.assertEquals(collaborationID, collaborationInfo.getID());
         Assert.assertEquals(folderID, collaborationInfo.getItem().getID());
         Assert.assertEquals(accessiblyByLogin, collaborationInfo.getAccessibleBy().getName());
         Assert.assertEquals(collaborationRole, collaborationInfo.getRole());
-        Assert.assertEquals(collaborationType2, collaborationInfo2.getAccessibleBy().getType());
-        Assert.assertEquals(collaborationGroupType, collaborationInfo2.getAccessibleBy().getGroupType());
+        Assert.assertEquals(collaborationType, collaborationInfo2.getAccessibleBy().getType());
+        Assert.assertEquals(BoxCollaborator.GroupType.MANAGED_GROUP,
+            collaborationInfo2.getAccessibleBy().getGroupType());
     }
 
     @Test

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -1366,11 +1366,14 @@ public class BoxFolderTest {
     @Category(UnitTest.class)
     public void testGetAllFolderCollaborationsSucceeds() throws IOException {
         String result = "";
+        final String collaborationType = "user";
         final String folderID = "3333";
         final String folderCollaborationURL = "/folders/" + folderID + "/collaborations";
         final String collaborationID = "12345";
         final String accessiblyByLogin = "Test User";
         final BoxCollaboration.Role collaborationRole = BoxCollaboration.Role.VIEWER;
+        final String collaborationType2 = "group";
+        final String collaborationGroupType = "managed_group";
 
         result = TestConfig.getFixture("BoxFolder/GetAllFolderCollaborations200");
 
@@ -1382,11 +1385,15 @@ public class BoxFolderTest {
         BoxFolder folder = new BoxFolder(this.api, folderID);
         Collection<BoxCollaboration.Info> collaborations = folder.getCollaborations();
         BoxCollaboration.Info collaborationInfo = collaborations.iterator().next();
+        BoxCollaboration.Info collaborationInfo2 = collaborations.iterator().next();
 
+        Assert.assertEquals(collaborationType, collaborationInfo.getType());
         Assert.assertEquals(collaborationID, collaborationInfo.getID());
         Assert.assertEquals(folderID, collaborationInfo.getItem().getID());
         Assert.assertEquals(accessiblyByLogin, collaborationInfo.getAccessibleBy().getName());
         Assert.assertEquals(collaborationRole, collaborationInfo.getRole());
+        Assert.assertEquals(collaborationType2, collaborationInfo2.getAccessibleBy().getType());
+        Assert.assertEquals(collaborationGroupType, collaborationInfo2.getAccessibleBy().getGroupType());
     }
 
     @Test

--- a/src/test/java/com/box/sdk/BoxFolderTest.java
+++ b/src/test/java/com/box/sdk/BoxFolderTest.java
@@ -1371,8 +1371,6 @@ public class BoxFolderTest {
         final String collaborationID = "12345";
         final String accessiblyByLogin = "Test User";
         final BoxCollaboration.Role collaborationRole = BoxCollaboration.Role.VIEWER;
-        final String collaborationType = "group";
-        final String collaborationGroupType = "managed_group";
 
         result = TestConfig.getFixture("BoxFolder/GetAllFolderCollaborations200");
 
@@ -1391,7 +1389,7 @@ public class BoxFolderTest {
         Assert.assertEquals(folderID, collaborationInfo.getItem().getID());
         Assert.assertEquals(accessiblyByLogin, collaborationInfo.getAccessibleBy().getName());
         Assert.assertEquals(collaborationRole, collaborationInfo.getRole());
-        Assert.assertEquals(collaborationType, collaborationInfo2.getAccessibleBy().getType());
+        Assert.assertEquals(BoxCollaborator.CollaboratorType.GROUP, collaborationInfo2.getAccessibleBy().getType());
         Assert.assertEquals(BoxCollaborator.GroupType.MANAGED_GROUP,
             collaborationInfo2.getAccessibleBy().getGroupType());
     }


### PR DESCRIPTION
Added support for the `type` field and the `group_type` field. This is to address issue #807.