### PR TITLE
Update `getAllGroupsByName()` to use documented parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 __New Features and Enhancements:__
 
-- Add support for more fields in `BoxCollaborator.Info` ([#843](https://github.com/box/box-java-sdk/pull/843))
 - Update `getAllGroupsByName()` to use documented parameter ([#851](https://github.com/box/box-java-sdk/pull/851))
+- Add support for `copyInstanceOnItemCopy` field for metadata templates ([#850](https://github.com/box/box-java-sdk/pull/850))
+- Add support for more fields in `BoxCollaborator.Info` ([#843](https://github.com/box/box-java-sdk/pull/843))
 
 ## 2.50.1 [2020-08-20]
 - Fix bug that occurred when downscoping a token for a Box folder ([#832](https://github.com/box/box-java-sdk/pull/832))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## Next Release
+
+__New Features and Enhancements:__
+
 - Add support for more fields in `BoxCollaborator.Info` ([#843](https://github.com/box/box-java-sdk/pull/843))
+- Update `getAllGroupsByName()` to use documented parameter ([#851](https://github.com/box/box-java-sdk/pull/851))
 
 ## 2.50.1 [2020-08-20]
 - Fix bug that occurred when downscoping a token for a Box folder ([#832](https://github.com/box/box-java-sdk/pull/832))

--- a/src/main/java/com/box/sdk/BoxGroup.java
+++ b/src/main/java/com/box/sdk/BoxGroup.java
@@ -165,7 +165,7 @@ public class BoxGroup extends BoxCollaborator {
         if (name == null || name.trim().isEmpty()) {
             throw new BoxAPIException("Searching groups by name requires a non NULL or non empty name");
         } else {
-            builder.appendParam("name", name);
+            builder.appendParam("filter_term", name);
             if (fields != null && fields.length > 0) {
                 builder.appendParam("fields", fields);
             }

--- a/src/test/java/com/box/sdk/BoxGroupTest.java
+++ b/src/test/java/com/box/sdk/BoxGroupTest.java
@@ -46,7 +46,7 @@ public class BoxGroupTest {
         result = TestConfig.getFixture("BoxGroup/GetGroupsByName200");
 
         WIRE_MOCK_CLASS_RULE.stubFor(WireMock.get(WireMock.urlPathEqualTo(getGroupsByNameURL))
-                .withQueryParam("name", WireMock.containing("Test"))
+                .withQueryParam("filter_term", WireMock.containing("Test"))
                 .withQueryParam("limit", WireMock.containing("1000"))
                 .withQueryParam("offset", WireMock.containing("0"))
                 .willReturn(WireMock.aResponse()
@@ -71,7 +71,7 @@ public class BoxGroupTest {
         result = TestConfig.getFixture("BoxGroup/GetGroupsByNameWithFieldsOption200");
 
         WIRE_MOCK_CLASS_RULE.stubFor(WireMock.get(WireMock.urlPathEqualTo(getGroupsByNameURL))
-                .withQueryParam("name", WireMock.containing("Test"))
+                .withQueryParam("filter_term", WireMock.containing("Test"))
                 .withQueryParam("fields", WireMock.containing("description"))
                 .withQueryParam("limit", WireMock.containing("1000"))
                 .withQueryParam("offset", WireMock.containing("0"))


### PR DESCRIPTION
`getAllGroupsByName()` was using the undocumented `name` parameter instead of `filter_term` to filter by name. Now it uses `filter_term`.