### PR TITLE
Fix for cross-enterprise collaborator calls to updateMetadata

### DIFF
--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -1352,6 +1352,8 @@ public class BoxFile extends BoxItem {
         String scope;
         if (metadata.getScope().equals(Metadata.GLOBAL_METADATA_SCOPE)) {
             scope = Metadata.GLOBAL_METADATA_SCOPE;
+        } else if (metadata.getScope().startsWith(Metadata.ENTERPRISE_METADATA_SCOPE)) {
+            scope = metadata.getScope();
         } else {
             scope = Metadata.ENTERPRISE_METADATA_SCOPE;
         }


### PR DESCRIPTION
When external users updates a metadata instance, the scope needs to be "enterprise_xxxx".
"xxxx" is the EID of the metadata template. The current code overwrites "enterprise_xxxx" to "enterprise".
This fix allows to keep the correct scope.
