### PR TITLE
Fix bug with search including shared links

### DIFF
--- a/src/main/java/com/box/sdk/BoxSearch.java
+++ b/src/main/java/com/box/sdk/BoxSearch.java
@@ -58,6 +58,38 @@ public class BoxSearch {
     }
 
     /**
+     * Searches all descendant folders using a given query and query parameters.
+     * @param  offset is the starting position.
+     * @param  limit the maximum number of items to return. The default is 30 and the maximum is 200.
+     * @param  bsp containing query and advanced search capabilities.
+     * @return a PartialCollection containing the search results.
+     */
+    public PartialCollection<BoxSearchSharedLink> searchRangeIncludeSharedLinks(long offset, long limit,
+                                                                                final BoxSearchParameters bsp) {
+        QueryStringBuilder builder = bsp.getQueryParameters()
+                .appendParam("include_recent_shared_links", "true")
+                .appendParam("limit", limit)
+                .appendParam("offset", offset);
+        URL url = SEARCH_URL_TEMPLATE.buildWithQuery(this.getAPI().getBaseURL(), builder.toString());
+        BoxAPIRequest request = new BoxAPIRequest(this.getAPI(), url, "GET");
+        BoxJSONResponse response = (BoxJSONResponse) request.send();
+        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        String totalCountString = responseJSON.get("total_count").toString();
+        long fullSize = Double.valueOf(totalCountString).longValue();
+        PartialCollection<BoxSearchSharedLink> results = new PartialCollection<BoxSearchSharedLink>(offset,
+            limit, fullSize);
+        JsonArray jsonArray = responseJSON.get("entries").asArray();
+        for (JsonValue value : jsonArray) {
+            JsonObject jsonObject = value.asObject();
+            BoxSearchSharedLink parsedItem = new BoxSearchSharedLink(jsonObject, this.getAPI());
+            if (parsedItem != null) {
+                results.add(parsedItem);
+            }
+        }
+        return results;
+    }
+
+    /**
      * Gets the API connection used by this resource.
      * @return the API connection used by this resource.
      */

--- a/src/main/java/com/box/sdk/BoxSearchParameters.java
+++ b/src/main/java/com/box/sdk/BoxSearchParameters.java
@@ -61,7 +61,6 @@ public class BoxSearchParameters {
         this.metadataFilter = null;
         this.sort = null;
         this.direction = null;
-        this.includeRecentSharedLinks = null;
         return true;
     }
     /**
@@ -280,23 +279,6 @@ public class BoxSearchParameters {
     }
 
     /**
-     * Set the include recent shared links field to determine whether to include items accessible only via shared link
-     * in the Box Search results.
-     * @param includeRecentSharedLinks Whether to include items accessible only via shared link in the response.
-     */
-    public void setIncludeRecentSharedLinks(Boolean includeRecentSharedLinks) {
-        this.includeRecentSharedLinks = includeRecentSharedLinks;
-    }
-
-    /**
-     * Retrieves the include recent shared links field.
-     * @return The include recent shared links field.
-     */
-    public Boolean getIncludeRecentSharedLinks() {
-        return this.includeRecentSharedLinks;
-    }
-
-    /**
      * Checks String to see if the parameter is null.
      * @param    paramValue Object that will be checked if null.
      * @return this.true if the parameter that is being checked is not null
@@ -419,10 +401,6 @@ public class BoxSearchParameters {
             builder.appendParam("direction", this.direction);
         }
 
-        //Include Recent Shared Links
-        if (!this.isNullOrEmpty(this.includeRecentSharedLinks)) {
-            builder.appendParam("include_recent_shared_links", this.includeRecentSharedLinks.toString());
-        }
         return builder;
     }
 }

--- a/src/main/java/com/box/sdk/BoxSearchSharedLink.java
+++ b/src/main/java/com/box/sdk/BoxSearchSharedLink.java
@@ -1,0 +1,96 @@
+package com.box.sdk;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import com.eclipsesource.json.JsonObject;
+import com.eclipsesource.json.JsonValue;
+
+/**
+ * Represents a search item when searching shared links.
+ *
+ * <p>Unless otherwise noted, the methods in this class can throw an unchecked {@link BoxAPIException} (unchecked
+ * meaning that the compiler won't force you to handle it) if an error occurs. If you wish to implement custom error
+ * handling for errors related to the Box REST API, you should capture this exception explicitly.*
+ */
+public class BoxSearchSharedLink extends BoxJSONObject {
+    private String type;
+    private BoxItem.Info item;
+    private URL accessibleViaSharedLink;
+    private BoxAPIConnection api;
+
+    /**
+     * Construct a BoxRecentItem.
+     *
+     * @param jsonObject the parsed JSON object.
+     * @param api        the API connection to be used to fetch interacted item
+     */
+    public BoxSearchSharedLink(JsonObject jsonObject, BoxAPIConnection api) {
+        super(jsonObject);
+        this.api = api;
+    }
+
+    @Override
+    protected void parseJSONMember(JsonObject.Member member) {
+        super.parseJSONMember(member);
+
+        String memberName = member.getName();
+        JsonValue value = member.getValue();
+        try {
+            if (memberName.equals("type")) {
+                this.type = value.asString();
+            } else if (memberName.equals("item")) {
+                JsonObject jsonObject = value.asObject();
+                String type = jsonObject.get("type").asString();
+                String id = jsonObject.get("id").asString();
+
+                if (type.equals("folder")) {
+                    BoxFolder folder = new BoxFolder(this.api, id);
+                    this.item = folder.new Info(jsonObject);
+                } else if (type.equals("file")) {
+                    BoxFile file = new BoxFile(this.api, id);
+                    this.item = file.new Info(jsonObject);
+                } else if (type.equals("web_link")) {
+                    BoxWebLink link = new BoxWebLink(this.api, id);
+                    this.item = link.new Info(jsonObject);
+                } else {
+                    assert false : "Unsupported item type: " + type;
+                    throw new BoxAPIException("Unsupported item type: " + type);
+                }
+            } else if (memberName.equals("accessible_via_shared_link")) {
+                this.accessibleViaSharedLink = new URL(value.asString());
+            }
+        } catch (MalformedURLException e) {
+            assert false : "A ParseException indicates a bug in the SDK.";
+        }
+    }
+
+    /**
+     * Get item type.
+     *
+     * @return type of item
+     */
+    public String getType() {
+        return this.type;
+    }
+
+    /**
+     * Get the item which was interacted with.
+     *
+     * @return box item
+     */
+    public BoxItem.Info getItem() {
+        return this.item;
+    }
+
+    /**
+     * Get the optional shared link through which the user has access to this item.
+     *
+     * @return shared link
+     */
+    public URL getAccessibleViaSharedLink() {
+        return this.accessibleViaSharedLink;
+    }
+
+}
+

--- a/src/test/Fixtures/BoxSearch/GetSearchItemsIncludingSharedLinks200.json
+++ b/src/test/Fixtures/BoxSearch/GetSearchItemsIncludingSharedLinks200.json
@@ -1,6 +1,7 @@
 {
   "entries": [
     {
+      "type": "search_result",
       "accessible_via_shared_link": "https://www.box.com/s/vspke7y05sb214wjokpk",
       "item": {
         "id": "12345",

--- a/src/test/Fixtures/BoxSearch/GetSearchItemsIncludingSharedLinks200.json
+++ b/src/test/Fixtures/BoxSearch/GetSearchItemsIncludingSharedLinks200.json
@@ -1,0 +1,86 @@
+{
+  "entries": [
+    {
+      "accessible_via_shared_link": "https://www.box.com/s/vspke7y05sb214wjokpk",
+      "item": {
+        "id": "12345",
+        "etag": "1",
+        "type": "file",
+        "sequence_id": "3",
+        "name": "Contract.pdf",
+        "sha1": "85136C79CBF9FE36BB9D05D0639C70C265C18D37",
+        "file_version": {
+          "id": "12345",
+          "type": "file_version",
+          "sha1": "134b65991ed521fcfe4724b7d814ab8ded5185dc"
+        },
+        "description": "Contract for Q1 renewal",
+        "size": 629644,
+        "path_collection": {
+          "total_count": 1,
+          "entries": [
+            {
+              "id": "12345",
+              "etag": "1",
+              "type": "folder",
+              "sequence_id": "3",
+              "name": "Contracts"
+            }
+          ]
+        },
+        "created_at": "2012-12-12T10:53:43-08:00",
+        "modified_at": "2012-12-12T10:53:43-08:00",
+        "trashed_at": "2012-12-12T10:53:43-08:00",
+        "purged_at": "2012-12-12T10:53:43-08:00",
+        "content_created_at": "2012-12-12T10:53:43-08:00",
+        "content_modified_at": "2012-12-12T10:53:43-08:00",
+        "created_by": {
+          "id": "11446498",
+          "type": "user",
+          "name": "Aaron Levie",
+          "login": "ceo@example.com"
+        },
+        "modified_by": {
+          "id": "11446498",
+          "type": "user",
+          "name": "Aaron Levie",
+          "login": "ceo@example.com"
+        },
+        "owned_by": {
+          "id": "11446498",
+          "type": "user",
+          "name": "Aaron Levie",
+          "login": "ceo@example.com"
+        },
+        "shared_link": {
+          "url": "https://www.box.com/s/vspke7y05sb214wjokpk",
+          "download_url": "https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg",
+          "vanity_url": "https://acme.app.box.com/v/my_url/",
+          "vanity_name": "my_url",
+          "access": "open",
+          "effective_access": "company",
+          "effective_permission": "can_download",
+          "unshared_at": "2018-04-13T13:53:23-07:00",
+          "is_password_enabled": true,
+          "permissions": {
+            "can_download": true,
+            "can_preview": true
+          },
+          "download_count": 3,
+          "preview_count": 3
+        },
+        "parent": {
+          "id": "12345",
+          "etag": "1",
+          "type": "folder",
+          "sequence_id": "3",
+          "name": "Contracts"
+        },
+        "item_status": "active"
+      }
+    }
+  ],
+  "limit": 10,
+  "offset": 10,
+  "total_count": 11
+}

--- a/src/test/java/com/box/sdk/BoxSearchTest.java
+++ b/src/test/java/com/box/sdk/BoxSearchTest.java
@@ -11,6 +11,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
+import java.io.IOException;
+import java.util.Iterator;
+
 public class BoxSearchTest {
     @Rule
     public final WireMockRule wireMockRule = new WireMockRule(53620);
@@ -77,5 +80,42 @@ public class BoxSearchTest {
         PartialCollection<BoxItem.Info> searchResults = boxSearch.searchRange(10, 10, searchParams);
 
         assertThat(searchResults.size(), is(1));
+    }
+
+    @Test
+    @Category(UnitTest.class)
+    public void searchIncludeSharedLinksRequestsCorrectFields() throws IOException {
+        String result = "";
+        String query = "A query";
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setBaseURL("http://localhost:53620/");
+
+        result = TestConfig.getFixture("BoxSearch/GetSearchItemsIncludingSharedLinks200");
+
+        stubFor(get(urlPathEqualTo("/search"))
+                .withQueryParam("query", WireMock.equalTo(query))
+                .withQueryParam("include_recent_shared_links", WireMock.equalTo("true"))
+                .withQueryParam("limit", WireMock.equalTo("10"))
+                .withQueryParam("offset", WireMock.equalTo("10"))
+                .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(result)));
+
+        BoxSearch boxSearch = new BoxSearch(api);
+        BoxSearchParameters searchParams = new BoxSearchParameters();
+
+        searchParams.setQuery(query);
+
+        PartialCollection<BoxSearchSharedLink> searchResults = boxSearch.searchRangeIncludeSharedLinks(10,
+            10, searchParams);
+        Iterator<BoxSearchSharedLink> searchResultsIterator = searchResults.iterator();
+        BoxSearchSharedLink searchItem = searchResultsIterator.next();
+
+        assertThat(searchResults.size(), is(1));
+        assertThat(searchItem.getItem().getID(), is("12345"));
+        assertThat(searchItem.getItem().getSharedLink().getURL(),
+            is("https://www.box.com/s/vspke7y05sb214wjokpk"));
+        assertThat(searchItem.getAccessibleViaSharedLink().toString(),
+            is("https://www.box.com/s/vspke7y05sb214wjokpk"));
     }
 }

--- a/src/test/java/com/box/sdk/BoxSearchTest.java
+++ b/src/test/java/com/box/sdk/BoxSearchTest.java
@@ -112,6 +112,7 @@ public class BoxSearchTest {
         BoxSearchSharedLink searchItem = searchResultsIterator.next();
 
         assertThat(searchResults.size(), is(1));
+        assertThat(searchItem.getType(), is("search_result"));
         assertThat(searchItem.getItem().getID(), is("12345"));
         assertThat(searchItem.getItem().getSharedLink().getURL(),
             is("https://www.box.com/s/vspke7y05sb214wjokpk"));


### PR DESCRIPTION
When hitting the search endpoint and setting `include_recent_shared_links` to true, a different response is returned than when it's false. Now a new model and method has been added to account for this difference.