### PR TITLE
remove toString to avoid null pointer exception while removing the ex…

### DIFF
--- a/src/main/java/com/box/sdk/BoxSharedLink.java
+++ b/src/main/java/com/box/sdk/BoxSharedLink.java
@@ -145,7 +145,7 @@ public class BoxSharedLink extends BoxJSONObject {
      */
     public void setPassword(String password) {
         this.password = password;
-        this.addPendingChange("password", password.toString());
+        this.addPendingChange("password", password);
     }
 
     /**


### PR DESCRIPTION
remove toString to avoid null pointer exception while removing the password of BoxSharedLink