### PR TITLE
Add task assignment setters

### DIFF
--- a/doc/retention_policies.md
+++ b/doc/retention_policies.md
@@ -89,7 +89,7 @@ Updating a retention policy's information is done by calling
 ```java
 BoxRetentionPolicy policy = new BoxRetentionPolicy(api, id);
 BoxRetentionPolicy.Info policyInfo = policy.new Info();
-policyInfo.addPendingChange("policy_name", "new policy name");
+policyInfo.setPolicyName("new policy name");
 policy.updateInfo(policyInfo);
 ```
 

--- a/doc/tasks.md
+++ b/doc/tasks.md
@@ -165,7 +165,7 @@ Updating the resolution state:
 String assignmentID = "12345";
 BoxTaskAssignment taskAssignment = new BoxTaskAssignment(api, assignmentID);
 BoxTaskAssignment.Info info = taskAssignment.getInfo();
-info.addPendingChange("resolution_state", "approved");
+info.setResolutionState(BoxTaskAssignment.ResolutionState.APPROVED);
 taskAssignment.updateInfo(info);
 ```
 
@@ -175,7 +175,7 @@ Updating the message:
 String assignmentID = "12345";
 BoxTaskAssignment taskAssignment = new BoxTaskAssignment(api, assignmentID);
 BoxTaskAssignment.Info info = taskAssignment.getInfo();
-info.addPendingChange("message", "Please review the meeting notes");
+info.setMessage("Please review the meeting notes");
 taskAssignment.updateInfo(info);
 ```
 

--- a/src/main/java/com/box/sdk/BoxTaskAssignment.java
+++ b/src/main/java/com/box/sdk/BoxTaskAssignment.java
@@ -157,6 +157,15 @@ public class BoxTaskAssignment extends BoxResource {
         }
 
         /**
+         * Sets the message for the assignment.
+         * @param message the message to be set on the assignment.
+         */
+        public void setMessage(String message) {
+            this.message = message;
+            this.addPendingChange("message", message);
+        }
+
+        /**
          * Gets the date the assignment is to be completed at.
          * @return the date the assignment is to be completed at.
          */
@@ -186,6 +195,15 @@ public class BoxTaskAssignment extends BoxResource {
          */
         public ResolutionState getResolutionState() {
             return this.resolutionState;
+        }
+
+        /**
+         * Sets the resolution state for the assignment.
+         * @param resolutionState the resolution state to be set on the assignment.
+         */
+        public void setResolutionState(ResolutionState resolutionState) {
+            this.resolutionState = resolutionState;
+            this.addPendingChange("resolution_state", resolutionState.toJSONString());
         }
 
         /**

--- a/src/test/java/com/box/sdk/BoxRetentionPolicyTest.java
+++ b/src/test/java/com/box/sdk/BoxRetentionPolicyTest.java
@@ -140,8 +140,8 @@ public class BoxRetentionPolicyTest {
 
         BoxRetentionPolicy policy = new BoxRetentionPolicy(this.api, policyID);
         BoxRetentionPolicy.Info policyInfo = policy.new Info();
-        policyInfo.addPendingChange("policy_name", updatedPolicyName);
-        policyInfo.addPendingChange("status", updatedPolicyStatus);
+        policyInfo.setPolicyName(updatedPolicyName);
+        policyInfo.setStatus(updatedPolicyStatus);
         policy.updateInfo(policyInfo);
     }
 }

--- a/src/test/java/com/box/sdk/BoxTaskAssignmentTest.java
+++ b/src/test/java/com/box/sdk/BoxTaskAssignmentTest.java
@@ -185,7 +185,7 @@ public class BoxTaskAssignmentTest {
         final String assignedToID = "33333";
         final String assignedToLogin = "testuser@example.com";
         final String updatedMessage = "Looks good to me!";
-        final String updatedState = "completed";
+        final BoxTaskAssignment.ResolutionState updatedState = BoxTaskAssignment.ResolutionState.COMPLETED;
         final String assignmentURL = "/task_assignments/" + assignmentID;
 
         JsonObject updateObject = new JsonObject()
@@ -208,7 +208,8 @@ public class BoxTaskAssignmentTest {
 
         BoxTaskAssignment taskAssignment = new BoxTaskAssignment(this.api, assignmentID);
         BoxTaskAssignment.Info info = taskAssignment.getInfo();
-        info.addPendingChange("resolution_state", updatedState);
+        info.setResolutionState(updatedState);
+        info.setMessage(updatedMessage);
         taskAssignment.updateInfo(info);
 
         Assert.assertEquals(assignmentID, info.getID());


### PR DESCRIPTION
- Adds support for setting `message` & `resolution_state` for task assignments
- Documents how to update a retention policy's name