### PR TITLE
Fix FileRequest url format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ __Breaking Changes:__
 __New Features and Enhancements:__
 
 __Bug Fixes:__
-- Fix return `url` data type of `BoxFileRequest.Info` object ([#906](https://github.com/box/box-java-sdk/pull/906))
+- Fix `url` for `BoxFileRequest.Info` object ([#906](https://github.com/box/box-java-sdk/pull/906))
 
 
 ## 2.55.0 [2021-07-26]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ __Breaking Changes:__
 __New Features and Enhancements:__
 
 __Bug Fixes:__
+- Fix return `url` data type of `BoxFileRequest.Info` object ([#906](https://github.com/box/box-java-sdk/pull/906))
 
 
 ## 2.55.0 [2021-07-26]

--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -42,6 +42,7 @@ public class BoxAPIConnection {
     private static final String REVOKE_URL_STRING = "https://api.box.com/oauth2/revoke";
     private static final String DEFAULT_BASE_URL = "https://api.box.com/2.0/";
     private static final String DEFAULT_BASE_UPLOAD_URL = "https://upload.box.com/api/2.0/";
+    private static final String DEFAULT_BASE_APP_URL = "https://app.box.com";
 
     private static final String AS_USER_HEADER = "As-User";
     private static final String BOX_NOTIFICATIONS_HEADER = "Box-Notifications";
@@ -75,6 +76,7 @@ public class BoxAPIConnection {
     private String revokeURL;
     private String baseURL;
     private String baseUploadURL;
+    private String baseAppURL;
     private boolean autoRefresh;
     private int maxRetryAttempts;
     private int connectTimeout;
@@ -129,6 +131,7 @@ public class BoxAPIConnection {
         this.revokeURL = REVOKE_URL_STRING;
         this.baseURL = DEFAULT_BASE_URL;
         this.baseUploadURL = DEFAULT_BASE_UPLOAD_URL;
+        this.baseAppURL = DEFAULT_BASE_APP_URL;
         this.autoRefresh = true;
         this.maxRetryAttempts = BoxGlobalSettings.getMaxRetryAttempts();
         this.connectTimeout = BoxGlobalSettings.getConnectTimeout();
@@ -361,6 +364,22 @@ public class BoxAPIConnection {
      */
     public void setUserAgent(String userAgent) {
         this.userAgent = userAgent;
+    }
+
+    /**
+     * Gets the base App url. Used for e.g. file requests.
+     * @return the base App Url.
+     */
+    public String getBaseAppUrl() {
+        return this.baseAppURL;
+    }
+
+    /**
+     * Sets the base App url. Used for e.g. file requests.
+     * @param baseAppURL a base App Url.
+     */
+    public void setBaseAppUrl(String baseAppURL) {
+        this.baseAppURL = baseAppURL;
     }
 
     /**

--- a/src/main/java/com/box/sdk/BoxFileRequest.java
+++ b/src/main/java/com/box/sdk/BoxFileRequest.java
@@ -331,7 +331,7 @@ public class BoxFileRequest extends BoxResource {
         /**
          * Gets the title of file request.
          *
-         * @return the title of file request.`
+         * @return the title of file request.
          */
         public String getTitle() {
             return this.title;

--- a/src/main/java/com/box/sdk/BoxFileRequest.java
+++ b/src/main/java/com/box/sdk/BoxFileRequest.java
@@ -1,6 +1,5 @@
 package com.box.sdk;
 
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Date;
 
@@ -144,7 +143,7 @@ public class BoxFileRequest extends BoxResource {
         private String title;
         private Date updatedAt;
         private BoxUser.Info updatedBy;
-        private URL url;
+        private String url;
 
         /**
          * Constructs an empty Info object.
@@ -359,10 +358,11 @@ public class BoxFileRequest extends BoxResource {
 
         /**
          * Gets the URL can be shared with users to let them upload files to the associated folder.
+         * The URL contains only the path (e.g. "/f/123456789").
          *
          * @return the date at which this task is due.
          */
-        public URL getUrl() {
+        public String getUrl() {
             return this.url;
         }
 
@@ -409,12 +409,7 @@ public class BoxFileRequest extends BoxResource {
                     BoxUser user = new BoxUser(getAPI(), userID);
                     this.createdBy = user.new Info(userJSON);
                 } else if (memberName.equals("url")) {
-                    try {
-                        String urlString = value.asString();
-                        this.url = new URL(urlString);
-                    } catch (MalformedURLException e) {
-                        throw new BoxAPIException("Couldn't parse url for file request", e);
-                    }
+                    this.url = value.asString();
                 }
             } catch (Exception e) {
                 throw new BoxDeserializationException(memberName, value.toString(), e);

--- a/src/test/Fixtures/BoxFileRequest/CopyFileRequest200.json
+++ b/src/test/Fixtures/BoxFileRequest/CopyFileRequest200.json
@@ -29,5 +29,5 @@
     "login": "ceo@example.com",
     "name": "Aaron Levie"
   },
-  "url": "https://cloud.app.box.com/f/19e57f40ace247278a8e3d336678c64a"
+  "url": "/f/19e57f40ace247278a8e3d336678c64a"
 }

--- a/src/test/Fixtures/BoxFileRequest/GetFileRequest200.json
+++ b/src/test/Fixtures/BoxFileRequest/GetFileRequest200.json
@@ -29,5 +29,5 @@
     "login": "ceo@example.com",
     "name": "Aaron Levie"
   },
-  "url": "https://cloud.app.box.com/f/19e57f40ace247278a8e3d336678c64a"
+  "url": "/f/19e57f40ace247278a8e3d336678c64a"
 }

--- a/src/test/Fixtures/BoxFileRequest/UpdateFileRequest200.json
+++ b/src/test/Fixtures/BoxFileRequest/UpdateFileRequest200.json
@@ -29,5 +29,5 @@
     "login": "ceo@example.com",
     "name": "Aaron Levie"
   },
-  "url": "https://cloud.app.box.com/f/19e57f40ace247278a8e3d336678c64a"
+  "url": "/f/19e57f40ace247278a8e3d336678c64a"
 }

--- a/src/test/java/com/box/sdk/BoxFileRequestTest.java
+++ b/src/test/java/com/box/sdk/BoxFileRequestTest.java
@@ -38,8 +38,8 @@ public class BoxFileRequestTest {
 
         Assert.assertEquals("Following documents are requested for your process", fileRequestInfo.getDescription());
         Assert.assertEquals("Please upload documents", fileRequestInfo.getTitle());
-        Assert.assertEquals(this.api.getBaseAppUrl() +
-                fileRequestInfo.getPath(), fileRequestInfo.getUrl().toString());
+        Assert.assertEquals(this.api.getBaseAppUrl()
+                + fileRequestInfo.getPath(), fileRequestInfo.getUrl().toString());
     }
 
     @Test

--- a/src/test/java/com/box/sdk/BoxFileRequestTest.java
+++ b/src/test/java/com/box/sdk/BoxFileRequestTest.java
@@ -38,6 +38,8 @@ public class BoxFileRequestTest {
 
         Assert.assertEquals("Following documents are requested for your process", fileRequestInfo.getDescription());
         Assert.assertEquals("Please upload documents", fileRequestInfo.getTitle());
+        Assert.assertEquals(this.api.getBaseAppUrl() +
+                fileRequestInfo.getPath(), fileRequestInfo.getUrl().toString());
     }
 
     @Test


### PR DESCRIPTION
From owners of FileRequest API
`This field is intended to not have host name. As there are multiple scenarios for customers (app vs. ent and subdomains), these can change at runtime. We decided to not store or return hostname prior to release.`