### PR TITLE
Fix #921 Unable to set Vanity URL on BoxSharedLink for BoxFile and BoxFolder. New safe method to create BoxShareLink on BoxWebLink.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,12 @@
 __Breaking Changes:__
 
 __New Features and Enhancements:__
-
+- Upgraded minimal-json to v0.9.5
+- Upgraded jose4j to v0.7.9
+- Upgraded bouncycastle bcprov-jdk15on and bcpkix-jdk15on to v1.69
+- 
 __Bug Fixes:__
- - Fix unable to set Vanity URL on `BoxSharedLink` ([#921](https://github.com/box/box-java-sdk/issues/921))
+- Fix unable to set Vanity URL on `BoxSharedLink` for BoxFile and BoxFolder ([#921](https://github.com/box/box-java-sdk/issues/921))
 
 ## 2.56.0 [2021-08-31]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ __Breaking Changes:__
 __New Features and Enhancements:__
 
 __Bug Fixes:__
+ - Fix unable to set Vanity URL on `BoxSharedLink` ([#914](https://github.com/box/box-java-sdk/issues/914))
 
 ## 2.56.0 [2021-08-31]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ __Breaking Changes:__
 __New Features and Enhancements:__
 
 __Bug Fixes:__
- - Fix unable to set Vanity URL on `BoxSharedLink` ([#914](https://github.com/box/box-java-sdk/issues/914))
+ - Fix unable to set Vanity URL on `BoxSharedLink` ([#921](https://github.com/box/box-java-sdk/issues/921))
 
 ## 2.56.0 [2021-08-31]
 

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ cloning the source into your project, or by downloading one of the precompiled J
 
 **IF YOU USE THE JAR, you'll also need to include several dependencies:**
 
-1. [minimal-json v0.9.1](https://github.com/ralfstx/minimal-json)
-   Maven: `com.eclipsesource.minimal-json:minimal-json:0.9.1`
-2. [jose4j v0.5.5](https://bitbucket.org/b_c/jose4j/wiki/Home)
-   Maven: `org.bitbucket.b_c:jose4j:0.5.5`
-3. [bouncycastle bcprov-jdk15on v1.60](http://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on)
+1. [minimal-json v0.9.5](https://github.com/ralfstx/minimal-json)
+   Maven: `com.eclipsesource.minimal-json:minimal-json:0.9.5`
+2. [jose4j v0.7.9](https://bitbucket.org/b_c/jose4j/wiki/Home)
+   Maven: `org.bitbucket.b_c:jose4j:0.7.8`
+3. [bouncycastle bcprov-jdk15on v1.69](http://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on)
    Maven: `org.bouncycastle:bcprov-jdk15on:1.60`
-4. [bouncycastle bcpkix-jdk15on v1.60](http://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15on)
+4. [bouncycastle bcpkix-jdk15on v1.69](http://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk15on)
    Maven: `org.bouncycastle:bcpkix-jdk15on:1.60`
 5. [Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files 7](http://www.oracle.com/technetwork/java/javase/downloads/jce-7-download-432124.html)
    If you don't install this, you'll get an exception about key length or exception about parsing PKCS private key for Box Developer Edition. This is not a Box thing, this is a U.S. Government requirement concerning strong encryption.

--- a/src/intTest/java/com/box/sdk/BoxFileIT.java
+++ b/src/intTest/java/com/box/sdk/BoxFileIT.java
@@ -1,9 +1,11 @@
 package com.box.sdk;
 
+import static com.box.sdk.BoxSharedLink.Access.OPEN;
 import static com.box.sdk.UniqueTestFolder.getUniqueFolder;
 import static com.box.sdk.UniqueTestFolder.removeUniqueFolder;
 import static com.box.sdk.UniqueTestFolder.setupUniqeFolder;
 import static com.box.sdk.UniqueTestFolder.uploadFileToUniqueFolder;
+import static com.box.sdk.UniqueTestFolder.uploadFileToUniqueFolderWithSomeContent;
 import static com.box.sdk.UniqueTestFolder.uploadSampleFileToUniqueFolder;
 import static com.box.sdk.UniqueTestFolder.uploadTwoFileVersionsToUniqueFolder;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -517,7 +519,7 @@ public class BoxFileIT {
             BoxSharedLink.Permissions permissions = new BoxSharedLink.Permissions();
             permissions.setCanDownload(true);
             permissions.setCanPreview(true);
-            BoxSharedLink sharedLink = uploadedFile.createSharedLink(BoxSharedLink.Access.OPEN, null, permissions);
+            BoxSharedLink sharedLink = uploadedFile.createSharedLink(OPEN, null, permissions);
 
             assertThat(sharedLink.getURL(), not(isEmptyOrNullString()));
 
@@ -886,6 +888,29 @@ public class BoxFileIT {
             assertNotNull(fileVersion);
 
             assertEquals(1491613088000L, fileVersion.getContentModifiedAt().getTime());
+        } finally {
+            this.deleteFile(uploadedFile);
+        }
+    }
+
+    @Test
+    public void setsVanityNameOnASharedLink() {
+        BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
+        BoxFile uploadedFile = null;
+        try {
+            uploadedFile = uploadFileToUniqueFolderWithSomeContent(api, "file_to_share.txt");
+
+            BoxSharedLink.Permissions permissions = new BoxSharedLink.Permissions();
+            permissions.setCanDownload(true);
+            permissions.setCanPreview(true);
+            BoxSharedLink link = new BoxSharedLink();
+            link.setAccess(OPEN);
+            link.setPermissions(permissions);
+            link.setVanityName("myCustomName");
+            BoxSharedLink linkWithVanityName = uploadedFile.createSharedLink(link);
+
+            assertThat(linkWithVanityName.getVanityName(), is("myCustomName"));
+            assertThat(uploadedFile.getInfo().getSharedLink().getVanityName(), is("myCustomName"));
         } finally {
             this.deleteFile(uploadedFile);
         }

--- a/src/intTest/java/com/box/sdk/BoxFolderIT.java
+++ b/src/intTest/java/com/box/sdk/BoxFolderIT.java
@@ -1,6 +1,7 @@
 package com.box.sdk;
 
 import static com.box.sdk.BoxCollaborationAllowlist.AllowlistDirection.INBOUND;
+import static com.box.sdk.BoxSharedLink.Access.OPEN;
 import static com.box.sdk.UniqueTestFolder.getUniqueFolder;
 import static com.box.sdk.UniqueTestFolder.removeUniqueFolder;
 import static com.box.sdk.UniqueTestFolder.setupUniqeFolder;
@@ -36,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
@@ -671,6 +673,30 @@ public class BoxFolderIT {
             assertEquals(1491613088000L, info.getContentModifiedAt().getTime());
         } finally {
             this.deleteFile(fileUploaded);
+        }
+    }
+
+    @Test
+    public void setsVanityNameOnASharedLink() {
+        BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
+        BoxFolder rootFolder = getUniqueFolder(api);
+        BoxFolder sharedFolder = null;
+        try {
+            sharedFolder = rootFolder.createFolder(UUID.randomUUID().toString()).getResource();
+
+            BoxSharedLink.Permissions permissions = new BoxSharedLink.Permissions();
+            permissions.setCanDownload(true);
+            permissions.setCanPreview(true);
+            BoxSharedLink link = new BoxSharedLink();
+            link.setAccess(OPEN);
+            link.setPermissions(permissions);
+            link.setVanityName("myCustomName");
+            BoxSharedLink linkWithVanityName = sharedFolder.createSharedLink(link);
+
+            assertThat(linkWithVanityName.getVanityName(), is("myCustomName"));
+            assertThat(sharedFolder.getInfo().getSharedLink().getVanityName(), is("myCustomName"));
+        } finally {
+            this.deleteFolder(sharedFolder);
         }
     }
 

--- a/src/intTest/java/com/box/sdk/BoxWebLinkIT.java
+++ b/src/intTest/java/com/box/sdk/BoxWebLinkIT.java
@@ -1,11 +1,9 @@
 package com.box.sdk;
 
-import static com.box.sdk.BoxSharedLink.Access.OPEN;
 import static com.box.sdk.UniqueTestFolder.getUniqueFolder;
 import static com.box.sdk.UniqueTestFolder.removeUniqueFolder;
 import static com.box.sdk.UniqueTestFolder.setupUniqeFolder;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
@@ -16,7 +14,6 @@ import java.net.URL;
 import org.hamcrest.Matchers;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -164,36 +161,5 @@ public class BoxWebLinkIT {
         assertThat(newInfo.getName(), is(equalTo(newFileName)));
 
         uploadedWebLink.delete();
-    }
-
-    @Test
-    @Ignore("Cannot create shared link on a WebLink this way. API returns 400 error.")
-    public void setsVanityUrlOnASharedLink() throws MalformedURLException {
-        BoxAPIConnection api = new BoxAPIConnection(TestConfig.getAccessToken());
-        BoxFolder rootFolder = getUniqueFolder(api);
-        String webLinkName = "createSharedLink";
-        URL url = new URL("https://api.box.com");
-        String description = "[createSharedLink] Test WebLink";
-        BoxWebLink webLink = null;
-
-        try {
-            webLink = rootFolder.createWebLink(webLinkName, url, description).getResource();
-            BoxSharedLink.Permissions permissions = new BoxSharedLink.Permissions();
-            permissions.setCanDownload(true);
-            permissions.setCanPreview(true);
-            BoxSharedLink sharedLink = new BoxSharedLink();
-            sharedLink.setAccess(OPEN);
-            sharedLink.setPermissions(permissions);
-            sharedLink.setVanityName("myCustomName");
-            BoxSharedLink linkWithVanityName = webLink.createSharedLink(sharedLink);
-
-            assertThat(linkWithVanityName.getVanityName(), is("myCustomName"));
-            assertThat(webLink.getInfo().getSharedLink().getVanityName(), is("myCustomName"));
-            assertThat(webLink.getInfo().getSharedLink().getVanityURL(), endsWith("myCustomName"));
-        } finally {
-            if (webLink != null) {
-                webLink.delete();
-            }
-        }
     }
 }

--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -157,12 +157,7 @@ public class BoxFile extends BoxItem {
         return createSharedLink(new BoxSharedLink(access, unshareDate, permissions, password));
     }
 
-    /**
-     * Creates a shared link.
-     *
-     * @param sharedLink Shared link to create
-     * @return Created shared link.
-     */
+    @Override
     public BoxSharedLink createSharedLink(BoxSharedLink sharedLink) {
         Info info = new Info();
         info.setSharedLink(sharedLink);

--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -157,7 +157,12 @@ public class BoxFile extends BoxItem {
         return createSharedLink(new BoxSharedLink(access, unshareDate, permissions, password));
     }
 
-    @Override
+    /**
+     * Creates a shared link.
+     *
+     * @param sharedLink Shared link to create
+     * @return Created shared link.
+     */
     public BoxSharedLink createSharedLink(BoxSharedLink sharedLink) {
         Info info = new Info();
         info.setSharedLink(sharedLink);

--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -235,7 +235,12 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         return this.createSharedLink(new BoxSharedLink(access, unshareDate, permissions, password));
     }
 
-    @Override
+    /**
+     * Creates a shared link.
+     *
+     * @param sharedLink Shared link to create
+     * @return Created shared link.
+     */
     public BoxSharedLink createSharedLink(BoxSharedLink sharedLink) {
         BoxFolder.Info info = new BoxFolder.Info();
         info.setSharedLink(sharedLink);

--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -1,6 +1,7 @@
 package com.box.sdk;
 
 import com.box.sdk.internal.utils.Parsers;
+import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
@@ -216,12 +217,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
     public BoxSharedLink createSharedLink(BoxSharedLink.Access access, Date unshareDate,
                                           BoxSharedLink.Permissions permissions) {
 
-        BoxSharedLink sharedLink = new BoxSharedLink(access, unshareDate, permissions);
-        Info info = new Info();
-        info.setSharedLink(sharedLink);
-
-        this.updateInfo(info);
-        return info.getSharedLink();
+        return this.createSharedLink(new BoxSharedLink(access, unshareDate, permissions));
     }
 
     /**
@@ -236,8 +232,12 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
     public BoxSharedLink createSharedLink(BoxSharedLink.Access access, Date unshareDate,
                                           BoxSharedLink.Permissions permissions, String password) {
 
-        BoxSharedLink sharedLink = new BoxSharedLink(access, unshareDate, permissions, password);
-        Info info = new Info();
+        return this.createSharedLink(new BoxSharedLink(access, unshareDate, permissions, password));
+    }
+
+    @Override
+    public BoxSharedLink createSharedLink(BoxSharedLink sharedLink) {
+        BoxFolder.Info info = new BoxFolder.Info();
         info.setSharedLink(sharedLink);
 
         this.updateInfo(info);
@@ -255,7 +255,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
 
         BoxAPIRequest request = new BoxAPIRequest(api, url, "GET");
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        JsonObject responseJSON = Json.parse(response.getJSON()).asObject();
 
         int entriesCount = responseJSON.get("total_count").asInt();
         Collection<BoxCollaboration.Info> collaborations = new ArrayList<BoxCollaboration.Info>(entriesCount);
@@ -298,7 +298,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         BoxJSONRequest request = new BoxJSONRequest(this.getAPI(), url, "PUT");
         request.setBody(info.getPendingChanges());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject jsonObject = JsonObject.readFrom(response.getJSON());
+        JsonObject jsonObject = Json.parse(response.getJSON()).asObject();
         info.update(jsonObject);
     }
 
@@ -323,7 +323,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
 
         request.setBody(copyInfo.toString());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        JsonObject responseJSON = Json.parse(response.getJSON()).asObject();
         BoxFolder copiedFolder = new BoxFolder(this.getAPI(), responseJSON.get("id").asString());
         return copiedFolder.new Info(responseJSON);
     }
@@ -346,7 +346,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
             "POST");
         request.setBody(newFolder.toString());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        JsonObject responseJSON = Json.parse(response.getJSON()).asObject();
 
         BoxFolder createdFolder = new BoxFolder(this.getAPI(), responseJSON.get("id").asString());
         return createdFolder.new Info(responseJSON);
@@ -385,7 +385,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
 
         request.setBody(updateInfo.toString());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        JsonObject responseJSON = Json.parse(response.getJSON()).asObject();
         BoxFolder movedFolder = new BoxFolder(this.getAPI(), responseJSON.get("id").asString());
         return movedFolder.new Info(responseJSON);
     }
@@ -541,7 +541,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         } else {
             response = (BoxJSONResponse) request.send(uploadParams.getProgressListener());
         }
-        JsonObject collection = JsonObject.readFrom(response.getJSON());
+        JsonObject collection = Json.parse(response.getJSON()).asObject();
         JsonArray entries = collection.get("entries").asArray();
         JsonObject fileInfoJSON = entries.get(0).asObject();
         String uploadedFileID = fileInfoJSON.get("id").asString();
@@ -609,7 +609,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
             CREATE_WEB_LINK_URL.build(this.getAPI().getBaseURL()), "POST");
         request.setBody(newWebLink.toString());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        JsonObject responseJSON = Json.parse(response.getJSON()).asObject();
 
         BoxWebLink createdWebLink = new BoxWebLink(this.getAPI(), responseJSON.get("id").asString());
         return createdWebLink.new Info(responseJSON);
@@ -657,7 +657,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
             .appendParam("direction", direction.toString());
 
         if (fields.length > 0) {
-            builder.appendParam("fields", fields).toString();
+            builder.appendParam("fields", fields);
         }
         final String query = builder.toString();
         return new Iterable<BoxItem.Info>() {
@@ -686,7 +686,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
             .appendParam("direction", direction.toString());
 
         if (fields.length > 0) {
-            builder.appendParam("fields", fields).toString();
+            builder.appendParam("fields", fields);
         }
         final String query = builder.toString();
         return new Iterable<BoxItem.Info>() {
@@ -712,13 +712,13 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
             .appendParam("offset", offset);
 
         if (fields.length > 0) {
-            builder.appendParam("fields", fields).toString();
+            builder.appendParam("fields", fields);
         }
 
         URL url = GET_ITEMS_URL.buildWithQuery(getAPI().getBaseURL(), builder.toString(), getID());
         BoxAPIRequest request = new BoxAPIRequest(this.getAPI(), url, "GET");
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        JsonObject responseJSON = Json.parse(response.getJSON()).asObject();
 
         String totalCountString = responseJSON.get("total_count").toString();
         long fullSize = Double.valueOf(totalCountString).longValue();
@@ -832,7 +832,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         BoxJSONRequest request = new BoxJSONRequest(this.getAPI(), url, "PUT");
         request.setBody(infoJSON.toString());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject jsonObject = JsonObject.readFrom(response.getJSON());
+        JsonObject jsonObject = Json.parse(response.getJSON()).asObject();
         return new Info(jsonObject);
     }
 
@@ -872,7 +872,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         request.addHeader("Content-Type", "application/json");
         request.setBody(metadata.toString());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        return new Metadata(JsonObject.readFrom(response.getJSON()));
+        return new Metadata(Json.parse(response.getJSON()).asObject());
     }
 
     /**
@@ -884,7 +884,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
      * @return the metadata returned from the server.
      */
     public Metadata setMetadata(String templateName, String scope, Metadata metadata) {
-        Metadata metadataValue = null;
+        Metadata metadataValue;
 
         try {
             metadataValue = this.createMetadata(templateName, scope, metadata);
@@ -946,7 +946,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         URL url = METADATA_URL_TEMPLATE.buildAlpha(this.getAPI().getBaseURL(), this.getID(), scope, templateName);
         BoxAPIRequest request = new BoxAPIRequest(this.getAPI(), url, "GET");
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        return new Metadata(JsonObject.readFrom(response.getJSON()));
+        return new Metadata(Json.parse(response.getJSON()).asObject());
     }
 
     /**
@@ -962,7 +962,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         request.addHeader("Content-Type", "application/json-patch+json");
         request.setBody(metadata.getPatch());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        return new Metadata(JsonObject.readFrom(response.getJSON()));
+        return new Metadata(Json.parse(response.getJSON()).asObject());
     }
 
     /**
@@ -1031,7 +1031,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
      */
     public String setClassification(String classificationType) {
         Metadata metadata = new Metadata().add(Metadata.CLASSIFICATION_KEY, classificationType);
-        Metadata classification = null;
+        Metadata classification;
 
         try {
             classification = this.createMetadata(Metadata.CLASSIFICATION_TEMPLATE_KEY, "enterprise", metadata);
@@ -1085,7 +1085,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         request.setBody(body.toString());
 
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject jsonObject = JsonObject.readFrom(response.getJSON());
+        JsonObject jsonObject = Json.parse(response.getJSON()).asObject();
 
         String sessionId = jsonObject.get("id").asString();
         BoxFileUploadSession session = new BoxFileUploadSession(this.getAPI(), sessionId);
@@ -1196,10 +1196,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
      * @return the Iterable of Box Metadata Cascade Policies in your enterprise.
      */
     public Iterable<BoxMetadataCascadePolicy.Info> getMetadataCascadePolicies(String... fields) {
-        Iterable<BoxMetadataCascadePolicy.Info> cascadePoliciesInfo =
-            BoxMetadataCascadePolicy.getAll(this.getAPI(), this.getID(), fields);
-
-        return cascadePoliciesInfo;
+        return BoxMetadataCascadePolicy.getAll(this.getAPI(), this.getID(), fields);
     }
 
     /**
@@ -1212,10 +1209,8 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
      */
     public Iterable<BoxMetadataCascadePolicy.Info> getMetadataCascadePolicies(String enterpriseID,
                                                                               int limit, String... fields) {
-        Iterable<BoxMetadataCascadePolicy.Info> cascadePoliciesInfo =
-            BoxMetadataCascadePolicy.getAll(this.getAPI(), this.getID(), enterpriseID, limit, fields);
 
-        return cascadePoliciesInfo;
+        return BoxMetadataCascadePolicy.getAll(this.getAPI(), this.getID(), enterpriseID, limit, fields);
     }
 
     /**
@@ -1242,7 +1237,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
                 "POST");
         request.setBody(body.toString());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        JsonObject responseJSON = Json.parse(response.getJSON()).asObject();
 
         BoxFolderLock createdFolderLock = new BoxFolderLock(this.getAPI(), responseJSON.get("id").asString());
         return createdFolderLock.new Info(responseJSON);

--- a/src/main/java/com/box/sdk/BoxItem.java
+++ b/src/main/java/com/box/sdk/BoxItem.java
@@ -1,5 +1,6 @@
 package com.box.sdk;
 
+import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
@@ -67,7 +68,7 @@ public abstract class BoxItem extends BoxResource {
         URL url = SHARED_ITEM_URL_TEMPLATE.build(newAPI.getBaseURL());
         BoxAPIRequest request = new BoxAPIRequest(newAPI, url, "GET");
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject json = JsonObject.readFrom(response.getJSON());
+        JsonObject json = Json.parse(response.getJSON()).asObject();
         return (BoxItem.Info) BoxResource.parseInfo(newAPI, json);
     }
 
@@ -180,6 +181,14 @@ public abstract class BoxItem extends BoxResource {
      */
     public abstract BoxSharedLink createSharedLink(BoxSharedLink.Access access, Date unshareDate,
                                                    BoxSharedLink.Permissions permissions);
+
+    /**
+     * Creates a shared link.
+     *
+     * @param sharedLink Shared link to create
+     * @return Created shared link.
+     */
+    public abstract BoxSharedLink createSharedLink(BoxSharedLink sharedLink);
 
     /**
      * Gets information about this item.

--- a/src/main/java/com/box/sdk/BoxItem.java
+++ b/src/main/java/com/box/sdk/BoxItem.java
@@ -183,14 +183,6 @@ public abstract class BoxItem extends BoxResource {
                                                    BoxSharedLink.Permissions permissions);
 
     /**
-     * Creates a shared link.
-     *
-     * @param sharedLink Shared link to create
-     * @return Created shared link.
-     */
-    public abstract BoxSharedLink createSharedLink(BoxSharedLink sharedLink);
-
-    /**
      * Gets information about this item.
      *
      * @return info about this item.

--- a/src/main/java/com/box/sdk/BoxJSONObject.java
+++ b/src/main/java/com/box/sdk/BoxJSONObject.java
@@ -1,5 +1,6 @@
 package com.box.sdk;
 
+import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
@@ -41,7 +42,7 @@ public abstract class BoxJSONObject {
      * @param json the JSON string to decode.
      */
     public BoxJSONObject(String json) {
-        this(JsonObject.readFrom(json));
+        this(Json.parse(json).asObject());
     }
 
     /**
@@ -82,11 +83,7 @@ public abstract class BoxJSONObject {
      * @return a JSON string containing the pending changes.
      */
     public JsonObject getPendingChangesAsJsonObject() {
-        JsonObject jsonObject = this.getPendingJSONObject();
-        if (jsonObject == null) {
-            return null;
-        }
-        return jsonObject;
+        return this.getPendingJSONObject();
     }
 
     /**
@@ -123,7 +120,7 @@ public abstract class BoxJSONObject {
      * @param value the new String value of the field.
      */
     void addPendingChange(String key, String value) {
-        this.addPendingChange(key, JsonValue.valueOf(value));
+        this.addPendingChange(key, Json.value(value));
     }
 
     /**
@@ -134,7 +131,7 @@ public abstract class BoxJSONObject {
      * @param value the new long value of the field.
      */
     void addPendingChange(String key, long value) {
-        this.addPendingChange(key, JsonValue.valueOf(value));
+        this.addPendingChange(key, Json.value(value));
     }
 
     /**
@@ -161,7 +158,7 @@ public abstract class BoxJSONObject {
 
     void addChildObject(String fieldName, BoxJSONObject child) {
         if (child == null) {
-            this.addPendingChange(fieldName, JsonValue.NULL);
+            this.addPendingChange(fieldName, Json.NULL);
         } else {
             this.children.put(fieldName, child);
         }

--- a/src/main/java/com/box/sdk/BoxSharedLink.java
+++ b/src/main/java/com/box/sdk/BoxSharedLink.java
@@ -11,6 +11,7 @@ public class BoxSharedLink extends BoxJSONObject {
     private String url;
     private String downloadUrl;
     private String vanityUrl;
+    private String vanityName;
     private boolean isPasswordEnabled;
     private String password;
     private Date unsharedAt;
@@ -87,6 +88,34 @@ public class BoxSharedLink extends BoxJSONObject {
     }
 
     /**
+     * Returns vanity name used to create vanity URL.
+     *
+     * @return Vanity name
+     */
+    public String getVanityName() {
+        return vanityName;
+    }
+
+    /**
+     * Sets vanity name used to create vanity URL.
+     * For example:
+     * vanityName = myCustomName
+     * will produce vanityUrl as:
+     * https://app.box.com/v/myCustomName
+     * Custom URLs should not be used when sharing sensitive content
+     * as vanity URLs are a lot easier to guess than regular shared links.
+     *
+     * @param vanityName Vanity name. Vanity name must be at least 12 characters long.
+     */
+    public void setVanityName(String vanityName) {
+        if (vanityName != null && vanityName.length() < 12) {
+            throw new IllegalArgumentException("The vanityName has to be at least 12 characters long.");
+        }
+        this.vanityName = vanityName;
+        this.addPendingChange("vanity_name", vanityName);
+    }
+
+    /**
      * Gets whether or not a password is enabled on this shared link.
      *
      * @return true if there's a password enabled on this shared link; otherwise false.
@@ -158,7 +187,7 @@ public class BoxSharedLink extends BoxJSONObject {
      */
     public void setPassword(String password) {
         this.password = password;
-        this.addPendingChange("password", password.toString());
+        this.addPendingChange("password", password);
     }
 
     /**
@@ -188,7 +217,7 @@ public class BoxSharedLink extends BoxJSONObject {
      * @param permissions the new permissions for this shared link.
      */
     public void setPermissions(Permissions permissions) {
-        if (this.permissions == permissions) {
+        if (this.permissions != null && this.permissions.equals(permissions)) {
             return;
         }
 
@@ -214,6 +243,8 @@ public class BoxSharedLink extends BoxJSONObject {
                 this.downloadUrl = value.asString();
             } else if (memberName.equals("vanity_url")) {
                 this.vanityUrl = value.asString();
+            } else if (memberName.equals("vanity_name")) {
+                this.vanityName = value.asString();
             } else if (memberName.equals("is_password_enabled")) {
                 this.isPasswordEnabled = value.asBoolean();
             } else if (memberName.equals("unshared_at")) {
@@ -346,6 +377,35 @@ public class BoxSharedLink extends BoxJSONObject {
             } else if (memberName.equals("can_preview")) {
                 this.canPreview = value.asBoolean();
             }
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Permissions that = (Permissions) o;
+
+            if (canDownload != that.canDownload) {
+                return false;
+            }
+            return canPreview == that.canPreview;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = (canDownload ? 1 : 0);
+            result = 31 * result + (canPreview ? 1 : 0);
+            return result;
+        }
+
+        @Override
+        public String toString() {
+            return "Permissions{canDownload=" + canDownload + ", canPreview=" + canPreview + '}';
         }
     }
 }

--- a/src/main/java/com/box/sdk/BoxWebLink.java
+++ b/src/main/java/com/box/sdk/BoxWebLink.java
@@ -1,5 +1,6 @@
 package com.box.sdk;
 
+import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonArray;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
@@ -49,11 +50,7 @@ public class BoxWebLink extends BoxItem {
                                           BoxSharedLink.Permissions permissions) {
 
         BoxSharedLink sharedLink = new BoxSharedLink(access, unshareDate, permissions);
-        Info info = new Info();
-        info.setSharedLink(sharedLink);
-
-        this.updateInfo(info);
-        return info.getSharedLink();
+        return this.createSharedLink(sharedLink);
     }
 
     /**
@@ -69,12 +66,18 @@ public class BoxWebLink extends BoxItem {
                                           BoxSharedLink.Permissions permissions, String password) {
 
         BoxSharedLink sharedLink = new BoxSharedLink(access, unshareDate, permissions, password);
-        Info info = new Info();
+        return this.createSharedLink(sharedLink);
+    }
+
+    @Override
+    public BoxSharedLink createSharedLink(BoxSharedLink sharedLink) {
+        BoxWebLink.Info info = new BoxWebLink.Info();
         info.setSharedLink(sharedLink);
 
         this.updateInfo(info);
         return info.getSharedLink();
     }
+
 
     @Override
     public BoxWebLink.Info copy(BoxFolder destination) {
@@ -97,7 +100,7 @@ public class BoxWebLink extends BoxItem {
         BoxJSONRequest request = new BoxJSONRequest(this.getAPI(), url, "POST");
         request.setBody(copyInfo.toString());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        JsonObject responseJSON = Json.parse(response.getJSON()).asObject();
         BoxWebLink copiedWebLink = new BoxWebLink(this.getAPI(), responseJSON.get("id").asString());
         return copiedWebLink.new Info(responseJSON);
     }
@@ -133,7 +136,7 @@ public class BoxWebLink extends BoxItem {
 
         request.setBody(updateInfo.toString());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject responseJSON = JsonObject.readFrom(response.getJSON());
+        JsonObject responseJSON = Json.parse(response.getJSON()).asObject();
         BoxWebLink movedWebLink = new BoxWebLink(this.getAPI(), responseJSON.get("id").asString());
         return movedWebLink.new Info(responseJSON);
     }
@@ -190,9 +193,8 @@ public class BoxWebLink extends BoxItem {
         URL url = WEB_LINK_URL_TEMPLATE.build(this.getAPI().getBaseURL(), this.getID());
         BoxJSONRequest request = new BoxJSONRequest(this.getAPI(), url, "PUT");
         request.setBody(info.getPendingChanges());
-        String body = info.getPendingChanges();
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject jsonObject = JsonObject.readFrom(response.getJSON());
+        JsonObject jsonObject = Json.parse(response.getJSON()).asObject();
         info.update(jsonObject);
     }
 
@@ -212,7 +214,7 @@ public class BoxWebLink extends BoxItem {
         BoxJSONRequest request = new BoxJSONRequest(this.getAPI(), url, "PUT");
         request.setBody(infoJSON.toString());
         BoxJSONResponse response = (BoxJSONResponse) request.send();
-        JsonObject jsonObject = JsonObject.readFrom(response.getJSON());
+        JsonObject jsonObject = Json.parse(response.getJSON()).asObject();
         return new Info(jsonObject);
     }
 

--- a/src/main/java/com/box/sdk/BoxWebLink.java
+++ b/src/main/java/com/box/sdk/BoxWebLink.java
@@ -69,8 +69,7 @@ public class BoxWebLink extends BoxItem {
         return this.createSharedLink(sharedLink);
     }
 
-    @Override
-    public BoxSharedLink createSharedLink(BoxSharedLink sharedLink) {
+    private BoxSharedLink createSharedLink(BoxSharedLink sharedLink) {
         BoxWebLink.Info info = new BoxWebLink.Info();
         info.setSharedLink(sharedLink);
 

--- a/src/test/java/com/box/sdk/BoxFileTest.java
+++ b/src/test/java/com/box/sdk/BoxFileTest.java
@@ -1,6 +1,8 @@
 package com.box.sdk;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -917,6 +919,35 @@ public class BoxFileTest {
         assertEquals("folder", uploadedFile.getParent().getType());
         assertEquals("testfile.txt", uploadedFile.getName());
         assertEquals(1491613088000L, uploadedFile.getContentModifiedAt().getTime());
+    }
+
+    @Test
+    public void setsVanityUrlOnASharedLink() {
+        //given
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(
+            new RequestInterceptor() {
+                @Override
+                public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                    //then
+                    JsonObject responseJson = Json.parse(request.bodyToString()).asObject();
+                    JsonObject sharedLinkJson = responseJson.get("shared_link").asObject();
+                    assertThat(sharedLinkJson.get("vanity_name").asString(), is("myCustomName"));
+                    return new BoxJSONResponse() {
+                        @Override
+                        public String getJSON() {
+                            return "{}";
+                        }
+                    };
+                }
+            }
+        );
+        BoxSharedLink sharedLink = new BoxSharedLink();
+        sharedLink.setVanityName("myCustomName");
+
+        //when
+        BoxFile file = new BoxFile(api, "12345");
+        file.createSharedLink(sharedLink);
     }
 
     /**

--- a/src/test/java/com/box/sdk/BoxSharedLinkTest.java
+++ b/src/test/java/com/box/sdk/BoxSharedLinkTest.java
@@ -1,0 +1,76 @@
+package com.box.sdk;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.box.sdk.BoxSharedLink.Permissions;
+import com.eclipsesource.json.JsonObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
+
+public class BoxSharedLinkTest {
+
+    @Test
+    public void vanityNameHasToBeAtLeast12CharactersLong() {
+        final BoxSharedLink link = new BoxSharedLink();
+        Assert.assertThrows(
+            "The vanityName has to be at least 12 characters long.",
+            IllegalArgumentException.class,
+            new ThrowingRunnable() {
+                @Override
+                public void run() {
+                    link.setVanityName("tooShort");
+                }
+            }
+        );
+    }
+
+    @Test
+    public void setsNewPermissions() {
+        BoxSharedLink link = new BoxSharedLink();
+
+        link.setPermissions(permissions(true, false));
+
+        assertThat(link.getPermissions(), is(this.permissions(true, false)));
+        JsonObject pendingChanges = link.getPendingChangesAsJsonObject();
+        JsonObject changesToPermissions = pendingChanges.get("permissions").asObject();
+        assertThat(changesToPermissions.get("can_download").asBoolean(), is(true));
+        assertThat(changesToPermissions.get("can_preview").asBoolean(), is(false));
+    }
+
+    @Test
+    public void doNotStorePendingChangeWhenPermissionsNotChanged() {
+        BoxSharedLink link = new BoxSharedLink();
+        link.setPermissions(permissions(true, false));
+        link.removeChildObject("permissions");
+
+        link.setPermissions(this.permissions(true, false));
+
+        assertThat(link.getPermissions(), is(permissions(true, false)));
+        assertThat(link.getPendingChangesAsJsonObject(), is(nullValue()));
+    }
+
+    @Test
+    public void storePendingChangeWhenPermissionsChanged() {
+        BoxSharedLink link = new BoxSharedLink();
+        link.setPermissions(permissions(true, false));
+        link.removeChildObject("permissions");
+
+        link.setPermissions(this.permissions(false, false));
+
+        assertThat(link.getPermissions(), is(permissions(false, false)));
+        JsonObject pendingChanges = link.getPendingChangesAsJsonObject();
+        JsonObject changesToPermissions = pendingChanges.get("permissions").asObject();
+        assertThat(changesToPermissions.get("can_download").asBoolean(), is(false));
+        assertThat(changesToPermissions.get("can_preview").asBoolean(), is(false));
+    }
+
+    private Permissions permissions(boolean canDownload, boolean canPreview) {
+        Permissions permissions = new Permissions();
+        permissions.setCanDownload(canDownload);
+        permissions.setCanPreview(canPreview);
+        return permissions;
+    }
+}

--- a/src/test/java/com/box/sdk/BoxWebLinkTest.java
+++ b/src/test/java/com/box/sdk/BoxWebLinkTest.java
@@ -1,11 +1,8 @@
 package com.box.sdk;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
@@ -153,33 +150,5 @@ public class BoxWebLinkTest {
             password);
 
         assertTrue(sharedLink.getIsPasswordEnabled());
-    }
-
-    @Test
-    public void setsVanityUrlOnASharedLink() {
-        //given
-        this.api.setRequestInterceptor(
-            new RequestInterceptor() {
-                @Override
-                public BoxAPIResponse onRequest(BoxAPIRequest request) {
-                    //then
-                    JsonObject responseJson = Json.parse(request.bodyToString()).asObject();
-                    JsonObject sharedLinkJson = responseJson.get("shared_link").asObject();
-                    assertThat(sharedLinkJson.get("vanity_name").asString(), is("myCustomName"));
-                    return new BoxJSONResponse() {
-                        @Override
-                        public String getJSON() {
-                            return "{}";
-                        }
-                    };
-                }
-            }
-        );
-        BoxSharedLink sharedLink = new BoxSharedLink();
-        sharedLink.setVanityName("myCustomName");
-
-        //when
-        BoxWebLink webLink = new BoxWebLink(this.api, "12345");
-        webLink.createSharedLink(sharedLink);
     }
 }

--- a/src/test/java/com/box/sdk/BoxWebLinkTest.java
+++ b/src/test/java/com/box/sdk/BoxWebLinkTest.java
@@ -1,8 +1,11 @@
 package com.box.sdk;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockClassRule;
@@ -150,5 +153,33 @@ public class BoxWebLinkTest {
             password);
 
         assertTrue(sharedLink.getIsPasswordEnabled());
+    }
+
+    @Test
+    public void setsVanityUrlOnASharedLink() {
+        //given
+        this.api.setRequestInterceptor(
+            new RequestInterceptor() {
+                @Override
+                public BoxAPIResponse onRequest(BoxAPIRequest request) {
+                    //then
+                    JsonObject responseJson = Json.parse(request.bodyToString()).asObject();
+                    JsonObject sharedLinkJson = responseJson.get("shared_link").asObject();
+                    assertThat(sharedLinkJson.get("vanity_name").asString(), is("myCustomName"));
+                    return new BoxJSONResponse() {
+                        @Override
+                        public String getJSON() {
+                            return "{}";
+                        }
+                    };
+                }
+            }
+        );
+        BoxSharedLink sharedLink = new BoxSharedLink();
+        sharedLink.setVanityName("myCustomName");
+
+        //when
+        BoxWebLink webLink = new BoxWebLink(this.api, "12345");
+        webLink.createSharedLink(sharedLink);
     }
 }


### PR DESCRIPTION
We cannot set Vanity URL directly but we can set Vanity Name. This name is later used in generated link.
Deprecating old methods to create BoxSharedLink.