### PR TITLE
feat: Add new parameters to the retention_policies and retention_policy_assignments endpoints

### DIFF
--- a/src/main/java/com/box/sdk/BoxRetentionPolicy.java
+++ b/src/main/java/com/box/sdk/BoxRetentionPolicy.java
@@ -187,6 +187,7 @@ public class BoxRetentionPolicy extends BoxResource {
         if (optionalParams != null) {
             requestJSON.add("can_owner_extend_retention", optionalParams.getCanOwnerExtendRetention());
             requestJSON.add("are_owners_notified", optionalParams.getAreOwnersNotified());
+            requestJSON.add("description", optionalParams.getDescription());
 
             List<BoxUser.Info> customNotificationRecipients = optionalParams.getCustomNotificationRecipients();
             if (customNotificationRecipients.size() > 0) {
@@ -377,8 +378,22 @@ public class BoxRetentionPolicy extends BoxResource {
      */
     public BoxRetentionPolicyAssignment.Info assignToMetadataTemplate(String templateID,
                                                                       MetadataFieldFilter... fieldFilters) {
+        return assignToMetadataTemplate(templateID, null, fieldFilters);
+    }
+
+    /**
+     * Assigns this retention policy to a metadata template, optionally with certain field values.
+     *
+     * @param templateID the ID of the metadata template to apply to.
+     * @param startDateField the date the retention policy assignment begins. This field can be a date field's metadata attribute key id.
+     * @param fieldFilters optional field value filters.
+     * @return info about the created assignment.
+     */
+    public BoxRetentionPolicyAssignment.Info assignToMetadataTemplate(String templateID,
+                                                                      String startDateField,
+                                                                      MetadataFieldFilter... fieldFilters) {
         return BoxRetentionPolicyAssignment.createAssignmentToMetadata(this.getAPI(), this.getID(), templateID,
-            fieldFilters);
+                startDateField, fieldFilters);
     }
 
     /**
@@ -467,6 +482,11 @@ public class BoxRetentionPolicy extends BoxResource {
          * @see #getAreOwnersNotified()
          */
         private boolean areOwnersNotified;
+
+        /**
+         * @see #getDescription()
+         */
+        private String description;
 
         private List<BoxUser.Info> customNotificationRecipients;
 
@@ -630,6 +650,25 @@ public class BoxRetentionPolicy extends BoxResource {
         }
 
         /**
+         * Gets the additional text desription of the retention policy.
+         *
+         * @return the additional text desription of the retention policy
+         */
+        public String getDescription() {
+            return this.description;
+        }
+
+        /**
+         * Set the additional text desription of the retention policy.
+         *
+         * @param description the new text desription of the retention policy
+         */
+        public void setDescription(String description) {
+            this.description = description;
+            this.addPendingChange("description", description);
+        }
+
+        /**
          * Gets the list of users to be notified of a retained file when near expiration.
          *
          * @return the list of users to be notified.
@@ -681,6 +720,8 @@ public class BoxRetentionPolicy extends BoxResource {
                     this.canOwnerExtendRetention = value.asBoolean();
                 } else if (memberName.equals("are_owners_notified")) {
                     this.areOwnersNotified = value.asBoolean();
+                } else if (memberName.equals("description")) {
+                    this.description = value.asString();
                 } else if (memberName.equals("custom_notification_recipients")) {
                     List<BoxUser.Info> recipients = new ArrayList<BoxUser.Info>();
                     for (JsonValue userJSON : value.asArray()) {

--- a/src/main/java/com/box/sdk/RetentionPolicyParams.java
+++ b/src/main/java/com/box/sdk/RetentionPolicyParams.java
@@ -21,6 +21,11 @@ public class RetentionPolicyParams {
     private boolean areOwnersNotified;
 
     /**
+     * @see #getDescription()
+     */
+    private String description;
+
+    /**
      * @see #getCustomNotificationRecipients()
      */
     private List<BoxUser.Info> customNotificationRecipients;
@@ -31,7 +36,8 @@ public class RetentionPolicyParams {
     public RetentionPolicyParams() {
         this.canOwnerExtendRetention = false;
         this.areOwnersNotified = false;
-        this.customNotificationRecipients = new ArrayList<BoxUser.Info>();
+        this.customNotificationRecipients = new ArrayList<>();
+        this.description = "";
     }
 
     /**
@@ -64,6 +70,22 @@ public class RetentionPolicyParams {
      */
     public void setAreOwnersNotified(boolean areOwnersNotified) {
         this.areOwnersNotified = areOwnersNotified;
+    }
+
+    /**
+     * @return The additional text description of the retention policy
+     */
+    public String getDescription() {
+        return this.description;
+    }
+
+    /**
+     * Set additional text description of the retention policy.
+     *
+     * @param description The additional text description of the retention policy.
+     */
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     /**

--- a/src/test/Fixtures/BoxRetentionPolicy/CreateRetentionPolicy201.json
+++ b/src/test/Fixtures/BoxRetentionPolicy/CreateRetentionPolicy201.json
@@ -21,5 +21,6 @@
     "login": "test@user.com"
   },
   "created_at": "2018-04-23T10:17:14-07:00",
-  "modified_at": "2018-04-23T10:17:14-07:00"
+  "modified_at": "2018-04-23T10:17:14-07:00",
+  "description": "description"
 }

--- a/src/test/Fixtures/BoxRetentionPolicy/CreateRetentionPolicyAssignmentForMetadataTemplate201.json
+++ b/src/test/Fixtures/BoxRetentionPolicy/CreateRetentionPolicyAssignmentForMetadataTemplate201.json
@@ -1,0 +1,24 @@
+{
+  "type": "retention_policy_assignment",
+  "id": "12345",
+  "retention_policy": {
+    "type": "retention_policy",
+    "id": "1111",
+    "policy_name": "A Retention Policy",
+    "retention_length": "30",
+    "disposition_action": "remove_retention"
+  },
+  "assigned_to": {
+    "type": "metadata_template",
+    "id": "c5c3a90a-7530-44c9-a47a-e522473a8d06"
+  },
+  "filter_fields": [],
+  "assigned_by": {
+    "type": "user",
+    "id": "3333",
+    "name": "Test User",
+    "login": "test@user.com"
+  },
+  "assigned_at": "2021-12-16T10:37:10-08:00",
+  "start_date_field": "68144df9-597b-4ccb-b1ca-b981eaa321c4"
+}

--- a/src/test/Fixtures/BoxRetentionPolicy/CreateRetentionPolicyAssignmentForMetadataTemplateWithoutStartDateField201.json
+++ b/src/test/Fixtures/BoxRetentionPolicy/CreateRetentionPolicyAssignmentForMetadataTemplateWithoutStartDateField201.json
@@ -4,11 +4,13 @@
   "retention_policy": {
     "type": "retention_policy",
     "id": "1111",
-    "policy_name": "A Retention Policy"
+    "policy_name": "A Retention Policy",
+    "retention_length": "30",
+    "disposition_action": "remove_retention"
   },
   "assigned_to": {
-    "type": "enterprise",
-    "id": "2222"
+    "type": "metadata_template",
+    "id": "c5c3a90a-7530-44c9-a47a-e522473a8d06"
   },
   "filter_fields": [],
   "assigned_by": {
@@ -17,6 +19,6 @@
     "name": "Test User",
     "login": "test@user.com"
   },
-  "assigned_at": "2018-04-23T12:37:36-07:00",
+  "assigned_at": "2021-12-16T10:37:10-08:00",
   "start_date_field": "upload_date"
 }

--- a/src/test/Fixtures/BoxRetentionPolicy/GetRetentionPolicyAssignmentInfo200.json
+++ b/src/test/Fixtures/BoxRetentionPolicy/GetRetentionPolicyAssignmentInfo200.json
@@ -17,5 +17,6 @@
     "name": "Test User",
     "login": "test@user.com"
   },
-  "assigned_at": "2018-04-23T12:37:36-07:00"
+  "assigned_at": "2018-04-23T12:37:36-07:00",
+  "start_date_field": "upload_date"
 }

--- a/src/test/Fixtures/BoxRetentionPolicy/GetRetentionPolicyInfo200.json
+++ b/src/test/Fixtures/BoxRetentionPolicy/GetRetentionPolicyInfo200.json
@@ -21,5 +21,6 @@
     "login": "test@user.com"
   },
   "created_at": "2018-04-09T15:16:39-07:00",
-  "modified_at": "2018-04-09T15:16:39-07:00"
+  "modified_at": "2018-04-09T15:16:39-07:00",
+  "description": "description"
 }

--- a/src/test/Fixtures/BoxRetentionPolicy/UpdateRetentionPolicyInfo200.json
+++ b/src/test/Fixtures/BoxRetentionPolicy/UpdateRetentionPolicyInfo200.json
@@ -21,5 +21,6 @@
     "login": "test@user.com"
   },
   "created_at": "2018-04-23T10:17:14-07:00",
-  "modified_at": "2018-04-23T11:07:29-07:00"
+  "modified_at": "2018-04-23T11:07:29-07:00",
+  "description": "updated description"
 }

--- a/src/test/java/com/box/sdk/BoxRetentionPolicyAssignmentTest.java
+++ b/src/test/java/com/box/sdk/BoxRetentionPolicyAssignmentTest.java
@@ -17,7 +17,7 @@ public class BoxRetentionPolicyAssignmentTest {
 
     @ClassRule
     public static final WireMockClassRule WIRE_MOCK_CLASS_RULE = new WireMockClassRule(53621);
-    private BoxAPIConnection api = TestConfig.getAPIConnection();
+    private final BoxAPIConnection api = TestConfig.getAPIConnection();
 
     @Test
     public void testGetPolicyAssignmentForEnterpriseSucceeds() throws IOException {
@@ -100,6 +100,7 @@ public class BoxRetentionPolicyAssignmentTest {
         final String policyID = "1111";
         final String policyName = "A Retention Policy";
         final String assignedByLogin = "test@user.com";
+        final String startDateField = "upload_date";
 
         JsonObject assignToObject = new JsonObject()
             .add("type", "enterprise");
@@ -122,6 +123,77 @@ public class BoxRetentionPolicyAssignmentTest {
         assertEquals(assignmentID, enterpriseAssignmentInfo.getID());
         assertEquals(policyName, enterpriseAssignmentInfo.getRetentionPolicy().getPolicyName());
         assertEquals(assignedByLogin, enterpriseAssignmentInfo.getAssignedBy().getLogin());
+        assertEquals(startDateField, enterpriseAssignmentInfo.getStartDateField());
+    }
+
+    @Test
+    public void testCreateRetentionPolicyAssignmentToMetadataTemplate() throws IOException {
+        final String assignmentID = "12345";
+        final String assignmentURL = "/retention_policy_assignments";
+        final String policyID = "1111";
+        final String metadataTemplateID = "c5c3a90a-7530-44c9-a47a-e522473a8d06";
+        final String metadataTemplateDateFieldId = "68144df9-597b-4ccb-b1ca-b981eaa321c4";
+
+        JsonObject assignToObject = new JsonObject()
+                .add("type", "metadata_template")
+                .add("id", metadataTemplateID);
+
+        JsonObject assignmentObject = new JsonObject()
+                .add("policy_id", policyID)
+                .add("assign_to", assignToObject)
+                .add("start_date_field", metadataTemplateDateFieldId);
+
+        String result = TestConfig.getFixture(
+                "BoxRetentionPolicy/CreateRetentionPolicyAssignmentForMetadataTemplate201");
+
+        WIRE_MOCK_CLASS_RULE.stubFor(WireMock.post(WireMock.urlPathEqualTo(assignmentURL))
+                .withRequestBody(WireMock.equalToJson(assignmentObject.toString()))
+                .willReturn(WireMock.aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(result)));
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(this.api, policyID);
+        BoxRetentionPolicyAssignment.Info enterpriseAssignmentInfo = policy.assignToMetadataTemplate(
+                metadataTemplateID, metadataTemplateDateFieldId);
+
+        assertEquals(assignmentID, enterpriseAssignmentInfo.getID());
+        assertEquals(policyID, enterpriseAssignmentInfo.getRetentionPolicy().getID());
+        assertEquals(metadataTemplateID, enterpriseAssignmentInfo.getAssignedToID());
+        assertEquals(metadataTemplateDateFieldId, enterpriseAssignmentInfo.getStartDateField());
+    }
+
+    @Test
+    public void testCreateRetentionPolicyAssignmentToMetadataTemplateWithoutStartDateField() throws IOException {
+        final String assignmentID = "12345";
+        final String assignmentURL = "/retention_policy_assignments";
+        final String policyID = "1111";
+        final String metadataTemplateID = "c5c3a90a-7530-44c9-a47a-e522473a8d06";
+
+        JsonObject assignToObject = new JsonObject()
+                .add("type", "metadata_template")
+                .add("id", metadataTemplateID);
+
+        JsonObject assignmentObject = new JsonObject()
+                .add("policy_id", policyID)
+                .add("assign_to", assignToObject);
+
+        String result = TestConfig.getFixture(
+                "BoxRetentionPolicy/CreateRetentionPolicyAssignmentForMetadataTemplateWithoutStartDateField201");
+
+        WIRE_MOCK_CLASS_RULE.stubFor(WireMock.post(WireMock.urlPathEqualTo(assignmentURL))
+                .withRequestBody(WireMock.equalToJson(assignmentObject.toString()))
+                .willReturn(WireMock.aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(result)));
+
+        BoxRetentionPolicy policy = new BoxRetentionPolicy(this.api, policyID);
+        BoxRetentionPolicyAssignment.Info enterpriseAssignmentInfo
+                = policy.assignToMetadataTemplate(metadataTemplateID);
+
+        assertEquals(assignmentID, enterpriseAssignmentInfo.getID());
+        assertEquals(policyID, enterpriseAssignmentInfo.getRetentionPolicy().getID());
+        assertEquals(metadataTemplateID, enterpriseAssignmentInfo.getAssignedToID());
+        assertEquals("upload_date", enterpriseAssignmentInfo.getStartDateField());
     }
 
     @Test
@@ -130,6 +202,7 @@ public class BoxRetentionPolicyAssignmentTest {
         String assignmentURL = "/retention_policy_assignments/" + assignmentID;
         final String retentionPolicyID = "1111";
         final String assignedByLogin = "test@user.com";
+        final String startDateField = "upload_date";
 
         String result = TestConfig.getFixture("BoxRetentionPolicy/GetRetentionPolicyAssignmentInfo200");
 
@@ -144,6 +217,7 @@ public class BoxRetentionPolicyAssignmentTest {
         assertEquals(assignmentID, assignmentInfo.getID());
         assertEquals(retentionPolicyID, assignmentInfo.getRetentionPolicy().getID());
         assertEquals(assignedByLogin, assignmentInfo.getAssignedBy().getLogin());
+        assertEquals(startDateField, assignmentInfo.getStartDateField());
     }
 
     @Test

--- a/src/test/java/com/box/sdk/BoxRetentionPolicyTest.java
+++ b/src/test/java/com/box/sdk/BoxRetentionPolicyTest.java
@@ -54,6 +54,7 @@ public class BoxRetentionPolicyTest {
         final String dispositionAction = "remove_retention";
         final String retentionPolicyID = "12345";
         final String getRetentionPolicyInfoURL = "/retention_policies/" + retentionPolicyID;
+        final String description = "description";
 
         String result = TestConfig.getFixture("BoxRetentionPolicy/GetRetentionPolicyInfo200");
 
@@ -69,6 +70,7 @@ public class BoxRetentionPolicyTest {
         assertEquals(policyStatus, policyInfo.getStatus());
         assertEquals(retentionPolicyID, policyInfo.getID());
         assertEquals(dispositionAction, policyInfo.getDispositionAction());
+        assertEquals(description, policyInfo.getDescription());
         assertTrue(policyInfo.getAreOwnersNotified());
         assertTrue(policyInfo.getCanOwnerExtendRetention());
     }
@@ -82,6 +84,7 @@ public class BoxRetentionPolicyTest {
         final String createRetentionPolicyURL = "/retention_policies";
         final String createdByLogin = "test@user.com";
         final String policyStatus = "active";
+        final String description = "description";
 
         String result = TestConfig.getFixture("BoxRetentionPolicy/CreateRetentionPolicy201");
 
@@ -98,6 +101,7 @@ public class BoxRetentionPolicyTest {
         assertEquals(createdByLogin, policyInfo.getCreatedBy().getLogin());
         assertEquals(policyID, policyInfo.getID());
         assertEquals(policyStatus, policyInfo.getStatus());
+        assertEquals(description, policyInfo.getDescription());
     }
 
     @Test
@@ -106,10 +110,13 @@ public class BoxRetentionPolicyTest {
         final String updateRetentionPolicyURL = "/retention_policies/" + policyID;
         final String updatedPolicyName = "New Policy Name";
         final String updatedPolicyStatus = "retired";
+        final String updatedDescription = "updated description";
+
 
         JsonObject retentionPolicyObject = new JsonObject()
             .add("policy_name", updatedPolicyName)
-            .add("status", updatedPolicyStatus);
+            .add("status", updatedPolicyStatus)
+            .add("description", updatedDescription);
 
         String result = TestConfig.getFixture("BoxRetentionPolicy/UpdateRetentionPolicyInfo200");
 
@@ -123,6 +130,7 @@ public class BoxRetentionPolicyTest {
         BoxRetentionPolicy.Info policyInfo = policy.new Info();
         policyInfo.setPolicyName(updatedPolicyName);
         policyInfo.setStatus(updatedPolicyStatus);
+        policyInfo.setDescription(updatedDescription);
         policy.updateInfo(policyInfo);
     }
 }


### PR DESCRIPTION
Add new optional `description` parameter to the retention_policies endpoint and `start_date_field` to the retention_policy_assignments endpoint.

Closes: SDK-1839