### PR TITLE
feat: Add `typeName` to `BoxEvent` that contains name of the event, even if it is not mapped to `BoxEvent.EventType`

### DIFF
--- a/src/main/java/com/box/sdk/BoxEvent.java
+++ b/src/main/java/com/box/sdk/BoxEvent.java
@@ -16,6 +16,7 @@ public class BoxEvent extends BoxResource {
     private BoxResource.Info sourceInfo;
     private BoxEvent.Type type;
     private BoxEvent.EventType eventType;
+    private String typeName;
     private JsonObject sourceJSON;
     private Date createdAt;
     private String ipAddress;
@@ -91,6 +92,16 @@ public class BoxEvent extends BoxResource {
      */
     public BoxEvent.EventType getEventType() {
         return this.eventType;
+    }
+
+    /**
+     * Gets the type name as String. Every BoxEvent will have typeName, some will have
+     * eventType set to specific value and some will have eventType = UNKNOWN.
+     *
+     * @return the name of the type of this event.
+     */
+    public String getTypeName() {
+        return this.typeName;
     }
 
     /**
@@ -180,6 +191,7 @@ public class BoxEvent extends BoxResource {
             this.sourceJSON = JsonObject.unmodifiableObject(value.asObject());
         } else if (memberName.equals("event_type")) {
             String stringValue = value.asString();
+            this.typeName = stringValue;
             for (Type t : Type.values()) {
                 if (t.name().equals(stringValue)) {
                     this.type = t;

--- a/src/main/java/com/box/sdk/EnterpriseEventsRequest.java
+++ b/src/main/java/com/box/sdk/EnterpriseEventsRequest.java
@@ -22,7 +22,7 @@ public final class EnterpriseEventsRequest {
     private Date after;
     private String position;
     private int limit = ENTERPRISE_LIMIT;
-    private Collection<EventType> types = new ArrayList<>();
+    private Collection<String> types = new ArrayList<>();
 
     /**
      * The lower bound on the timestamp of the events returned.
@@ -70,7 +70,19 @@ public final class EnterpriseEventsRequest {
      * @return request being created.
      */
     public EnterpriseEventsRequest types(EventType... types) {
-        this.types = Arrays.asList(types);
+        return typeNames(Arrays.stream(types)
+            .map(EventType::toJSONString)
+            .toArray(String[]::new)
+        );
+    }
+
+    /**
+     * List of event type names to filter by.
+     * @param typeNames list of event type names to filter by.
+     * @return request being created.
+     */
+    public EnterpriseEventsRequest typeNames(String... typeNames) {
+        this.types = Arrays.asList(typeNames);
         return this;
     }
 
@@ -91,7 +103,7 @@ public final class EnterpriseEventsRequest {
     }
 
 
-    Collection<EventType> getTypes() {
+    Collection<String> getTypes() {
         return types;
     }
 

--- a/src/main/java/com/box/sdk/EnterpriseEventsStreamRequest.java
+++ b/src/main/java/com/box/sdk/EnterpriseEventsStreamRequest.java
@@ -19,7 +19,7 @@ public final class EnterpriseEventsStreamRequest {
     private static final String ADMIN_LOGS_STREAM_TYPE = "admin_logs_streaming";
     private String position;
     private int limit = ENTERPRISE_LIMIT;
-    private Collection<EventType> types = new ArrayList<>();
+    private Collection<String> types = new ArrayList<>();
 
 
     /**
@@ -48,7 +48,19 @@ public final class EnterpriseEventsStreamRequest {
      * @return request being created.
      */
     public EnterpriseEventsStreamRequest types(EventType... types) {
-        this.types = Arrays.asList(types);
+        return typeNames(Arrays.stream(types)
+            .map(EventType::toJSONString)
+            .toArray(String[]::new)
+        );
+    }
+
+    /**
+     * List of event type names to filter by.
+     * @param typeNames list of event type names to filter by.
+     * @return request being created.
+     */
+    public EnterpriseEventsStreamRequest typeNames(String... typeNames) {
+        this.types = Arrays.asList(typeNames);
         return this;
     }
 
@@ -61,7 +73,7 @@ public final class EnterpriseEventsStreamRequest {
     }
 
 
-    Collection<EventType> getTypes() {
+    Collection<String> getTypes() {
         return types;
     }
 

--- a/src/main/java/com/box/sdk/EventLog.java
+++ b/src/main/java/com/box/sdk/EventLog.java
@@ -265,13 +265,8 @@ public class EventLog implements Iterable<BoxEvent> {
             queryBuilder.appendParam("stream_position", request.getPosition());
         }
         if (request.getTypes().size() > 0) {
-            StringBuilder filterBuilder = new StringBuilder();
-            for (BoxEvent.EventType filterType : request.getTypes()) {
-                filterBuilder.append(filterType.name());
-                filterBuilder.append(',');
-            }
-            filterBuilder.deleteCharAt(filterBuilder.length() - 1);
-            queryBuilder.appendParam("event_type", filterBuilder.toString());
+            String types = String.join(",", request.getTypes());
+            queryBuilder.appendParam("event_type", types);
         }
     }
 
@@ -385,14 +380,14 @@ public class EventLog implements Iterable<BoxEvent> {
         private final Date after;
         private final String position;
         private final Integer limit;
-        private final Collection<BoxEvent.EventType> types;
+        private final Collection<String> types;
 
         private EventLogRequest(
             Date before,
             Date after,
             String position,
             Integer limit,
-            Collection<BoxEvent.EventType> types
+            Collection<String> types
         ) {
             this.before = before;
             this.after = after;
@@ -417,7 +412,7 @@ public class EventLog implements Iterable<BoxEvent> {
             return limit;
         }
 
-        private Collection<BoxEvent.EventType> getTypes() {
+        private Collection<String> getTypes() {
             return types;
         }
     }

--- a/src/test/java/com/box/sdk/BoxEventTest.java
+++ b/src/test/java/com/box/sdk/BoxEventTest.java
@@ -70,6 +70,7 @@ public class BoxEventTest {
         assertEquals("Example User", event.getCreatedBy().getName());
         assertEquals(BoxEvent.Type.ADD_LOGIN_ACTIVITY_DEVICE, event.getType());
         assertEquals(BoxEvent.EventType.ADD_LOGIN_ACTIVITY_DEVICE, event.getEventType());
+        assertEquals("ADD_LOGIN_ACTIVITY_DEVICE", event.getTypeName());
     }
 
     @Test

--- a/src/test/java/com/box/sdk/EventLogTest.java
+++ b/src/test/java/com/box/sdk/EventLogTest.java
@@ -30,21 +30,18 @@ public class EventLogTest {
         final String position = "1152923110369165138";
         BoxEvent.EventType[] eventTypes = {LOGIN, FAILED_LOGIN};
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setRequestInterceptor(new RequestInterceptor() {
-            @Override
-            public BoxAPIResponse onRequest(BoxAPIRequest request) {
-                try {
-                    String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
-                    assertThat(query, containsString("stream_type=admin_logs"));
-                    assertThat(query, containsString("created_after=" + BoxDateFormat.format(after)));
-                    assertThat(query, containsString("created_before=" + BoxDateFormat.format(before)));
-                    assertThat(query, containsString("limit=" + limit));
-                    assertThat(query, containsString("stream_position=" + position));
-                    assertThat(query, containsString("event_type=LOGIN,FAILED_LOGIN"));
-                    return EMPTY_RESPONSE;
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+        api.setRequestInterceptor(request -> {
+            try {
+                String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
+                assertThat(query, containsString("stream_type=admin_logs"));
+                assertThat(query, containsString("created_after=" + BoxDateFormat.format(after)));
+                assertThat(query, containsString("created_before=" + BoxDateFormat.format(before)));
+                assertThat(query, containsString("limit=" + limit));
+                assertThat(query, containsString("stream_position=" + position));
+                assertThat(query, containsString("event_type=LOGIN,FAILED_LOGIN"));
+                return EMPTY_RESPONSE;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
         });
 
@@ -60,16 +57,13 @@ public class EventLogTest {
     @Test
     public void getEnterpriseEventsWithoutAnyParams() {
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setRequestInterceptor(new RequestInterceptor() {
-            @Override
-            public BoxAPIResponse onRequest(BoxAPIRequest request) {
-                try {
-                    String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
-                    assertThat(query, is("stream_type=admin_logs&limit=500"));
-                    return EMPTY_RESPONSE;
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+        api.setRequestInterceptor(request -> {
+            try {
+                String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
+                assertThat(query, is("stream_type=admin_logs&limit=500"));
+                return EMPTY_RESPONSE;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
         });
 
@@ -80,16 +74,13 @@ public class EventLogTest {
     public void getEnterpriseEventsAddsLimitOnlyIfDifferentThanDefault() {
         final int limit = 100;
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setRequestInterceptor(new RequestInterceptor() {
-            @Override
-            public BoxAPIResponse onRequest(BoxAPIRequest request) {
-                try {
-                    String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
-                    assertThat(query, is("stream_type=admin_logs&limit=" + limit));
-                    return EMPTY_RESPONSE;
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+        api.setRequestInterceptor(request -> {
+            try {
+                String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
+                assertThat(query, is("stream_type=admin_logs&limit=" + limit));
+                return EMPTY_RESPONSE;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
         });
 
@@ -102,21 +93,18 @@ public class EventLogTest {
         final String position = "1152923110369165138";
         BoxEvent.EventType[] eventTypes = {LOGIN, FAILED_LOGIN};
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setRequestInterceptor(new RequestInterceptor() {
-            @Override
-            public BoxAPIResponse onRequest(BoxAPIRequest request) {
-                try {
-                    String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
-                    assertThat(query, containsString("stream_type=admin_logs_streaming"));
-                    assertThat(query, not(containsString("created_after")));
-                    assertThat(query, not(containsString("created_before")));
-                    assertThat(query, containsString("limit=" + limit));
-                    assertThat(query, containsString("stream_position=1152923110369165138"));
-                    assertThat(query, containsString("event_type=LOGIN,FAILED_LOGIN"));
-                    return EMPTY_RESPONSE;
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+        api.setRequestInterceptor(request -> {
+            try {
+                String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
+                assertThat(query, containsString("stream_type=admin_logs_streaming"));
+                assertThat(query, not(containsString("created_after")));
+                assertThat(query, not(containsString("created_before")));
+                assertThat(query, containsString("limit=" + limit));
+                assertThat(query, containsString("stream_position=1152923110369165138"));
+                assertThat(query, containsString("event_type=LOGIN,FAILED_LOGIN"));
+                return EMPTY_RESPONSE;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
         });
 
@@ -130,16 +118,13 @@ public class EventLogTest {
     @Test
     public void getEnterpriseEventsStreamWithoutAnyParams() {
         BoxAPIConnection api = new BoxAPIConnection("");
-        api.setRequestInterceptor(new RequestInterceptor() {
-            @Override
-            public BoxAPIResponse onRequest(BoxAPIRequest request) {
-                try {
-                    String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
-                    assertThat(query, is("stream_type=admin_logs_streaming&limit=500"));
-                    return EMPTY_RESPONSE;
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
+        api.setRequestInterceptor(request -> {
+            try {
+                String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
+                assertThat(query, is("stream_type=admin_logs_streaming&limit=500"));
+                return EMPTY_RESPONSE;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
             }
         });
 
@@ -166,5 +151,63 @@ public class EventLogTest {
         EventLog eventLog = new EventLog(api, json, null, 10);
 
         assertThat(eventLog.getNextStreamPosition(), is("1152923112788365709"));
+    }
+
+    @Test
+    public void getEnterpriseEventsTypesAsString() {
+        final Date after = new Date(0L);
+        final Date before = new Date(System.currentTimeMillis());
+        final int limit = 500;
+        final String position = "1152923110369165138";
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(request -> {
+            try {
+                String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
+                assertThat(query, containsString("stream_type=admin_logs"));
+                assertThat(query, containsString("created_after=" + BoxDateFormat.format(after)));
+                assertThat(query, containsString("created_before=" + BoxDateFormat.format(before)));
+                assertThat(query, containsString("limit=" + limit));
+                assertThat(query, containsString("stream_position=" + position));
+                assertThat(query, containsString("event_type=LOGIN,FAILED_LOGIN"));
+                return EMPTY_RESPONSE;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        EnterpriseEventsRequest request = new EnterpriseEventsRequest()
+            .after(after)
+            .before(before)
+            .limit(limit)
+            .position(position)
+            .typeNames("LOGIN", "FAILED_LOGIN");
+        EventLog.getEnterpriseEvents(api, request);
+    }
+
+    @Test
+    public void getEnterpriseEventsStreamWithTypesAsString() {
+        final int limit = 100;
+        final String position = "1152923110369165138";
+        BoxAPIConnection api = new BoxAPIConnection("");
+        api.setRequestInterceptor(request -> {
+            try {
+                String query = URLDecoder.decode(request.getUrl().getQuery(), "UTF-8");
+                assertThat(query, containsString("stream_type=admin_logs_streaming"));
+                assertThat(query, not(containsString("created_after")));
+                assertThat(query, not(containsString("created_before")));
+                assertThat(query, containsString("limit=" + limit));
+                assertThat(query, containsString("stream_position=1152923110369165138"));
+                assertThat(query, containsString("event_type=LOGIN,FAILED_LOGIN"));
+                return EMPTY_RESPONSE;
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        EnterpriseEventsStreamRequest request = new EnterpriseEventsStreamRequest()
+            .limit(limit)
+            .position(position)
+            .typeNames("LOGIN", "FAILED_LOGIN");
+        EventLog.getEnterpriseEventsStream(api, request);
     }
 }


### PR DESCRIPTION
 - fixes #968 