### PR TITLE
fix: Documentation Client credentials grant sample code tag

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -160,7 +160,7 @@ Allows you to obtain an access token by having client credentials and secret wit
 which allows you to work using service or user account.
 
 The `BoxCCGAPIConnection` works the same way as the `BoxAPIConnection` so for example to get root folder you can do:
-<!-- sample x_auth with_client_credentials_enterprise -->
+<!-- sample x_auth with_client_credentials -->
 ```java
 BoxCCGAPIConnection api = BoxCCGAPIConnection.userConnection(
     "client_id",


### PR DESCRIPTION
Correct sample code tag, so it [developer.box.com](https://developer.box.com/guides/authentication/client-credentials/) correctly display sample code.