### PR TITLE
fix: Documentation - Add missing blank line after code tag

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -169,6 +169,7 @@ BoxCCGAPIConnection api = BoxCCGAPIConnection.userConnection(
 );
 BoxFolder root = BoxFolder.getRootFolder(api);
 ```
+
 Obtained token is valid for specified ammount of time and it will be refreshed automatically by default.
 
 #### Obtaining Service Account token
@@ -238,6 +239,7 @@ BoxCCGAPIConnection api = BoxCCGAPIConnection.userConnection(
 );
 api.asUser("user_id")
 ```
+
 Calling `asUser` or `asSelf` on user connection will fail with `IllegalStateException`.
 
 ## Token Exchange
@@ -271,4 +273,3 @@ At any point if you wish to revoke your tokens you can do so by calling the foll
 BoxAPIConnection api = new BoxAPIConnection("YOUR-ACCESS-TOKEN");
 api.revokeToken();
 ```
-

--- a/doc/events.md
+++ b/doc/events.md
@@ -141,6 +141,7 @@ for (BoxEvent event : eventLog){
   );
 };
 ```
+
 Bear in mind that if an event type is not mapped to `BoxEvent.EventType` the value of `BoxEvent#getEventType()` will
 be `BoxEvent.EventType.UNKNOWN` but `BoxEvent#getTypeName()` will return its name.
 
@@ -222,6 +223,7 @@ for (BoxEvent event : eventLog){
   );
 };
 ```
+
 Bear in mind that if an event type is not mapped to `BoxEvent.EventType` the value of `BoxEvent#getEventType()` will
 be `BoxEvent.EventType.UNKNOWN` but `BoxEvent#getTypeName()` will return its name.
 
@@ -235,6 +237,7 @@ EnterpriseEventsStreamRequest request2 = new EnterpriseEventsStreamRequest().lim
 EventLog eventLog2 = EventLog.getEnterpriseEventsStream(api, request2);
 // process revieved events
 ```
+
 If you have the next stream position, and make a subsequent call, the API will return immediately
 even when there are no events, the next stream position will be returned.
 If you have a stream position that is older than two weeks than API will return no events and next

--- a/doc/folders.md
+++ b/doc/folders.md
@@ -125,6 +125,7 @@ while (itemIterator.hasNext()){
     // Do something
 }
 ```
+
 With offset pagination you cannot set offset larger than 300000.
 
 By default, SDK is using marker based pagination to get items. 


### PR DESCRIPTION
Blank line between the sample tag and markdown