### PR TITLE
feat: Added protected getter for `BoxAPIRequest#sslSocketFactory`

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -599,6 +599,15 @@ public class BoxAPIRequest {
     }
 
     /**
+     * Sometimes it may be necessary to get access to the SSLSocketFactory. For example for testing purposes.
+     *
+     * @return a SSLSocketFactory used for this connection
+     */
+    protected SSLSocketFactory getSslSocketFactory() {
+        return sslSocketFactory;
+    }
+
+    /**
      * Writes the body of this request to an HttpURLConnection.
      *
      * <p>Subclasses overriding this method must remember to close the connection's OutputStream after writing.</p>

--- a/src/main/java/com/box/sdk/BoxAPIRequest.java
+++ b/src/main/java/com/box/sdk/BoxAPIRequest.java
@@ -603,7 +603,7 @@ public class BoxAPIRequest {
      *
      * @return a SSLSocketFactory used for this connection
      */
-    protected SSLSocketFactory getSslSocketFactory() {
+    SSLSocketFactory getSslSocketFactory() {
         return sslSocketFactory;
     }
 


### PR DESCRIPTION
As in https://jira.inside-box.net/browse/SDK-2417 - added a getter to sslSocketFactory to make easier usage during testing.