### PR TITLE
feat: Adding Jackson to Java SDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ configurations {
 
 dependencies {
     implementation "com.eclipsesource.minimal-json:minimal-json:0.9.5"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.13.3"
     implementation "org.bitbucket.b_c:jose4j:0.7.9"
     implementation("org.bouncycastle:bcprov-jdk15on") {
         version {

--- a/src/main/java/com/box/sdk/BoxInvite.java
+++ b/src/main/java/com/box/sdk/BoxInvite.java
@@ -5,6 +5,8 @@ import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
 import java.net.URL;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Represents an invitation for a user to join an enterprise.
@@ -51,17 +53,19 @@ public class BoxInvite extends BoxResource {
         URL url = INVITE_CREATION_URL_TEMPLATE.build(api.getBaseURL());
         BoxJSONRequest request = new BoxJSONRequest(api, url, "POST");
 
-        JsonObject body = new JsonObject();
 
-        JsonObject enterprise = new JsonObject();
-        enterprise.add("id", enterpriseID);
-        body.add("enterprise", enterprise);
+        Map<String, Object> body = new HashMap<>();
 
-        JsonObject actionableBy = new JsonObject();
-        actionableBy.add("login", userLogin);
-        body.add("actionable_by", actionableBy);
+        Map<String, String> enterprise = new HashMap<>();
+        enterprise.put("id", enterpriseID);
+        body.put("enterprise", enterprise);
 
-        request.setBody(body);
+        Map<String, String> actionableBy = new HashMap<>();
+        actionableBy.put("login", userLogin);
+        body.put("actionable_by", actionableBy);
+
+
+        request.setBody(BoxJsonMapper.getInstance().valueToString(body));
         BoxJSONResponse response = (BoxJSONResponse) request.send();
         JsonObject responseJSON = Json.parse(response.getJSON()).asObject();
 

--- a/src/main/java/com/box/sdk/BoxJSONRequest.java
+++ b/src/main/java/com/box/sdk/BoxJSONRequest.java
@@ -4,6 +4,7 @@ import com.box.sdk.http.HttpMethod;
 import com.eclipsesource.json.Json;
 import com.eclipsesource.json.JsonObject;
 import com.eclipsesource.json.JsonValue;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URL;
 
 /**
@@ -13,7 +14,7 @@ import java.net.URL;
  * automatically sets the appropriate "Content-Type" HTTP headers and allows the JSON in the request to be logged.</p>
  */
 public class BoxJSONRequest extends BoxAPIRequest {
-    private JsonValue jsonValue;
+    private JsonNode jsonNode;
 
     /**
      * Constructs an authenticated BoxJSONRequest using a provided BoxAPIConnection.
@@ -58,7 +59,7 @@ public class BoxJSONRequest extends BoxAPIRequest {
     @Override
     public void setBody(String body) {
         super.setBody(body);
-        this.jsonValue = Json.parse(body);
+        this.jsonNode = BoxJsonMapper.getInstance().parse(body);
     }
 
     /**
@@ -66,9 +67,10 @@ public class BoxJSONRequest extends BoxAPIRequest {
      *
      * @param body the JsonObject to use as the body.
      */
+    @Deprecated
     public void setBody(JsonObject body) {
         super.setBody(body.toString());
-        this.jsonValue = body;
+        this.jsonNode = BoxJsonMapper.getInstance().parse(body.toString());
     }
 
     /**
@@ -76,9 +78,10 @@ public class BoxJSONRequest extends BoxAPIRequest {
      *
      * @return body represented as JsonObject.
      */
+    @Deprecated
     public JsonObject getBodyAsJsonObject() {
-        if (this.jsonValue.isObject()) {
-            return this.jsonValue.asObject();
+        if (this.jsonNode.isObject()) {
+            return Json.parse(jsonNode.toString()).asObject();
         }
 
         return null;
@@ -89,12 +92,13 @@ public class BoxJSONRequest extends BoxAPIRequest {
      *
      * @return body represented as JsonValue
      */
+    @Deprecated
     public JsonValue getBodyAsJsonValue() {
-        return this.jsonValue;
+        return Json.parse(jsonNode.toString());
     }
 
     @Override
     protected String bodyToString() {
-        return this.jsonValue != null ? this.jsonValue.toString() : null;
+        return this.jsonNode != null ? this.jsonNode.toString() : null;
     }
 }

--- a/src/main/java/com/box/sdk/BoxJsonMapper.java
+++ b/src/main/java/com/box/sdk/BoxJsonMapper.java
@@ -1,0 +1,37 @@
+package com.box.sdk;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ *
+ */
+class BoxJsonMapper {
+    private final static BoxJsonMapper INSTANCE = new BoxJsonMapper();
+    private final ObjectMapper objectMapper;
+
+    public static BoxJsonMapper getInstance() {
+        return INSTANCE;
+    }
+
+    private BoxJsonMapper() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    JsonNode parse(String jsonString) {
+        try {
+            return objectMapper.readTree(jsonString);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Couldn't parse JSON", e);
+        }
+    }
+
+    String valueToString(Object value) {
+        try {
+            return this.objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("Couldn't serialize object", e);
+        }
+    }
+}

--- a/src/main/java/com/box/sdk/BoxJsonMapper.java
+++ b/src/main/java/com/box/sdk/BoxJsonMapper.java
@@ -7,16 +7,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 /**
  *
  */
-class BoxJsonMapper {
-    private final static BoxJsonMapper INSTANCE = new BoxJsonMapper();
+final class BoxJsonMapper {
+    private static final BoxJsonMapper INSTANCE = new BoxJsonMapper();
     private final ObjectMapper objectMapper;
-
-    public static BoxJsonMapper getInstance() {
-        return INSTANCE;
-    }
 
     private BoxJsonMapper() {
         this.objectMapper = new ObjectMapper();
+    }
+
+    public static BoxJsonMapper getInstance() {
+        return INSTANCE;
     }
 
     JsonNode parse(String jsonString) {

--- a/src/test/java/com/box/sdk/BoxInviteTest.java
+++ b/src/test/java/com/box/sdk/BoxInviteTest.java
@@ -1,5 +1,7 @@
 package com.box.sdk;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -62,6 +64,15 @@ public class BoxInviteTest {
                         }
                     };
                 } else if (url.equals("https://api.box.com/2.0/invites")) {
+                    String requestBodyAsString = request.bodyToString();
+                    System.out.println(requestBodyAsString);
+                    assertThat(requestBodyAsString,
+                        is(String.format(
+                            "{\"enterprise\":{\"id\":\"%s\"},\"actionable_by\":{\"login\":\"%s\"}}",
+                            enterpriseID,
+                            userLogin
+                        ))
+                    );
 
                     return new BoxJSONResponse() {
                         @Override


### PR DESCRIPTION
All important data is stored in `Info` classes for example `BoxFile.Info`. Info classes are not static and cannot exist without resource classes. Resource classes contains API connection and String ID. There is no possibility to deserialise them. 

It makes little sense to introduce Jackson to SDK as we will gain nothing from its features.