### PR TITLE
chore: Removed deprecated methods

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -590,31 +590,6 @@ public class BoxAPIConnection {
         this.autoRefresh = autoRefresh;
     }
 
-    /**
-     * Sets the total maximum number of times an API request will be tried when error responses
-     * are received.
-     *
-     * @return the maximum number of request attempts.
-     * @deprecated getMaxRetryAttempts is preferred because it more clearly gets the number
-     * of times a request should be retried after an error response is received.
-     */
-    @Deprecated
-    public int getMaxRequestAttempts() {
-        return this.maxRetryAttempts + 1;
-    }
-
-    /**
-     * Sets the total maximum number of times an API request will be tried when error responses
-     * are received.
-     *
-     * @param attempts the maximum number of request attempts.
-     * @deprecated setMaxRetryAttempts is preferred because it more clearly sets the number
-     * of times a request should be retried after an error response is received.
-     */
-    @Deprecated
-    public void setMaxRequestAttempts(int attempts) {
-        this.maxRetryAttempts = attempts - 1;
-    }
 
     /**
      * Gets the maximum number of times an API request will be retried after an error response

--- a/src/main/java/com/box/sdk/SharedLinkAPIConnection.java
+++ b/src/main/java/com/box/sdk/SharedLinkAPIConnection.java
@@ -94,34 +94,6 @@ public class SharedLinkAPIConnection extends BoxAPIConnection {
     }
 
     /**
-     * Sets the total maximum number of times an API request will be tried when error responses
-     * are received.
-     *
-     * @return the maximum number of request attempts.
-     * @deprecated getMaxRetryAttempts is preferred because it more clearly gets the number
-     * of times a request should be retried after an error response is received.
-     */
-    @Deprecated
-    @Override
-    public int getMaxRequestAttempts() {
-        return this.wrappedConnection.getMaxRetryAttempts() + 1;
-    }
-
-    /**
-     * Sets the total maximum number of times an API request will be tried when error responses
-     * are received.
-     *
-     * @param attempts the maximum number of request attempts.
-     * @deprecated setMaxRetryAttempts is preferred because it more clearly sets the number
-     * of times a request should be retried after an error response is received.
-     */
-    @Deprecated
-    @Override
-    public void setMaxRequestAttempts(int attempts) {
-        this.wrappedConnection.setMaxRetryAttempts(attempts - 1);
-    }
-
-    /**
      * Gets the maximum number of times an API request will be retried after an error response
      * is received.
      *


### PR DESCRIPTION
Removed methods getMaxRequestAttempts and setMaxRequestAttempts. Still we are reading values from JSON if someone has still stored it somewhere and restoring API connection from JSON.