### PR TITLE
fix: `OAUTH_SUFFIX` gets appended twice to `baseAuthorizationURL`

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -466,9 +466,7 @@ public class BoxAPIConnection {
      * @return the authorization URL
      */
     public URL getAuthorizationURL(URI redirectUri, String state, List<String> scopes) {
-        return createFullAuthorizationUrl(
-            this.baseAuthorizationURL + OAUTH_SUFFIX, this.clientID, redirectUri, state, scopes
-        );
+        return createFullAuthorizationUrl(this.baseAuthorizationURL, this.clientID, redirectUri, state, scopes);
     }
 
     /**


### PR DESCRIPTION
Issue: [OAUTH_SUFFIX gets appended twice to baseAuthorizationURL #1147](https://github.com/box/box-java-sdk/issues/1147)

Code changes:
* Removed unnecessary append of `OAUTH_SUFFIX`