### PR TITLE
fix: Allow registering custom logger handlers

### DIFF
--- a/src/main/java/com/box/sdk/BoxLogger.java
+++ b/src/main/java/com/box/sdk/BoxLogger.java
@@ -7,6 +7,7 @@ import static java.util.logging.Level.OFF;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
 
+import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -145,5 +146,24 @@ public final class BoxLogger {
      */
     public void setUseParentHandlers(boolean useParentHandlers) {
         this.logger.setUseParentHandlers(useParentHandlers);
+    }
+
+    /**
+     * Adds handler to logger.
+     * Check {@link Logger#addHandler(Handler)}
+     * @param handler a logging handler to add.
+     */
+    public void addHandler(Handler handler) {
+        logger.addHandler(handler);
+    }
+
+    /**
+     * Removes handler from logger.
+     * Will not fail if handler is null or not registered.
+     * Check {@link Logger#removeHandler(Handler)}
+     * @param handler a logging handler to remove.
+     */
+    public void removeHandler(Handler handler) {
+        logger.removeHandler(handler);
     }
 }

--- a/src/test/java/com/box/sdk/BoxLoggerTest.java
+++ b/src/test/java/com/box/sdk/BoxLoggerTest.java
@@ -1,0 +1,54 @@
+package com.box.sdk;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import org.junit.Test;
+
+public class BoxLoggerTest {
+    @Test
+    public void canAddHandler() {
+        HandlerForTests handler = new HandlerForTests();
+        BoxLogger boxLogger = BoxLogger.defaultLogger();
+
+        boxLogger.addHandler(handler);
+        boxLogger.info("Test");
+
+        LogRecord logRecord = handler.logEntries.get(0);
+        assertThat(logRecord.getMessage(), is("Test"));
+    }
+
+    @Test
+    public void canRemoveHandler() {
+        HandlerForTests handler = new HandlerForTests();
+        BoxLogger boxLogger = BoxLogger.defaultLogger();
+
+        boxLogger.addHandler(handler);
+        boxLogger.removeHandler(handler);
+        boxLogger.info("Test");
+
+        assertThat(handler.logEntries, empty());
+    }
+
+    private static final class HandlerForTests extends Handler {
+        List<LogRecord> logEntries = new ArrayList<>();
+
+        @Override
+        public void publish(LogRecord record) {
+            logEntries.add(record);
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() throws SecurityException {
+        }
+    }
+}


### PR DESCRIPTION
We are being asked by users to allow configuring handlers. For example if you want to enable debug logging you will need to register new handler with allowed level set to at least FINE.