### PR TITLE
fix: Fixed upload when data are coming from a dynamic source

### DIFF
--- a/src/intTest/java/com/box/sdk/BoxFolderIT.java
+++ b/src/intTest/java/com/box/sdk/BoxFolderIT.java
@@ -182,7 +182,7 @@ public class BoxFolderIT {
         BoxFile uploadedFile = null;
 
         try {
-            uploadedFile = uploadFileToUniqueFolderWithSomeContent(api, "Test File.txt");
+            uploadedFile = uploadFileToUniqueFolderWithSomeContent(api, randomizeName("Test File"));
 
             assertThat(rootFolder, hasItem(Matchers.<BoxItem.Info>hasProperty("ID", equalTo(uploadedFile.getID()))));
         } finally {
@@ -201,7 +201,7 @@ public class BoxFolderIT {
 
         try {
 
-            final String fileContent = "Test file";
+            final String fileContent = randomizeName("Test file");
             uploadedFile = rootFolder.uploadFile(outputStream -> {
                 outputStream.write(fileContent.getBytes());
                 callbackWasCalled.set(true);
@@ -777,7 +777,7 @@ public class BoxFolderIT {
         outputStream.connect(inputStream);
 
         String fileContent = "This is only a test";
-        final BoxFile uploadedFile = uploadFileToUniqueFolder(api, "Test File.txt", fileContent);
+        final BoxFile uploadedFile = uploadFileToUniqueFolder(api, randomizeName("Test File"), fileContent);
 
         Thread thread1 =
             new Thread(
@@ -842,7 +842,7 @@ public class BoxFolderIT {
         String fileContent = "This is only a test";
         Long fileSize = new Long(fileContent.getBytes(UTF_8).length);
 
-        final BoxFile uploadedFile = uploadFileToUniqueFolder(api, "Test File.txt", fileContent);
+        final BoxFile uploadedFile = uploadFileToUniqueFolder(api, randomizeName("Test File"), fileContent);
 
         Thread thread1 =
             new Thread(

--- a/src/main/java/com/box/sdk/AbstractBoxMultipartRequest.java
+++ b/src/main/java/com/box/sdk/AbstractBoxMultipartRequest.java
@@ -48,7 +48,9 @@ abstract class AbstractBoxMultipartRequest extends BoxAPIRequest {
      *
      * @param inputStream a stream containing the file contents.
      * @param filename    the name of the file.
-     * @param fileSize    the size of the file.
+     * @param fileSize    the size of the file. If the file content is coming from the dynamic stream,
+     *                    and it's full size cannot be determined on starting upload use fizeSize=-1
+     *                    or use {@link AbstractBoxMultipartRequest#setFile(InputStream, String)}
      */
     public void setFile(InputStream inputStream, String filename, long fileSize) {
         this.setFile(inputStream, filename);

--- a/src/main/java/com/box/sdk/AbstractBoxMultipartRequest.java
+++ b/src/main/java/com/box/sdk/AbstractBoxMultipartRequest.java
@@ -24,7 +24,7 @@ abstract class AbstractBoxMultipartRequest extends BoxAPIRequest {
     private final Map<String, String> fields = new HashMap<>();
     private InputStream inputStream;
     private String filename;
-    private long fileSize;
+    private long fileSize = -1;
     private UploadFileCallback callback;
 
     AbstractBoxMultipartRequest(BoxAPIConnection api, URL url) {
@@ -151,7 +151,9 @@ abstract class AbstractBoxMultipartRequest extends BoxAPIRequest {
 
     private RequestBody getBody(ProgressListener progressListener) {
         if (this.callback == null) {
-            return new RequestBodyFromStream(this.inputStream, getPartContentType(filename), progressListener);
+            return new RequestBodyFromStream(
+                this.inputStream, getPartContentType(filename), progressListener, fileSize
+            );
         } else {
             return new RequestBodyFromCallback(this.callback, getPartContentType(filename));
         }

--- a/src/main/java/com/box/sdk/BinaryBodyUtils.java
+++ b/src/main/java/com/box/sdk/BinaryBodyUtils.java
@@ -16,8 +16,9 @@ final class BinaryBodyUtils {
 
     /**
      * Writes response body bytes to output stream. After all closes the input stream.
+     *
      * @param response Response that is going to be written.
-     * @param output Output stream.
+     * @param output   Output stream.
      */
     static void writeStream(BoxAPIResponse response, OutputStream output) {
         writeStream(response, output, null);
@@ -25,8 +26,9 @@ final class BinaryBodyUtils {
 
     /**
      * Writes response body bytes to output stream. After all closes the input stream.
+     *
      * @param response Response that is going to be written.
-     * @param output Output stream.
+     * @param output   Output stream.
      * @param listener Listener that will be notified on writing response. Can be null.
      */
 
@@ -46,7 +48,8 @@ final class BinaryBodyUtils {
 
     /**
      * Writes content of input stream to provided output. Method is NOT closing input stream.
-     * @param input Input that will be read.
+     *
+     * @param input  Input that will be read.
      * @param output Output stream.
      */
     static void writeStreamTo(InputStream input, OutputStream output) {
@@ -59,6 +62,13 @@ final class BinaryBodyUtils {
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
+        } finally {
+            try {
+                input.close();
+                output.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }

--- a/src/main/java/com/box/sdk/FileUploadParams.java
+++ b/src/main/java/com/box/sdk/FileUploadParams.java
@@ -123,6 +123,7 @@ public class FileUploadParams {
 
     /**
      * Gets the size of the file's content used for monitoring the upload's progress.
+     * If the size cannot be determined value will be `-1L`.
      *
      * @return the size of the file's content.
      */
@@ -132,6 +133,9 @@ public class FileUploadParams {
 
     /**
      * Sets the size of the file content used for monitoring the upload's progress.
+     * When the content is coming from a dynamic source - other thread reading value
+     * set size to `-1L` to tell SDK that file size cannot be determined. Usefull
+     * when encuntering problems with writing different size of bytes than assumed.
      *
      * @param size the size of the file's content.
      * @return this FileUploadParams object for chaining.

--- a/src/main/java/com/box/sdk/FileUploadParams.java
+++ b/src/main/java/com/box/sdk/FileUploadParams.java
@@ -123,7 +123,7 @@ public class FileUploadParams {
 
     /**
      * Gets the size of the file's content used for monitoring the upload's progress.
-     * If the size cannot be determined value will be `-1L`.
+     * If the size cannot be determined value will be -1.
      *
      * @return the size of the file's content.
      */
@@ -134,7 +134,7 @@ public class FileUploadParams {
     /**
      * Sets the size of the file content used for monitoring the upload's progress.
      * When the content is coming from a dynamic source - other thread reading value
-     * set size to `-1L` to tell SDK that file size cannot be determined. Usefull
+     * set size to -1 to tell SDK that file size cannot be determined. Usefull
      * when encuntering problems with writing different size of bytes than assumed.
      *
      * @param size the size of the file's content.

--- a/src/main/java/com/box/sdk/ProgressListener.java
+++ b/src/main/java/com/box/sdk/ProgressListener.java
@@ -7,6 +7,8 @@ public interface ProgressListener {
 
     /**
      * Invoked when the progress of the API call changes.
+     * In case of file uploads which are coming from a dynamic stream the file size cannot be determined and
+     * total bytes will be reported as -1.
      *
      * @param numBytes   the number of bytes completed.
      * @param totalBytes the total number of bytes.

--- a/src/main/java/com/box/sdk/RequestBodyFromStream.java
+++ b/src/main/java/com/box/sdk/RequestBodyFromStream.java
@@ -41,7 +41,7 @@ final class RequestBodyFromStream extends RequestBody {
     }
 
     /**
-     * Returns content length. If the content length cannot be derermined
+     * Returns content length. If the content length cannot be determined
      * (is coming from a stream) this value will be -1.
      * @return Long representing content length
      */

--- a/src/main/java/com/box/sdk/RequestBodyFromStream.java
+++ b/src/main/java/com/box/sdk/RequestBodyFromStream.java
@@ -15,20 +15,15 @@ final class RequestBodyFromStream extends RequestBody {
     private final InputStream inputStream;
     private final ProgressListener progressListener;
     private final MediaType mediaType;
+    private final long fileSize;
 
-    RequestBodyFromStream(InputStream inputStream, MediaType mediaType, ProgressListener progressListener) {
+    RequestBodyFromStream(
+        InputStream inputStream, MediaType mediaType, ProgressListener progressListener, long fileSize
+    ) {
         this.inputStream = inputStream;
         this.progressListener = progressListener;
         this.mediaType = mediaType;
-    }
-
-    @Override
-    public long contentLength() {
-        try {
-            return inputStream.available();
-        } catch (IOException e) {
-            return 0;
-        }
+        this.fileSize = fileSize;
     }
 
     @Override
@@ -38,10 +33,52 @@ final class RequestBodyFromStream extends RequestBody {
 
     @Override
     public void writeTo(BufferedSink bufferedSink) {
+        if (progressListener == null) {
+            writeWithoutProgressListener(bufferedSink);
+        } else {
+            writeWithProgressListener(bufferedSink);
+        }
+    }
+
+    /**
+     * Returns content length. If the content length cannot be derermined
+     * (is coming from a stream) this value will be -1.
+     * @return Long representing content length
+     */
+    @Override
+    public long contentLength() {
+        return fileSize;
+    }
+
+    private void writeWithoutProgressListener(BufferedSink bufferedSink) {
         try (Source source = Okio.source(this.inputStream)) {
             bufferedSink.writeAll(source);
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    private void writeWithProgressListener(BufferedSink bufferedSink) {
+        try {
+            byte[] buffer = new byte[AbstractBoxMultipartRequest.BUFFER_SIZE];
+            int n = this.inputStream.read(buffer);
+            int totalWritten = 0;
+            while (n != -1) {
+                bufferedSink.write(buffer, 0, n);
+                totalWritten += n;
+                if (progressListener != null) {
+                    progressListener.onProgressChanged(totalWritten, this.contentLength());
+                }
+                n = this.inputStream.read(buffer);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } finally {
+            try {
+                this.inputStream.close();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
     }
 }

--- a/src/test/java/com/box/sdk/RequestBodyFromStreamTest.java
+++ b/src/test/java/com/box/sdk/RequestBodyFromStreamTest.java
@@ -3,7 +3,6 @@ package com.box.sdk;
 import static com.box.sdk.AbstractBoxMultipartRequest.BUFFER_SIZE;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import okhttp3.MediaType;
@@ -15,7 +14,7 @@ import org.junit.Test;
 public class RequestBodyFromStreamTest {
 
     @Test
-    public void reportCorrectProgressWhenFileIsEmpty() throws IOException {
+    public void reportCorrectProgressWhenFileIsEmpty() {
         ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[]{});
         ProgressListener progressListener = (numBytes, totalBytes) -> {
             MatcherAssert.assertThat(numBytes, Matchers.is((long) 0));
@@ -23,13 +22,17 @@ public class RequestBodyFromStreamTest {
         };
 
         RequestBodyFromStream request = new RequestBodyFromStream(
-            inputStream, MediaType.parse("application/json"), progressListener
+            inputStream,
+            MediaType.parse("application/json"),
+            progressListener,
+            0
         );
 
         request.writeTo(new Buffer());
     }
+
     @Test
-    public void reportCorrectProgressWhenFileSizeIfLessThanBuffer() throws IOException {
+    public void reportCorrectProgressWhenFileSizeIfLessThanBuffer() {
         int howManyBytes = 1000;
         ByteArrayInputStream inputStream = new ByteArrayInputStream(generateBytes(howManyBytes));
         ProgressListener progressListener = (numBytes, totalBytes) -> {
@@ -38,14 +41,17 @@ public class RequestBodyFromStreamTest {
         };
 
         RequestBodyFromStream request = new RequestBodyFromStream(
-            inputStream, MediaType.parse("application/json"), progressListener
+            inputStream,
+            MediaType.parse("application/json"),
+            progressListener,
+            howManyBytes
         );
 
         request.writeTo(new Buffer());
     }
 
     @Test
-    public void reportCorrectProgressWhenFileSizeIfEqualToBuffer() throws IOException {
+    public void reportCorrectProgressWhenFileSizeIfEqualToBuffer() {
         int howManyBytes = BUFFER_SIZE;
         ByteArrayInputStream inputStream = new ByteArrayInputStream(generateBytes(howManyBytes));
         ProgressListener progressListener = (numBytes, totalBytes) -> {
@@ -54,14 +60,17 @@ public class RequestBodyFromStreamTest {
         };
 
         RequestBodyFromStream request = new RequestBodyFromStream(
-            inputStream, MediaType.parse("application/json"), progressListener
+            inputStream,
+            MediaType.parse("application/json"),
+            progressListener,
+            howManyBytes
         );
 
         request.writeTo(new Buffer());
     }
 
     @Test
-    public void reportCorrectProgressWhenFileSizeIfGreaterThanBuffer() throws IOException {
+    public void reportCorrectProgressWhenFileSizeIfGreaterThanBuffer() {
         int howManyBytes = BUFFER_SIZE + 1000;
         ByteArrayInputStream inputStream = new ByteArrayInputStream(generateBytes(howManyBytes));
         AtomicInteger counter = new AtomicInteger(0);
@@ -76,7 +85,10 @@ public class RequestBodyFromStreamTest {
         };
 
         RequestBodyFromStream request = new RequestBodyFromStream(
-            inputStream, MediaType.parse("application/json"), progressListener
+            inputStream,
+            MediaType.parse("application/json"),
+            progressListener,
+            howManyBytes
         );
 
         request.writeTo(new Buffer());


### PR DESCRIPTION
With OkHttp not really working with stream we have our own solution. But it can work with them as long as we tell it that content size if unknown.

This was the source of the problem in the #1183 where two threads started and one was feeding data to other. First was downloading a file second was uploading new version.
This should also address failing uploads when dealing with a stream which full size cannot be determined upfront (#1190 ).