### PR TITLE
Upgrade jose4j from 0.9.3 to 0.9.5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ configurations {
 
 dependencies {
     implementation "com.eclipsesource.minimal-json:minimal-json:0.9.5"
-    implementation "org.bitbucket.b_c:jose4j:0.9.3"
+    implementation "org.bitbucket.b_c:jose4j:0.9.5"
     implementation("org.bouncycastle:bcprov-jdk15on") {
         version {
             strictly("1.57")


### PR DESCRIPTION
avoid https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-31582

release notes https://bitbucket.org/b_c/jose4j/wiki/Release%20Notes