### PR TITLE
fix: remove sensitive data when `BoxAPIException` logs request

### DIFF
--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -34,6 +34,7 @@ import okhttp3.Credentials;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.Headers;
 
 /**
  * Represents an authenticated connection to the Box API.
@@ -1265,7 +1266,7 @@ public class BoxAPIConnection {
         try {
             return createNewCall(httpClient, request).execute();
         } catch (IOException e) {
-            throw new BoxAPIException("Couldn't connect to the Box API due to a network error. Request\n" + request, e);
+            throw new BoxAPIException("Couldn't connect to the Box API due to a network error. Request\n" + toSanitizedRequest(request), e);
         }
     }
 
@@ -1297,5 +1298,13 @@ public class BoxAPIConnection {
          * or https://example.app.box.com/notes/0987654321?s=zxcvbnm1234567890asdfghjk.
          */
         SharedLink
+    }
+
+    private Request toSanitizedRequest(Request originalRequest) {
+        Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(originalRequest.headers());
+
+        return originalRequest.newBuilder()
+            .headers(sanitizedHeaders)
+            .build();
     }
 }

--- a/src/main/java/com/box/sdk/BoxAPIConnection.java
+++ b/src/main/java/com/box/sdk/BoxAPIConnection.java
@@ -31,10 +31,10 @@ import javax.net.ssl.X509TrustManager;
 import okhttp3.Authenticator;
 import okhttp3.Call;
 import okhttp3.Credentials;
+import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.Headers;
 
 /**
  * Represents an authenticated connection to the Box API.
@@ -1266,7 +1266,8 @@ public class BoxAPIConnection {
         try {
             return createNewCall(httpClient, request).execute();
         } catch (IOException e) {
-            throw new BoxAPIException("Couldn't connect to the Box API due to a network error. Request\n" + toSanitizedRequest(request), e);
+            throw new BoxAPIException("Couldn't connect to the Box API due to a network error. Request\n"
+                + toSanitizedRequest(request), e);
         }
     }
 

--- a/src/main/java/com/box/sdk/BoxSensitiveDataSanitizer.java
+++ b/src/main/java/com/box/sdk/BoxSensitiveDataSanitizer.java
@@ -1,0 +1,46 @@
+package com.box.sdk;
+
+import okhttp3.Headers;
+
+import java.util.Set;
+import java.util.HashSet;
+import java.util.Arrays;
+
+class BoxSensitiveDataSanitizer {
+	private static final Set<String> sensitiveKeys = new HashSet<>(Arrays.asList(
+		"authorization",
+		"access_token",
+		"refresh_token",
+		"subject_token",
+		"token",
+		"client_id",
+		"client_secret",
+		"code",
+		"shared_link",
+		"download_url",
+		"jwt_private_key",
+		"jwt_private_key_passphrase",
+		"password"
+	));
+
+	public static Headers sanitizeHeaders(Headers originalHeaders) {
+		Headers.Builder sanitizedHeadersBuilder = originalHeaders.newBuilder();
+
+		for (String originalHeaderName : originalHeaders.names()) {
+			if (isSensitiveKey(originalHeaderName)) {
+				sanitizedHeadersBuilder.set(originalHeaderName, "[REDACTED]");
+			} else {
+				String headerValue = originalHeaders.get(originalHeaderName);
+				if(headerValue != null) {
+					sanitizedHeadersBuilder.set(originalHeaderName, headerValue);
+				}
+			}
+		}
+
+		return sanitizedHeadersBuilder.build();
+	}
+
+	private static boolean isSensitiveKey(String key) {
+		return sensitiveKeys.contains(key.toLowerCase());
+	}
+}

--- a/src/main/java/com/box/sdk/BoxSensitiveDataSanitizer.java
+++ b/src/main/java/com/box/sdk/BoxSensitiveDataSanitizer.java
@@ -6,7 +6,10 @@ import java.util.Set;
 import okhttp3.Headers;
 import org.jetbrains.annotations.NotNull;
 
-final class BoxSensitiveDataSanitizer {
+/**
+ * Class used to sanitize sensitive data from payload.
+ */
+public final class BoxSensitiveDataSanitizer {
     private static final Set<String> SENSITIVE_KEYS = new HashSet<>(Arrays.asList("authorization", "access_token",
         "refresh_token", "subject_token", "token", "client_id", "client_secret", "code", "shared_link", "download_url",
         "jwt_private_key", "jwt_private_key_passphrase", "password"));
@@ -14,8 +17,17 @@ final class BoxSensitiveDataSanitizer {
     private BoxSensitiveDataSanitizer() {
     }
 
+    /**
+     * Add key that should be sanitized
+     *
+     * @param key key to be sanitized
+     */
+    public static void addKeyToSanitize(String key) {
+        SENSITIVE_KEYS.add(key);
+    }
+
     @NotNull
-    public static Headers sanitizeHeaders(Headers originalHeaders) {
+    static Headers sanitizeHeaders(Headers originalHeaders) {
         Headers.Builder sanitizedHeadersBuilder = originalHeaders.newBuilder();
 
         for (String originalHeaderName : originalHeaders.names()) {

--- a/src/main/java/com/box/sdk/BoxSensitiveDataSanitizer.java
+++ b/src/main/java/com/box/sdk/BoxSensitiveDataSanitizer.java
@@ -1,46 +1,38 @@
 package com.box.sdk;
 
-import okhttp3.Headers;
-
-import java.util.Set;
-import java.util.HashSet;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import okhttp3.Headers;
+import org.jetbrains.annotations.NotNull;
 
-class BoxSensitiveDataSanitizer {
-	private static final Set<String> sensitiveKeys = new HashSet<>(Arrays.asList(
-		"authorization",
-		"access_token",
-		"refresh_token",
-		"subject_token",
-		"token",
-		"client_id",
-		"client_secret",
-		"code",
-		"shared_link",
-		"download_url",
-		"jwt_private_key",
-		"jwt_private_key_passphrase",
-		"password"
-	));
+final class BoxSensitiveDataSanitizer {
+    private static final Set<String> SENSITIVE_KEYS = new HashSet<>(Arrays.asList("authorization", "access_token",
+        "refresh_token", "subject_token", "token", "client_id", "client_secret", "code", "shared_link", "download_url",
+        "jwt_private_key", "jwt_private_key_passphrase", "password"));
 
-	public static Headers sanitizeHeaders(Headers originalHeaders) {
-		Headers.Builder sanitizedHeadersBuilder = originalHeaders.newBuilder();
+    private BoxSensitiveDataSanitizer() {
+    }
 
-		for (String originalHeaderName : originalHeaders.names()) {
-			if (isSensitiveKey(originalHeaderName)) {
-				sanitizedHeadersBuilder.set(originalHeaderName, "[REDACTED]");
-			} else {
-				String headerValue = originalHeaders.get(originalHeaderName);
-				if(headerValue != null) {
-					sanitizedHeadersBuilder.set(originalHeaderName, headerValue);
-				}
-			}
-		}
+    @NotNull
+    public static Headers sanitizeHeaders(Headers originalHeaders) {
+        Headers.Builder sanitizedHeadersBuilder = originalHeaders.newBuilder();
 
-		return sanitizedHeadersBuilder.build();
-	}
+        for (String originalHeaderName : originalHeaders.names()) {
+            if (isSensitiveKey(originalHeaderName)) {
+                sanitizedHeadersBuilder.set(originalHeaderName, "[REDACTED]");
+            } else {
+                String headerValue = originalHeaders.get(originalHeaderName);
+                if (headerValue != null) {
+                    sanitizedHeadersBuilder.set(originalHeaderName, headerValue);
+                }
+            }
+        }
 
-	private static boolean isSensitiveKey(String key) {
-		return sensitiveKeys.contains(key.toLowerCase());
-	}
+        return sanitizedHeadersBuilder.build();
+    }
+
+    private static boolean isSensitiveKey(@NotNull String key) {
+        return SENSITIVE_KEYS.contains(key.toLowerCase());
+    }
 }

--- a/src/test/java/com/box/sdk/BoxSensitiveDataSanitizerTest.java
+++ b/src/test/java/com/box/sdk/BoxSensitiveDataSanitizerTest.java
@@ -2,74 +2,74 @@ package com.box.sdk;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+
 import java.util.HashMap;
 import java.util.Map;
-
 import okhttp3.Headers;
 import org.junit.Test;
 
 public class BoxSensitiveDataSanitizerTest {
-	@Test
-	public void removeSensitiveDataFromHeaders() {
-		Map<String, String> headersMap = new HashMap<>();
-		headersMap.put("authorization", "token");
-		headersMap.put("user-agent", "java-sdk");
+    @Test
+    public void removeSensitiveDataFromHeaders() {
+        Map<String, String> headersMap = new HashMap<>();
+        headersMap.put("authorization", "token");
+        headersMap.put("user-agent", "java-sdk");
 
-		Headers headers = Headers.of(headersMap);
-		Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+        Headers headers = Headers.of(headersMap);
+        Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
 
-		assertThat(sanitizedHeaders.size(), is(2));
-		assertThat(sanitizedHeaders.get("authorization"), is("[REDACTED]"));
-		assertThat(sanitizedHeaders.get("user-agent"), is("java-sdk"));
-	}
+        assertThat(sanitizedHeaders.size(), is(2));
+        assertThat(sanitizedHeaders.get("authorization"), is("[REDACTED]"));
+        assertThat(sanitizedHeaders.get("user-agent"), is("java-sdk"));
+    }
 
-	@Test
-	public void removeAllHeadersWhenOnlySensitiveData() {
-		Map<String, String> headersMap = new HashMap<>();
-		headersMap.put("authorization", "token");
-		headersMap.put("password", "123");
+    @Test
+    public void removeAllHeadersWhenOnlySensitiveData() {
+        Map<String, String> headersMap = new HashMap<>();
+        headersMap.put("authorization", "token");
+        headersMap.put("password", "123");
 
-		Headers headers = Headers.of(headersMap);
-		Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+        Headers headers = Headers.of(headersMap);
+        Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
 
-		assertThat(sanitizedHeaders.size(), is(2));
-		assertThat(sanitizedHeaders.get("authorization"), is("[REDACTED]"));
-		assertThat(sanitizedHeaders.get("password"), is("[REDACTED]"));
-	}
+        assertThat(sanitizedHeaders.size(), is(2));
+        assertThat(sanitizedHeaders.get("authorization"), is("[REDACTED]"));
+        assertThat(sanitizedHeaders.get("password"), is("[REDACTED]"));
+    }
 
-	@Test
-	public void removeSensitiveDataFromHeadersWhenUppercase() {
-		Map<String, String> headersMap = new HashMap<>();
-		headersMap.put("Authorization", "token");
-		headersMap.put("user-agent", "java-sdk");
+    @Test
+    public void removeSensitiveDataFromHeadersWhenUppercase() {
+        Map<String, String> headersMap = new HashMap<>();
+        headersMap.put("Authorization", "token");
+        headersMap.put("user-agent", "java-sdk");
 
-		Headers headers = Headers.of(headersMap);
-		Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+        Headers headers = Headers.of(headersMap);
+        Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
 
-		assertThat(sanitizedHeaders.size(), is(2));
-		assertThat(sanitizedHeaders.get("Authorization"), is("[REDACTED]"));
-		assertThat(sanitizedHeaders.get("user-agent"), is("java-sdk"));
-	}
+        assertThat(sanitizedHeaders.size(), is(2));
+        assertThat(sanitizedHeaders.get("Authorization"), is("[REDACTED]"));
+        assertThat(sanitizedHeaders.get("user-agent"), is("java-sdk"));
+    }
 
-	@Test
-	public void headersNotRemovedWhenNoSensitiveData() {
-		Map<String, String> headersMap = new HashMap<>();
-		headersMap.put("accept", "application/json");
-		headersMap.put("user-agent", "java-sdk");
+    @Test
+    public void headersNotRemovedWhenNoSensitiveData() {
+        Map<String, String> headersMap = new HashMap<>();
+        headersMap.put("accept", "application/json");
+        headersMap.put("user-agent", "java-sdk");
 
-		Headers headers = Headers.of(headersMap);
-		Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+        Headers headers = Headers.of(headersMap);
+        Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
 
-		assertThat(sanitizedHeaders.size(), is(2));
-		assertThat(sanitizedHeaders.get("accept"), is("application/json"));
-		assertThat(sanitizedHeaders.get("user-agent"), is("java-sdk"));
-	}
+        assertThat(sanitizedHeaders.size(), is(2));
+        assertThat(sanitizedHeaders.get("accept"), is("application/json"));
+        assertThat(sanitizedHeaders.get("user-agent"), is("java-sdk"));
+    }
 
-	@Test
-	public void returnEmptyHeadersWhenEmptyHeadersPassed() {
-		Headers headers = Headers.of(new HashMap<>());
-		Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+    @Test
+    public void returnEmptyHeadersWhenEmptyHeadersPassed() {
+        Headers headers = Headers.of(new HashMap<>());
+        Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
 
-		assertThat(sanitizedHeaders.size(), is(0));
-	}
+        assertThat(sanitizedHeaders.size(), is(0));
+    }
 }

--- a/src/test/java/com/box/sdk/BoxSensitiveDataSanitizerTest.java
+++ b/src/test/java/com/box/sdk/BoxSensitiveDataSanitizerTest.java
@@ -1,0 +1,81 @@
+package com.box.sdk;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import java.util.HashMap;
+import java.util.Map;
+
+import okhttp3.Headers;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class BoxSensitiveDataSanitizerTest {
+	@Rule
+	public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicHttpsPort().httpDisabled(true));
+
+	@Test
+	public void removeSensitiveDataFromHeaders() {
+		Map<String, String> headersMap = new HashMap<>();
+		headersMap.put("authorization", "token");
+		headersMap.put("user-agent", "java-sdk");
+
+		Headers headers = Headers.of(headersMap);
+		Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+
+		assertThat(sanitizedHeaders.size(), is(2));
+		assertThat(sanitizedHeaders.get("authorization"), is("[REDACTED]"));
+		assertThat(sanitizedHeaders.get("user-agent"), is("java-sdk"));
+	}
+
+	@Test
+	public void removeAllHeadersWhenOnlySensitiveData() {
+		Map<String, String> headersMap = new HashMap<>();
+		headersMap.put("authorization", "token");
+		headersMap.put("password", "123");
+
+		Headers headers = Headers.of(headersMap);
+		Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+
+		assertThat(sanitizedHeaders.size(), is(2));
+		assertThat(sanitizedHeaders.get("authorization"), is("[REDACTED]"));
+		assertThat(sanitizedHeaders.get("password"), is("[REDACTED]"));
+	}
+
+	@Test
+	public void removeSensitiveDataFromHeadersWhenUppercase() {
+		Map<String, String> headersMap = new HashMap<>();
+		headersMap.put("Authorization", "token");
+		headersMap.put("user-agent", "java-sdk");
+
+		Headers headers = Headers.of(headersMap);
+		Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+
+		assertThat(sanitizedHeaders.size(), is(2));
+		assertThat(sanitizedHeaders.get("Authorization"), is("[REDACTED]"));
+		assertThat(sanitizedHeaders.get("user-agent"), is("java-sdk"));
+	}
+
+	@Test
+	public void headersNotRemovedWhenNoSensitiveData() {
+		Map<String, String> headersMap = new HashMap<>();
+		headersMap.put("accept", "application/json");
+		headersMap.put("user-agent", "java-sdk");
+
+		Headers headers = Headers.of(headersMap);
+		Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+
+		assertThat(sanitizedHeaders.size(), is(2));
+		assertThat(sanitizedHeaders.get("accept"), is("application/json"));
+		assertThat(sanitizedHeaders.get("user-agent"), is("java-sdk"));
+	}
+
+	@Test
+	public void returnEmptyHeadersWhenEmptyHeadersPassed() {
+		Headers headers = Headers.of(new HashMap<>());
+		Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+
+		assertThat(sanitizedHeaders.size(), is(0));
+	}
+}

--- a/src/test/java/com/box/sdk/BoxSensitiveDataSanitizerTest.java
+++ b/src/test/java/com/box/sdk/BoxSensitiveDataSanitizerTest.java
@@ -1,20 +1,14 @@
 package com.box.sdk;
 
-import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import java.util.HashMap;
 import java.util.Map;
 
 import okhttp3.Headers;
-import org.junit.Rule;
 import org.junit.Test;
 
 public class BoxSensitiveDataSanitizerTest {
-	@Rule
-	public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicHttpsPort().httpDisabled(true));
-
 	@Test
 	public void removeSensitiveDataFromHeaders() {
 		Map<String, String> headersMap = new HashMap<>();

--- a/src/test/java/com/box/sdk/BoxSensitiveDataSanitizerTest.java
+++ b/src/test/java/com/box/sdk/BoxSensitiveDataSanitizerTest.java
@@ -72,4 +72,17 @@ public class BoxSensitiveDataSanitizerTest {
 
         assertThat(sanitizedHeaders.size(), is(0));
     }
+
+    @Test
+    public void sanitizeAddedKeys() {
+        Map<String, String> headersMap = new HashMap<>();
+        headersMap.put("x-auth", "token");
+
+        Headers headers = Headers.of(headersMap);
+        BoxSensitiveDataSanitizer.addKeyToSanitize("x-auth");
+        Headers sanitizedHeaders = BoxSensitiveDataSanitizer.sanitizeHeaders(headers);
+
+        assertThat(sanitizedHeaders.size(), is(1));
+        assertThat(sanitizedHeaders.get("x-auth"), is("[REDACTED]"));
+    }
 }


### PR DESCRIPTION
- should clean headers containing potentially sensitive data when request is directly logged and replace them with `[REDACTED]`
- list of sensitive keys taken from https://github.com/box/box-python-sdk/blob/e5c60b2718cb2be755da0fc6c51f73caa285c3a1/boxsdk/util/log.py#L13