### PR TITLE
fix: use `Locale.ROOT` to prevent issues with non-US locales

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -15,9 +15,9 @@ jobs:
     name: Java ${{ matrix.java }} (${{ matrix.distribution }})
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: ${{ matrix.distribution }}
           java-version: ${{ matrix.java }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '8'

--- a/.github/workflows/spell-check-lint.yml
+++ b/.github/workflows/spell-check-lint.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Checkout spellchecker
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: refs/heads/main
           repository: box/box-sdk-spellchecker

--- a/src/main/java/com/box/sdk/BoxAIItem.java
+++ b/src/main/java/com/box/sdk/BoxAIItem.java
@@ -111,7 +111,7 @@ public class BoxAIItem {
         }
 
         static BoxAIItem.Type fromJSONValue(String jsonValue) {
-            return BoxAIItem.Type.valueOf(jsonValue.toUpperCase());
+            return BoxAIItem.Type.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {

--- a/src/main/java/com/box/sdk/BoxAPIResponse.java
+++ b/src/main/java/com/box/sdk/BoxAPIResponse.java
@@ -306,7 +306,8 @@ public class BoxAPIResponse implements Closeable {
         headers.entrySet()
             .stream()
             .filter(Objects::nonNull)
-            .forEach(e -> builder.append(format("%s: [%s]%s", e.getKey().toLowerCase(), e.getValue(), lineSeparator)));
+            .forEach(e -> builder.append(format("%s: [%s]%s", e.getKey().toLowerCase(java.util.Locale.ROOT),
+                e.getValue(), lineSeparator)));
 
         String bodyString = this.bodyToString();
         if (bodyString != null && !bodyString.equals("")) {

--- a/src/main/java/com/box/sdk/BoxCollaboration.java
+++ b/src/main/java/com/box/sdk/BoxCollaboration.java
@@ -520,7 +520,7 @@ public class BoxCollaboration extends BoxResource {
          */
         public void setStatus(Status status) {
             this.status = status;
-            this.addPendingChange("status", status.name().toLowerCase());
+            this.addPendingChange("status", status.name().toLowerCase(java.util.Locale.ROOT));
         }
 
         /**
@@ -604,7 +604,7 @@ public class BoxCollaboration extends BoxResource {
                         this.expiresAt = BoxDateFormat.parse(value.asString());
                         break;
                     case "status":
-                        String statusString = value.asString().toUpperCase();
+                        String statusString = value.asString().toUpperCase(java.util.Locale.ROOT);
                         this.status = Status.valueOf(statusString);
 
                         break;

--- a/src/main/java/com/box/sdk/BoxCollaborator.java
+++ b/src/main/java/com/box/sdk/BoxCollaborator.java
@@ -40,7 +40,7 @@ public abstract class BoxCollaborator extends BoxResource {
         }
 
         static CollaboratorType fromJSONValue(String jsonValue) {
-            return CollaboratorType.valueOf(jsonValue.toUpperCase());
+            return CollaboratorType.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {
@@ -69,7 +69,7 @@ public abstract class BoxCollaborator extends BoxResource {
         }
 
         static GroupType fromJSONValue(String jsonValue) {
-            return GroupType.valueOf(jsonValue.toUpperCase());
+            return GroupType.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {

--- a/src/main/java/com/box/sdk/BoxFile.java
+++ b/src/main/java/com/box/sdk/BoxFile.java
@@ -1706,7 +1706,7 @@ public class BoxFile extends BoxItem {
         }
 
         static Permission fromJSONValue(String jsonValue) {
-            return Permission.valueOf(jsonValue.toUpperCase());
+            return Permission.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {

--- a/src/main/java/com/box/sdk/BoxFileRequest.java
+++ b/src/main/java/com/box/sdk/BoxFileRequest.java
@@ -151,7 +151,7 @@ public class BoxFileRequest extends BoxResource {
         }
 
         static Status fromJSONString(String jsonValue) {
-            return Status.valueOf(jsonValue.toUpperCase());
+            return Status.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONString() {

--- a/src/main/java/com/box/sdk/BoxFolder.java
+++ b/src/main/java/com/box/sdk/BoxFolder.java
@@ -1387,7 +1387,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         }
 
         static SyncState fromJSONValue(String jsonValue) {
-            return SyncState.valueOf(jsonValue.toUpperCase());
+            return SyncState.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {
@@ -1441,7 +1441,7 @@ public class BoxFolder extends BoxItem implements Iterable<BoxItem.Info> {
         }
 
         static Permission fromJSONValue(String jsonValue) {
-            return Permission.valueOf(jsonValue.toUpperCase());
+            return Permission.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {

--- a/src/main/java/com/box/sdk/BoxGroupMembership.java
+++ b/src/main/java/com/box/sdk/BoxGroupMembership.java
@@ -161,7 +161,7 @@ public class BoxGroupMembership extends BoxResource {
         }
 
         static Permission fromJSONValue(String jsonValue) {
-            return Permission.valueOf(jsonValue.toUpperCase());
+            return Permission.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {

--- a/src/main/java/com/box/sdk/BoxSensitiveDataSanitizer.java
+++ b/src/main/java/com/box/sdk/BoxSensitiveDataSanitizer.java
@@ -66,6 +66,6 @@ public final class BoxSensitiveDataSanitizer {
     }
 
     private static boolean isSensitiveKey(@NotNull String key) {
-        return SENSITIVE_KEYS.contains(key.toLowerCase());
+        return SENSITIVE_KEYS.contains(key.toLowerCase(java.util.Locale.ROOT));
     }
 }

--- a/src/main/java/com/box/sdk/BoxSharedLink.java
+++ b/src/main/java/com/box/sdk/BoxSharedLink.java
@@ -227,7 +227,7 @@ public class BoxSharedLink extends BoxJSONObject {
     }
 
     private Access parseAccessValue(JsonValue value) {
-        String accessString = value.asString().toUpperCase();
+        String accessString = value.asString().toUpperCase(java.util.Locale.ROOT);
         return Access.valueOf(accessString);
     }
 

--- a/src/main/java/com/box/sdk/BoxUploadEmail.java
+++ b/src/main/java/com/box/sdk/BoxUploadEmail.java
@@ -93,7 +93,7 @@ public class BoxUploadEmail extends BoxJSONObject {
         }
 
         static Access fromJSONValue(String jsonValue) {
-            return Access.valueOf(jsonValue.toUpperCase());
+            return Access.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {

--- a/src/main/java/com/box/sdk/BoxUser.java
+++ b/src/main/java/com/box/sdk/BoxUser.java
@@ -818,7 +818,7 @@ public class BoxUser extends BoxCollaborator {
         }
 
         static Role fromJSONValue(String jsonValue) {
-            return Role.valueOf(jsonValue.toUpperCase());
+            return Role.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {
@@ -857,7 +857,7 @@ public class BoxUser extends BoxCollaborator {
         }
 
         static Status fromJSONValue(String jsonValue) {
-            return Status.valueOf(jsonValue.toUpperCase());
+            return Status.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {
@@ -956,7 +956,7 @@ public class BoxUser extends BoxCollaborator {
          */
         public void setRole(Role role) {
             this.role = role;
-            this.addPendingChange("role", role.name().toLowerCase());
+            this.addPendingChange("role", role.name().toLowerCase(java.util.Locale.ROOT));
         }
 
         /**
@@ -1050,7 +1050,7 @@ public class BoxUser extends BoxCollaborator {
          */
         public void setStatus(Status status) {
             this.status = status;
-            this.addPendingChange("status", status.name().toLowerCase());
+            this.addPendingChange("status", status.name().toLowerCase(java.util.Locale.ROOT));
         }
 
         /**

--- a/src/main/java/com/box/sdk/BoxZipDownloadStatus.java
+++ b/src/main/java/com/box/sdk/BoxZipDownloadStatus.java
@@ -120,7 +120,7 @@ public class BoxZipDownloadStatus extends BoxJSONObject {
         }
 
         static State fromJSONValue(String jsonValue) {
-            return State.valueOf(jsonValue.toUpperCase());
+            return State.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONValue() {

--- a/src/main/java/com/box/sdk/MetadataQuery.java
+++ b/src/main/java/com/box/sdk/MetadataQuery.java
@@ -282,7 +282,7 @@ public class MetadataQuery {
             if (jsonValue.isObject()) {
                 JsonObject object = jsonValue.asObject();
                 String fieldName = object.get(FIELD_KEY).asString();
-                String direction = object.get(DIRECTION).asString().toLowerCase();
+                String direction = object.get(DIRECTION).asString().toLowerCase(java.util.Locale.ROOT);
                 if (!DIRECTION_ASCENDING.equals(direction) && !DIRECTION_DESCENDING.equals(direction)) {
                     throw new RuntimeException(
                         String.format("Unsupported sort direction [%s] for field [%s]", direction, fieldName)

--- a/src/main/java/com/box/sdk/RetentionPolicyParams.java
+++ b/src/main/java/com/box/sdk/RetentionPolicyParams.java
@@ -179,7 +179,7 @@ public class RetentionPolicyParams {
         }
 
         static RetentionType fromJSONString(String jsonValue) {
-            return RetentionType.valueOf(jsonValue.toUpperCase());
+            return RetentionType.valueOf(jsonValue.toUpperCase(java.util.Locale.ROOT));
         }
 
         String toJSONString() {

--- a/src/main/java/com/box/sdk/internal/utils/JsonUtils.java
+++ b/src/main/java/com/box/sdk/internal/utils/JsonUtils.java
@@ -76,7 +76,7 @@ public class JsonUtils {
      */
     public static void addIfNotNull(JsonObject jsonObject, String propertyName, Enum propertyValue) {
         if (propertyValue != null) {
-            jsonObject.add(propertyName, propertyValue.name().toLowerCase());
+            jsonObject.add(propertyName, propertyValue.name().toLowerCase(java.util.Locale.ROOT));
         }
     }
 

--- a/src/test/java/com/box/sdk/BoxTaskTest.java
+++ b/src/test/java/com/box/sdk/BoxTaskTest.java
@@ -136,7 +136,7 @@ public class BoxTaskTest {
         BoxTask.Info taskInfo = file.addTask(BoxTask.Action.COMPLETE, taskMessage, null,
             BoxTask.CompletionRule.ALL_ASSIGNEES);
 
-        assertEquals(BoxTask.Action.COMPLETE.toString().toLowerCase(), taskInfo.getTaskType());
+        assertEquals(BoxTask.Action.COMPLETE.toString().toLowerCase(java.util.Locale.ROOT), taskInfo.getTaskType());
         assertEquals(fileID, taskInfo.getItem().getID());
         assertEquals(taskID, taskInfo.getID());
         assertEquals(taskMessage, taskInfo.getMessage());

--- a/src/test/java/com/box/sdk/BoxUserTest.java
+++ b/src/test/java/com/box/sdk/BoxUserTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import org.hamcrest.CoreMatchers;
 import org.junit.Before;
@@ -89,8 +90,7 @@ public class BoxUserTest {
         assertArrayEquals(fileByteArray, output.toByteArray());
     }
 
-    @Test
-    public void testGetCurrentUserInfoSucceeds() {
+    private void getCurrentUserTest() {
         final String userURL = "/2.0/users/me";
         final String userInfoURL = "/2.0/users/12345";
         final String userName = "Test User";
@@ -111,6 +111,17 @@ public class BoxUserTest {
         assertEquals(userName, info.getName());
         assertEquals(userLogin, info.getLogin());
         assertEquals(userphoneNumber, info.getPhone());
+    }
+
+    @Test
+    public void testGetCurrentUserInfoSucceeds() {
+        getCurrentUserTest();
+    }
+
+    @Test
+    public void testGetCurrentUserInfoOnNonUsLocaleSucceeds() {
+        Locale.setDefault(new Locale("tr", "TR"));
+        getCurrentUserTest();
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/box/box-java-sdk/issues/1305

- Use Locale.ROOT in `toLowerCase` and `toUpperCase` to prevent unwanted conversion on characters on turkish locale (see comment for https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/lang/String.java#L3743)
- Fix github actions 322 code error by bumping version of used actions. Issue was most likely caused by using outdated version of https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/ somewhere in our actions