### PR TITLE
fix: Fix parsing `downloadFileCount` property for `BoxZipDownloadStatus`

### DIFF
--- a/src/main/java/com/box/sdk/BoxZipDownloadStatus.java
+++ b/src/main/java/com/box/sdk/BoxZipDownloadStatus.java
@@ -83,7 +83,7 @@ public class BoxZipDownloadStatus extends BoxJSONObject {
         String memberName = member.getName();
         if (memberName.equals("total_file_count")) {
             this.totalFileCount = value.asInt();
-        } else if (memberName.equals("download_file_count")) {
+        } else if (memberName.equals("downloaded_file_count")) {
             this.downloadFileCount = value.asInt();
         } else if (memberName.equals("skipped_file_count")) {
             this.skippedFileCount = value.asInt();


### PR DESCRIPTION
API call returns "downloaded_file_count" not "download_file_count"..  As such object is not representing the correct download count.