### PR TITLE
fix: Fix File Request Copy method to return valid data

### DIFF
--- a/src/main/java/com/box/sdk/BoxFileRequest.java
+++ b/src/main/java/com/box/sdk/BoxFileRequest.java
@@ -63,7 +63,8 @@ public class BoxFileRequest extends BoxResource {
         request.setBody(body.toString());
         try (BoxJSONResponse response = request.send()) {
             JsonObject jsonObject = Json.parse(response.getJSON()).asObject();
-            return new Info(jsonObject, this.getAPI().getBaseAppUrl());
+            String id = jsonObject.get("id").asString();
+            return new BoxFileRequest(this.getAPI(), id).new Info(jsonObject, this.getAPI().getBaseAppUrl());
         }
     }
 
@@ -91,8 +92,8 @@ public class BoxFileRequest extends BoxResource {
         request.setBody(body.toString());
         try (BoxJSONResponse response = request.send()) {
             JsonObject jsonObject = Json.parse(response.getJSON()).asObject();
-            info.update(jsonObject);
-            return new Info(jsonObject, this.getAPI().getBaseAppUrl());
+            String id = jsonObject.get("id").asString();
+            return new BoxFileRequest(this.getAPI(), id).new Info(jsonObject, this.getAPI().getBaseAppUrl());
         }
     }
 
@@ -199,7 +200,7 @@ public class BoxFileRequest extends BoxResource {
         /**
          * Constructs an Info object using an already parsed JSON object.
          *
-         * @param jsonObject the parsed JSON object.
+         * @param jsonObject         the parsed JSON object.
          * @param fileRequestBaseUrl Request base URL
          */
         Info(JsonObject jsonObject, String fileRequestBaseUrl) {

--- a/src/test/Fixtures/BoxFileRequest/CopyFileRequest200.json
+++ b/src/test/Fixtures/BoxFileRequest/CopyFileRequest200.json
@@ -1,5 +1,5 @@
 {
-  "id": "42037322",
+  "id": "82037344",
   "type": "file-request",
   "created_at": "2020-09-28T10:53:43-08:00",
   "created_by": {

--- a/src/test/java/com/box/sdk/BoxFileRequestTest.java
+++ b/src/test/java/com/box/sdk/BoxFileRequestTest.java
@@ -5,6 +5,7 @@ import static com.box.sdk.http.ContentType.APPLICATION_JSON;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import com.eclipsesource.json.JsonObject;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -99,6 +100,7 @@ public class BoxFileRequestTest {
         assertEquals(fileRequestInfo.getDescription(), description);
         assertEquals(fileRequestInfo.getIsDescriptionRequired(), true);
         assertEquals(fileRequestInfo.getStatus(), status);
+        assertNotEquals(fileRequestInfo.getID(), fileRequestID);
     }
 
     @Test


### PR DESCRIPTION
Fix for File Request Copy so it would return valid ID of new created File Request as previously the ID of the original one was returned. 