### PR TITLE
chore: Add cron job to run tests

### DIFF
--- a/.github/workflows/build-and-test-daily.yml
+++ b/.github/workflows/build-and-test-daily.yml
@@ -56,7 +56,7 @@ jobs:
           SLACK_WEBHOOK_TEST_NOTIFICATION_URL: ${{ secrets.SLACK_WEBHOOK_TEST_NOTIFICATION_URL }}
           BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          if [ "${{ needs.build-and-test }}" != "success" ]; then
+          if [ "${{ needs.build-and-test.result }}" != "success" ]; then
             STATUS="Failure ❌"
           else
             STATUS="Success ✅"


### PR DESCRIPTION
- add cron job to run tests at 3:20 AM CET. 

Looks like we don't need to adjust coveralls, as it should report coverage of the currently check out branch locally (tested locally - https://coveralls.io/github/box/box-java-sdk-gen?branch=test-branch