### PR TITLE
deps: Upgrade `Jackson` libraries to 2.21.4

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -29,8 +29,12 @@ jobs:
       - name: Build and test
         run: ./gradlew check --stacktrace
       - name: Generate JaCoCo report
+        if: ${{ matrix.java == '17' && matrix.distribution == 'temurin' }}
         run: ./gradlew jacocoTestReport --stacktrace
       - name: Upload coverage to Coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew coverallsJacoco --stacktrace
+        if: ${{ matrix.java == '17' && matrix.distribution == 'temurin' }}
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/reports/jacoco/test/jacocoTestReport.xml
+          format: jacoco

--- a/README.md
+++ b/README.md
@@ -283,14 +283,14 @@ The Java SDK uses third-party libraries that are required for usage. Their licen
 9. [kotlin-stdlib-common v1.6.20](https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib-common/1.6.20)
    Maven: `org.jetbrains.kotlin:kotlin-stdlib-common:1.6.20`
    Licence: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-10. [jackson-annotations v2.17.2](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations/2.17.2)
-    Maven: `com.fasterxml.jackson.core:jackson-annotations:2.17.2`
+10. [jackson-annotations v2.21](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-annotations/2.21)
+    Maven: `com.fasterxml.jackson.core:jackson-annotations:2.21`
     Licence: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-11. [jackson-core v2.17.2](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core/2.17.2)
-    Maven: `com.fasterxml.jackson.core:jackson-core:2.17.2`
+11. [jackson-core v2.21.4](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core/2.21.4)
+    Maven: `com.fasterxml.jackson.core:jackson-core:2.21.4`
     Licence: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
-12. [jackson-databind v2.17.2](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.17.2)
-    Maven: `com.fasterxml.jackson.core:jackson-databind:2.17.2`
+12. [jackson-databind v2.21.4](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.21.4)
+    Maven: `com.fasterxml.jackson.core:jackson-databind:2.21.4`
     Licence: [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
 13. [okio v3.5.0](https://mvnrepository.com/artifact/com.squareup.okio/okio/3.5.0)
     Maven: `com.squareup.okio:okio:3.5.0`

--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,9 @@ configurations {
 
 dependencies {
     implementation "com.eclipsesource.minimal-json:minimal-json:0.9.5"
-    implementation "com.fasterxml.jackson.core:jackson-annotations:2.18.2"
-    implementation "com.fasterxml.jackson.core:jackson-core:2.18.2"
-    implementation "com.fasterxml.jackson.core:jackson-databind:2.18.2"
+    implementation "com.fasterxml.jackson.core:jackson-annotations:2.21"
+    implementation "com.fasterxml.jackson.core:jackson-core:2.21.4"
+    implementation "com.fasterxml.jackson.core:jackson-databind:2.21.4"
     implementation "org.bitbucket.b_c:jose4j:0.9.6"
     implementation "org.bouncycastle:bcprov-jdk18on:1.82"
     implementation "org.bouncycastle:bcpkix-jdk18on:1.82"


### PR DESCRIPTION
Updated Jackson dependencies to remediate reported jackson-databind CVEs. This uses the fixed Jackson BOM-compatible set: jackson-annotations:2.21, jackson-core:2.21.4, and jackson-databind:2.21.4

Also updated the coverage upload job because the existing coverallsJacoco Gradle task was failing with HTTP 400 after the JaCoCo report was generated successfully. The workflow now uploads the JaCoCo XML report via the official Coveralls GitHub Action from a single matrix job